### PR TITLE
Redirect console.[log|...] to OutputDebugString to make it available in VS's output window

### DIFF
--- a/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
@@ -44,14 +44,17 @@ function Anchor() {
         this.warningEntries = [];
         this.errorEntries = [];
         this.log = function (entry) {
+            this.logEntries.push(entry);
             nativeInterface.system.log("log: " + entry + "\r\n");
         }.bind(this);
 
         this.warn = function (entry) {
+            this.warningEntries.push(entry);
             nativeInterface.system.log("warn: " + entry + "\r\n");
         }
 
         this.error = function (entry) {
+            this.errorEntries.push(entry);
             nativeInterface.system.log("error: " + entry + "\r\n");
         }
     }

--- a/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
@@ -44,15 +44,15 @@ function Anchor() {
         this.warningEntries = [];
         this.errorEntries = [];
         this.log = function (entry) {
-            this.logEntries.push("info: " + entry);
+            nativeInterface.system.log("log: " + entry + "\r\n");
         }.bind(this);
 
         this.warn = function (entry) {
-            this.warningEntries.push("warning: " + entry);
+            nativeInterface.system.log("warn " + entry + "\r\n");
         }
 
         this.error = function (entry) {
-            this.errorEntries.push("error: " + entry);
+            nativeInterface.system.log("error: " + entry + "\r\n");
         }
     }
 
@@ -144,5 +144,4 @@ function Anchor() {
     document = new makeDocument();
     console = new makeConsole();
     navigator = new makeNavigator();
-    console = new makeConsole();
 })();

--- a/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
@@ -48,7 +48,7 @@ function Anchor() {
         }.bind(this);
 
         this.warn = function (entry) {
-            nativeInterface.system.log("warn " + entry + "\r\n");
+            nativeInterface.system.log("warn: " + entry + "\r\n");
         }
 
         this.error = function (entry) {

--- a/HoloJS/HoloJsHost/System.cpp
+++ b/HoloJS/HoloJsHost/System.cpp
@@ -20,8 +20,25 @@ bool
 System::Initialize()
 {
 	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"setTimeout", L"system", setTimeoutStatic, this, &m_setTimeoutFunction));
+	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"log", L"system", logStatic, this, &m_logFunction));
 
 	return true;
+}
+
+JsValueRef
+System::log(
+	JsValueRef callee,
+	JsValueRef* arguments,
+	unsigned short argumentCount
+)
+{
+	RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
+
+	const wchar_t* logString;
+	size_t logStringLength;
+	RETURN_INVALID_REF_IF_JS_ERROR(JsStringToPointer(arguments[1], &logString, &logStringLength));
+
+	OutputDebugString(logString);
 }
 
 JsValueRef

--- a/HoloJS/HoloJsHost/System.cpp
+++ b/HoloJS/HoloJsHost/System.cpp
@@ -39,6 +39,8 @@ System::log(
 	RETURN_INVALID_REF_IF_JS_ERROR(JsStringToPointer(arguments[1], &logString, &logStringLength));
 
 	OutputDebugString(logString);
+
+	return JS_INVALID_REFERENCE;
 }
 
 JsValueRef

--- a/HoloJS/HoloJsHost/System.h
+++ b/HoloJS/HoloJsHost/System.h
@@ -26,7 +26,25 @@ namespace HologramJS
 				return reinterpret_cast<System*>(callbackData)->setTimeout(callee, arguments, argumentCount);
 			}
 
+			JsValueRef m_logFunction = JS_INVALID_REFERENCE;
+			static JsValueRef CHAKRA_CALLBACK logStatic(
+				JsValueRef callee,
+				bool isConstructCall,
+				JsValueRef* arguments,
+				unsigned short argumentCount,
+				PVOID callbackData
+			)
+			{
+				return reinterpret_cast<System*>(callbackData)->log(callee, arguments, argumentCount);
+			}
+
 			JsValueRef setTimeout(
+				JsValueRef callee,
+				JsValueRef* arguments,
+				unsigned short argumentCount
+			);
+
+			JsValueRef log(
 				JsValueRef callee,
 				JsValueRef* arguments,
 				unsigned short argumentCount


### PR DESCRIPTION
This only works only when doing native debugging.