### PR TITLE
Develop/threejs

### DIFF
--- a/HoloJS/HoloJsHost/ScriptHostUtilities.cpp
+++ b/HoloJS/HoloJsHost/ScriptHostUtilities.cpp
@@ -5,6 +5,20 @@ using namespace HologramJS::Utilities;
 using namespace std;
 
 bool
+ScriptHostUtilities::SetJsProperty(
+	JsValueRef& parentObject,
+	const std::wstring& propertyName,
+	JsValueRef& propertyValue
+)
+{
+	JsPropertyIdRef propertyId;
+	RETURN_IF_JS_ERROR(JsGetPropertyIdFromName(propertyName.c_str(), &propertyId));
+	RETURN_IF_JS_ERROR(JsSetProperty(parentObject, propertyId, propertyValue, true));
+
+	return true;
+}
+
+bool
 ScriptHostUtilities::GetJsProperty(
 	JsValueRef& parentObject,
 	const std::wstring& name,

--- a/HoloJS/HoloJsHost/ScriptHostUtilities.h
+++ b/HoloJS/HoloJsHost/ScriptHostUtilities.h
@@ -29,6 +29,8 @@ namespace HologramJS
 
 			static bool GetJsProperty(JsValueRef& parentObject, const std::wstring& name, JsValueRef* createdProperty);
 
+			static bool SetJsProperty(JsValueRef& parentObject, const std::wstring& propertyName, JsValueRef& propertyValue);
+
 			static bool GetString(JsValueRef value, std::wstring& outString);
 
 			static GLclampf GLclampfFromJsRef(JsValueRef value);

--- a/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
@@ -42,15 +42,15 @@ function Anchor() {
     function makeConsole() {
         this.messages = [];
         this.log = function (entry) {
-            this.messages.push(entry);
+            this.messages.push("info" + entry);
         }.bind(this);
 
         this.warn = function (entry) {
-            this.messages.push(entry);
+            this.messages.push("warning: " + entry);
         }
 
         this.error = function (entry) {
-            this.messages.push(entry);
+            this.messages.push("error" + entry);
         }
     }
 

--- a/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
@@ -40,17 +40,19 @@ function Anchor() {
 (function () {
 
     function makeConsole() {
-        this.messages = [];
+        this.logEntries = [];
+        this.warningEntries = [];
+        this.errorEntries = [];
         this.log = function (entry) {
-            this.messages.push("info" + entry);
+            this.logEntries.push("info: " + entry);
         }.bind(this);
 
         this.warn = function (entry) {
-            this.messages.push("warning: " + entry);
+            this.warningEntries.push("warning: " + entry);
         }
 
         this.error = function (entry) {
-            this.messages.push("error" + entry);
+            this.errorEntries.push("error: " + entry);
         }
     }
 

--- a/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
@@ -45,7 +45,11 @@ function Anchor() {
             this.messages.push(entry);
         }.bind(this);
 
-        this.warn = function () {
+        this.warn = function (entry) {
+            this.messages.push(entry);
+        }
+
+        this.error = function (entry) {
             this.messages.push(entry);
         }
     }

--- a/HoloJS/HoloJsHost/WebGLProjections.cpp
+++ b/HoloJS/HoloJsHost/WebGLProjections.cpp
@@ -160,8 +160,24 @@ WebGLProjections::getShaderPrecisionFormat(
 
 	GLenum shadertype = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
 	GLenum precisiontype = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
-	auto returnObject = context->getShaderPrecisionFormat(shadertype, precisiontype);
-	return ScriptResourceTracker::ObjectToExternal(returnObject);
+	auto precisionFormat = context->getShaderPrecisionFormat(shadertype, precisiontype);
+
+	JsValueRef rangeMinValue;
+	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(precisionFormat->rangeMin, &rangeMinValue));
+
+	JsValueRef rangeMaxValue;
+	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(precisionFormat->rangeMax, &rangeMaxValue));
+
+	JsValueRef precisionValue;
+	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(precisionFormat->precision, &precisionValue));
+
+	auto returnObject = ScriptResourceTracker::ObjectToExternal(precisionFormat);
+
+	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"rangeMin", rangeMinValue));
+	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"rangeMax", rangeMaxValue));
+	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"precision", precisionValue));
+
+	return returnObject;
 }
 
 JsValueRef
@@ -1458,8 +1474,25 @@ WebGLProjections::getActiveUniform(
 	RETURN_INVALID_REF_IF_NULL(program);
 
 	GLuint index = ScriptHostUtilities::GLuintFromJsRef(arguments[3]);
-	auto returnObject = context->getActiveUniform(program, index);
-	return ScriptResourceTracker::ObjectToExternal(returnObject);
+	auto activeUniform = context->getActiveUniform(program, index);
+
+
+	auto returnObject = ScriptResourceTracker::ObjectToExternal(activeUniform);
+
+	JsValueRef namePropertyValue;
+	RETURN_INVALID_REF_IF_JS_ERROR(JsPointerToString(activeUniform->name.c_str(), activeUniform->name.length(), &namePropertyValue));
+
+	JsValueRef sizePropertyValue;
+	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(activeUniform->size, &sizePropertyValue));
+
+	JsValueRef typePropertyValue;
+	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(activeUniform->type, &typePropertyValue));
+
+	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"name", namePropertyValue));
+	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"size", sizePropertyValue));
+	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"type", typePropertyValue));
+	
+	return returnObject;
 }
 
 JsValueRef

--- a/HoloJS/HoloJsHost/WebGLProjections.cpp
+++ b/HoloJS/HoloJsHost/WebGLProjections.cpp
@@ -162,6 +162,9 @@ WebGLProjections::getShaderPrecisionFormat(
 	GLenum precisiontype = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
 	auto precisionFormat = context->getShaderPrecisionFormat(shadertype, precisiontype);
 
+	// Project object to script; note that the projected object is opaque to the script
+	auto returnObject = ScriptResourceTracker::ObjectToExternal(precisionFormat);
+
 	JsValueRef rangeMinValue;
 	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(precisionFormat->rangeMin, &rangeMinValue));
 
@@ -171,8 +174,7 @@ WebGLProjections::getShaderPrecisionFormat(
 	JsValueRef precisionValue;
 	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(precisionFormat->precision, &precisionValue));
 
-	auto returnObject = ScriptResourceTracker::ObjectToExternal(precisionFormat);
-
+	// Add properties as required for WebGLShaderPrecisionFormat
 	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"rangeMin", rangeMinValue));
 	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"rangeMax", rangeMaxValue));
 	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"precision", precisionValue));
@@ -1476,7 +1478,7 @@ WebGLProjections::getActiveUniform(
 	GLuint index = ScriptHostUtilities::GLuintFromJsRef(arguments[3]);
 	auto activeUniform = context->getActiveUniform(program, index);
 
-
+	// Project object to script; note that the projected object is opaque to the script
 	auto returnObject = ScriptResourceTracker::ObjectToExternal(activeUniform);
 
 	JsValueRef namePropertyValue;
@@ -1488,6 +1490,7 @@ WebGLProjections::getActiveUniform(
 	JsValueRef typePropertyValue;
 	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(activeUniform->type, &typePropertyValue));
 
+	// Add properties for WebGLActiveInfo as required by spec
 	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"name", namePropertyValue));
 	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"size", sizePropertyValue));
 	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"type", typePropertyValue));

--- a/HoloJS/HoloJsHost/WebGLRenderingContext.cpp
+++ b/HoloJS/HoloJsHost/WebGLRenderingContext.cpp
@@ -645,13 +645,9 @@ WebGLRenderingContext::getParameter(GLenum pname)
     }
 	else if (pname == GL_VERSION)
 	{
-		auto asciiVersionBuffer = glGetString(pname);
-		string asciiVersion;
-		asciiVersion.assign(reinterpret_cast<const char*>(asciiVersionBuffer));
-		wstring unicodeVersion(asciiVersion.begin(), asciiVersion.end());
-
+		wstring versionString = L"WebGL 1.0";
 		JsValueRef retJsValue;
-		JsPointerToString(unicodeVersion.c_str(), unicodeVersion.length(), &retJsValue);
+		JsPointerToString(versionString.c_str(), versionString.length(), &retJsValue);
 		return retJsValue;
 	}
     else


### PR DESCRIPTION
Add console.error

Add required properties to the WebGLShaderPrecisionFormat and WebGLActiveInfo objects returned by getShaderPrecisionFormat and getActiveUniform respectively.

Return correct WebGL version (1.0) instead of the underlying OpenGL version.