### PR TITLE
Fix link in "Deploying" section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ run it.
 
 ### Deploying the sample to a Microsoft HoloLens
 
-- Developer unlock your Microsoft HoloLens. For instructions, go to [Enable your device for development]
-  (https://msdn.microsoft.com/windows/uwp/get-started/enable-your-device-for-development#enable-your-windows-10-devices).
+- Developer unlock your Microsoft HoloLens. For instructions, go to [Enable your device for development](https://msdn.microsoft.com/windows/uwp/get-started/enable-your-device-for-development#enable-your-windows-10-devices).
 - Find the IP address of your Microsoft HoloLens. The IP address can be found in **Settings** \> 
   **Network & Internet** \> **Wi-Fi** \> **Advanced options**. Or, you can ask Cortana for this 
   information by saying: "Hey Cortana, what's my IP address?"


### PR DESCRIPTION
The link was broken up due to the linebreak & spaces between the user-facing text ("Enable your device for development") and the actual link.