### PR TITLE
Fix mouse and keyboard input when running on desktop

### DIFF
--- a/HoloJS/HoloJsHost/HologramJS.h
+++ b/HoloJS/HoloJsHost/HologramJS.h
@@ -21,14 +21,6 @@ namespace HologramJS
 		void ResizeWindow(int width, int height) { m_window.Resize(width, height); }
 		void VSync(Windows::Foundation::Numerics::float4x4 viewMatrix) { m_window.VSync(viewMatrix); }
 
-		void KeyUp(Windows::UI::Core::KeyEventArgs ^args) { m_window.KeyboardRouter().KeyUp(args); }
-		void KeyDown(Windows::UI::Core::KeyEventArgs ^args) { m_window.KeyboardRouter().KeyDown(args); }
-
-		void MouseDown(Windows::UI::Core::PointerEventArgs^ args) { m_window.MouseRouter().MouseDown(args); }
-		void MouseUp(Windows::UI::Core::PointerEventArgs^ args) { m_window.MouseRouter().MouseUp(args); }
-		void MouseMove(Windows::UI::Core::PointerEventArgs^ args) { m_window.MouseRouter().MouseMove(args); }
-		void MouseWheel(Windows::UI::Core::PointerEventArgs^ args) { m_window.MouseRouter().MouseWheel(args); }
-
 	private:
 		JsRuntimeHandle m_jsRuntime = nullptr;
 		JsContextRef m_jsContext = nullptr;

--- a/HoloJS/HoloJsHost/KeyboardInput.h
+++ b/HoloJS/HoloJsHost/KeyboardInput.h
@@ -7,6 +7,7 @@ namespace HologramJS
 		{
 		public:
 			KeyboardInput();
+			~KeyboardInput();
 
 			void KeyUp(Windows::UI::Core::KeyEventArgs ^args);
 			void KeyDown(Windows::UI::Core::KeyEventArgs ^args);
@@ -20,8 +21,11 @@ namespace HologramJS
 				const std::wstring& eventName,
 				const std::wstring& actionType,
 				Windows::UI::Core::KeyEventArgs^ args,
-				std::vector<JsValueRef>& outParams
+				JsValueRef (&outParams)[4]
 			);
+
+			Windows::Foundation::EventRegistrationToken m_keyDownToken;
+			Windows::Foundation::EventRegistrationToken m_keyUpToken;
 		};
 
 	}

--- a/HoloJS/HoloJsHost/MouseInput.cpp
+++ b/HoloJS/HoloJsHost/MouseInput.cpp
@@ -4,54 +4,81 @@
 using namespace HologramJS::Input;
 using namespace Windows::UI::Core;
 using namespace std;
+using namespace Windows::Foundation;
+
+enum class MouseButtons : int
+{
+	NoButton = 0,
+	LeftButton = 1,
+	RightButton = 2,
+	MiddleButton = 4
+};
+
+inline MouseButtons &
+operator|=(MouseButtons & __x, MouseButtons __y)
+{
+	__x = static_cast<MouseButtons>(static_cast<int>(__x) | static_cast<int>(__y));
+	return __x;
+}
 
 MouseInput::MouseInput()
 {
+	m_mouseDownToken = CoreWindow::GetForCurrentThread()->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(
+		[this](CoreWindow ^sender, PointerEventArgs ^args)
+	{
+		this->MouseDown(args);
+	});
+
+	m_mouseUpToken = CoreWindow::GetForCurrentThread()->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(
+		[this](CoreWindow ^sender, PointerEventArgs ^args)
+	{
+		this->MouseUp(args);
+	});
+
+	m_mouseWheelToken = CoreWindow::GetForCurrentThread()->PointerWheelChanged += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(
+		[this](CoreWindow ^sender, PointerEventArgs ^args)
+	{
+		this->MouseWheel(args);
+	});
+
+	m_mouseMoveToken = CoreWindow::GetForCurrentThread()->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(
+		[this](CoreWindow ^sender, PointerEventArgs ^args)
+	{
+		this->MouseMove(args);
+	});
 }
 
 
 MouseInput::~MouseInput()
 {
+	CoreWindow::GetForCurrentThread()->PointerPressed -= m_mouseDownToken;
+	CoreWindow::GetForCurrentThread()->PointerReleased -= m_mouseUpToken;
+	CoreWindow::GetForCurrentThread()->PointerWheelChanged -= m_mouseWheelToken;
+	CoreWindow::GetForCurrentThread()->PointerMoved -= m_mouseMoveToken;
 }
 
-int GetButtonFromArgs(PointerEventArgs^ args)
+MouseButtons GetButtonFromArgs(PointerEventArgs^ args)
 {
-	auto pointProps = args->CurrentPoint->Properties;
-	const bool left = pointProps->IsLeftButtonPressed;
-	const bool middle = pointProps->IsMiddleButtonPressed;
-	const bool right = pointProps->IsRightButtonPressed;
-	if (left && !middle && !right)
+	auto returnValue = MouseButtons::NoButton;
+
+	const auto pointProps = args->CurrentPoint->Properties;
+
+	if (pointProps->IsLeftButtonPressed)
 	{
-		return 1;
+		returnValue |= MouseButtons::LeftButton;
 	}
-	else if (left && middle && !right)
+
+	if (pointProps->IsMiddleButtonPressed)
 	{
-		return 5;
+		returnValue |= MouseButtons::MiddleButton;
 	}
-	else if (left && middle && right)
+
+	if (pointProps->IsRightButtonPressed)
 	{
-		return 7;
+		returnValue |= MouseButtons::RightButton;
 	}
-	else if (left && !middle && right)
-	{
-		return 3;
-	}
-	else if (!left && middle && right)
-	{
-		return 6;
-	}
-	else if (!left && middle && !right)
-	{
-		return 4;
-	}
-	else if (!left && !middle && right)
-	{
-		return 2;
-	}
-	else
-	{
-		return 0;
-	}
+
+	return returnValue;
 }
 
 bool
@@ -59,11 +86,9 @@ MouseInput::CreateScriptParametersListForMouse(
 	const wstring& eventName,
 	const wstring& actionType,
 	PointerEventArgs^ args,
-	vector<JsValueRef>& outParams
+	JsValueRef (&outParams)[6]
 )
 {
-	outParams.resize(6);
-
 	outParams[0] = m_scriptCallback;
 	JsValueRef* eventNameParam = &outParams[1];
 	JsValueRef* xParam = &outParams[2];
@@ -74,7 +99,7 @@ MouseInput::CreateScriptParametersListForMouse(
 	RETURN_IF_JS_ERROR(JsPointerToString(eventName.c_str(), eventName.length(), eventNameParam));
 	RETURN_IF_JS_ERROR(JsDoubleToNumber(args->CurrentPoint->Position.X, xParam));
 	RETURN_IF_JS_ERROR(JsDoubleToNumber(args->CurrentPoint->Position.Y, yParam));
-	RETURN_IF_JS_ERROR(JsIntToNumber(GetButtonFromArgs(args), buttonParam));
+	RETURN_IF_JS_ERROR(JsIntToNumber(static_cast<int>(GetButtonFromArgs(args)), buttonParam));
 	RETURN_IF_JS_ERROR(JsPointerToString(actionType.c_str(), actionType.length(), actionParam));
 
 	return true;
@@ -86,14 +111,13 @@ MouseInput::MouseDown(PointerEventArgs^ args)
 	static std::wstring mouseEventName(L"mouse");
 	static std::wstring mouseActionType(L"mousedown");
 
-	if (m_scriptCallback != JS_INVALID_REFERENCE)
-	{
-		std::vector<JsValueRef> parameters;
-		CreateScriptParametersListForMouse(mouseEventName, mouseActionType, args, parameters);
+	EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
 
-		JsValueRef result;
-		EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters.data(), (unsigned short)parameters.size(), &result));
-	}
+	JsValueRef parameters[6];
+	CreateScriptParametersListForMouse(mouseEventName, mouseActionType, args, parameters);
+
+	JsValueRef result;
+	EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
 }
 
 void
@@ -102,14 +126,13 @@ MouseInput::MouseUp(PointerEventArgs^ args)
 	static std::wstring mouseEventName(L"mouse");
 	static std::wstring mouseActionType(L"mouseup");
 	
-	if (m_scriptCallback != JS_INVALID_REFERENCE)
-	{
-		std::vector<JsValueRef> parameters;
-		EXIT_IF_FALSE(CreateScriptParametersListForMouse(mouseEventName, mouseActionType, args, parameters));
+	EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
 
-		JsValueRef result;
-		EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters.data(), (unsigned short)parameters.size(), &result));
-	}
+	JsValueRef parameters[6];
+	EXIT_IF_FALSE(CreateScriptParametersListForMouse(mouseEventName, mouseActionType, args, parameters));
+
+	JsValueRef result;
+	EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
 }
 
 void
@@ -118,14 +141,13 @@ MouseInput::MouseMove(PointerEventArgs^ args)
 	static std::wstring mouseEventName(L"mouse");
 	static std::wstring mouseActionType(L"mousemove");
 
-	if (m_scriptCallback != JS_INVALID_REFERENCE)
-	{
-		vector<JsValueRef> parameters;
-		CreateScriptParametersListForMouse(mouseEventName, mouseActionType, args, parameters);
+	EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
 
-		JsValueRef result;
-		EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters.data(), (unsigned short)parameters.size(), &result));
-	}
+	JsValueRef parameters[6];
+	CreateScriptParametersListForMouse(mouseEventName, mouseActionType, args, parameters);
+
+	JsValueRef result;
+	EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
 }
 
 void
@@ -134,12 +156,11 @@ MouseInput::MouseWheel(PointerEventArgs^ args)
 	static std::wstring mouseEventName(L"mouse");
 	static std::wstring mouseActionType(L"mousewheel");
 
-	if (m_scriptCallback != JS_INVALID_REFERENCE)
-	{
-		vector<JsValueRef> parameters;
-		CreateScriptParametersListForMouse(mouseEventName, mouseActionType, args, parameters);
+	EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
+	
+	JsValueRef parameters[6];
+	CreateScriptParametersListForMouse(mouseEventName, mouseActionType, args, parameters);
 
-		JsValueRef result;
-		EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters.data(), (unsigned short)parameters.size(), &result));
-	}
+	JsValueRef result;
+	EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
 }

--- a/HoloJS/HoloJsHost/MouseInput.h
+++ b/HoloJS/HoloJsHost/MouseInput.h
@@ -10,11 +10,6 @@ namespace HologramJS
 			MouseInput();
 			~MouseInput();
 
-			void MouseDown(Windows::UI::Core::PointerEventArgs^ args);
-			void MouseUp(Windows::UI::Core::PointerEventArgs^ args);
-			void MouseMove(Windows::UI::Core::PointerEventArgs^ args);
-			void MouseWheel(Windows::UI::Core::PointerEventArgs^ args);
-
 			void SetScriptCallback(JsValueRef scriptCallback) { m_scriptCallback = scriptCallback; }
 
 		private:
@@ -24,9 +19,19 @@ namespace HologramJS
 				const std::wstring& eventName,
 				const std::wstring& actionType,
 				Windows::UI::Core::PointerEventArgs^ args,
-				std::vector<JsValueRef>& outParams
+				JsValueRef (&outParams)[6]
 			);
 
+
+			void MouseDown(Windows::UI::Core::PointerEventArgs^ args);
+			void MouseUp(Windows::UI::Core::PointerEventArgs^ args);
+			void MouseMove(Windows::UI::Core::PointerEventArgs^ args);
+			void MouseWheel(Windows::UI::Core::PointerEventArgs^ args);
+
+			Windows::Foundation::EventRegistrationToken m_mouseDownToken;
+			Windows::Foundation::EventRegistrationToken m_mouseUpToken;
+			Windows::Foundation::EventRegistrationToken m_mouseWheelToken;
+			Windows::Foundation::EventRegistrationToken m_mouseMoveToken;
 		};
 	}
 }

--- a/HoloJS/HoloJsHost/RenderingContext2D.cpp
+++ b/HoloJS/HoloJsHost/RenderingContext2D.cpp
@@ -28,8 +28,8 @@ RenderingContext2D::drawImage3(
 
 	m_canvasRenderTarget = ref new CanvasRenderTarget(
 		CanvasDevice::GetSharedDevice(),
-		m_width,
-		m_height,
+		static_cast<float>(m_width),
+		static_cast<float>(m_height),
 		96,
 		DirectXPixelFormat::R8G8B8A8UIntNormalized,
 		CanvasAlphaMode::Ignore);
@@ -54,8 +54,8 @@ RenderingContext2D::drawImage3(
 
     CanvasDrawingSession^ session = m_canvasRenderTarget->CreateDrawingSession();
 
-    Rect source(sx, sy, sWidth, sHeight);
-    Rect dest(dx, dy, dWidth, dHeight);
+    Rect source(static_cast<float>(sx), static_cast<float>(sy), static_cast<float>(sWidth), static_cast<float>(sHeight));
+    Rect dest(static_cast<float>(dx), static_cast<float>(dy), static_cast<float>(dWidth), static_cast<float>(dHeight));
     session->DrawImage(canvasBitmap, dest, source);
     session = nullptr;
 }
@@ -115,8 +115,8 @@ RenderingContext2D::drawImage2(
 
 	m_canvasRenderTarget = ref new CanvasRenderTarget(
 		CanvasDevice::GetSharedDevice(),
-		m_width,
-		m_height,
+		static_cast<float>(m_width),
+		static_cast<float>(m_height),
 		96,
 		DirectXPixelFormat::R8G8B8A8UIntNormalized,
 		CanvasAlphaMode::Ignore);
@@ -140,7 +140,7 @@ RenderingContext2D::drawImage2(
 
     auto session = m_canvasRenderTarget->CreateDrawingSession();
 
-    Rect dest(dx, dy, dWidth, dHeight);
+    Rect dest(static_cast<float>(dx), static_cast<float>(dy), static_cast<float>(dWidth), static_cast<float>(dHeight));
     session->DrawImage(canvasBitmap, dest);
     session = nullptr;
 }

--- a/HoloJS/HoloJsHost/ScriptingFramework/FrameworkHelpers.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/FrameworkHelpers.js
@@ -21,7 +21,7 @@
                 }
             }
 
-            if (base.eventListeners.length === 0) {
+            if (base.eventListeners.length === 0 && base.native && base.nativeCallback) {
                 nativeInterface.eventing.removeCallback(base.native);
             }
         };

--- a/HoloJS/HoloJsHost/ScriptingFramework/Window.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/Window.js
@@ -19,7 +19,18 @@
         }
 
         var mouseEvent = {};
-        mouseEvent.button = button;
+        
+        mouseEvent.buttons = button;
+
+        // Native button parameter is actually MouseEvent.buttons. Convert it to MouseEvent.button now
+        if (button & 1) {
+            mouseEvent.button = 0;
+        } else if (button & 2) {
+            mouseEvent.button = 2;
+        } else if (button & 4) {
+            mouseEvent.button = 1;
+        }
+
         mouseEvent.clientX = x;
         mouseEvent.clientY = y;
 
@@ -27,6 +38,7 @@
         mouseEvent.srcElement = document.canvas;
 
         document.canvas.fireHandlersByType(action, mouseEvent);
+        document.fireHandlersByType(action, mouseEvent);
     }
 
     function onKeyboardEvent(event) {

--- a/HoloJS/HoloJsHost/pch.h
+++ b/HoloJS/HoloJsHost/pch.h
@@ -50,6 +50,7 @@ void Log(PCSTR file, int line);
 
 #define EXIT_IF_JS_ERROR(x) do { if ((x) != JsNoError) { Log(__FILE__, __LINE__); return; } } while (0, 0)
 #define EXIT_IF_FALSE(x) do { if ((x) == false) { Log(__FILE__, __LINE__); return; } } while (0, 0)
+#define EXIT_IF_TRUE(x) do { if ((x) == true) { Log(__FILE__, __LINE__); return; } } while (0, 0)
 #define EXIT_IF_FAILED(x) do { if (FAILED(x)) { Log(__FILE__, __LINE__); return; } } while (0, 0)
 #define RETURN_IF_JS_ERROR(x) do { if ((x) != JsNoError) { Log(__FILE__, __LINE__); return false; } } while (0, 0)
 #define RETURN_IF_FAILED(x) do { if (FAILED(x)) { Log(__FILE__, __LINE__); return false; } } while (0, 0)

--- a/HoloJS/ThreeJSApp/Scripts/OrbitControls.js
+++ b/HoloJS/ThreeJSApp/Scripts/OrbitControls.js
@@ -1,0 +1,1040 @@
+/**
+ * @author qiao / https://github.com/qiao
+ * @author mrdoob / http://mrdoob.com
+ * @author alteredq / http://alteredqualia.com/
+ * @author WestLangley / http://github.com/WestLangley
+ * @author erich666 / http://erichaines.com
+ */
+
+// This set of controls performs orbiting, dollying (zooming), and panning.
+// Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
+//
+//    Orbit - left mouse / touch: one finger move
+//    Zoom - middle mouse, or mousewheel / touch: two finger spread or squish
+//    Pan - right mouse, or arrow keys / touch: three finger swipe
+
+THREE.OrbitControls = function ( object, domElement ) {
+
+	this.object = object;
+
+	this.domElement = ( domElement !== undefined ) ? domElement : document;
+
+	// Set to false to disable this control
+	this.enabled = true;
+
+	// "target" sets the location of focus, where the object orbits around
+	this.target = new THREE.Vector3();
+
+	// How far you can dolly in and out ( PerspectiveCamera only )
+	this.minDistance = 0;
+	this.maxDistance = Infinity;
+
+	// How far you can zoom in and out ( OrthographicCamera only )
+	this.minZoom = 0;
+	this.maxZoom = Infinity;
+
+	// How far you can orbit vertically, upper and lower limits.
+	// Range is 0 to Math.PI radians.
+	this.minPolarAngle = 0; // radians
+	this.maxPolarAngle = Math.PI; // radians
+
+	// How far you can orbit horizontally, upper and lower limits.
+	// If set, must be a sub-interval of the interval [ - Math.PI, Math.PI ].
+	this.minAzimuthAngle = - Infinity; // radians
+	this.maxAzimuthAngle = Infinity; // radians
+
+	// Set to true to enable damping (inertia)
+	// If damping is enabled, you must call controls.update() in your animation loop
+	this.enableDamping = false;
+	this.dampingFactor = 0.25;
+
+	// This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
+	// Set to false to disable zooming
+	this.enableZoom = true;
+	this.zoomSpeed = 1.0;
+
+	// Set to false to disable rotating
+	this.enableRotate = true;
+	this.rotateSpeed = 1.0;
+
+	// Set to false to disable panning
+	this.enablePan = true;
+	this.keyPanSpeed = 7.0;	// pixels moved per arrow key push
+
+	// Set to true to automatically rotate around the target
+	// If auto-rotate is enabled, you must call controls.update() in your animation loop
+	this.autoRotate = false;
+	this.autoRotateSpeed = 2.0; // 30 seconds per round when fps is 60
+
+	// Set to false to disable use of the keys
+	this.enableKeys = true;
+
+	// The four arrow keys
+	this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
+
+	// Mouse buttons
+	this.mouseButtons = { ORBIT: THREE.MOUSE.LEFT, ZOOM: THREE.MOUSE.MIDDLE, PAN: THREE.MOUSE.RIGHT };
+
+	// for reset
+	this.target0 = this.target.clone();
+	this.position0 = this.object.position.clone();
+	this.zoom0 = this.object.zoom;
+
+	//
+	// public methods
+	//
+
+	this.getPolarAngle = function () {
+
+		return spherical.phi;
+
+	};
+
+	this.getAzimuthalAngle = function () {
+
+		return spherical.theta;
+
+	};
+
+	this.saveState = function () {
+
+		scope.target0.copy( scope.target );
+		scope.position0.copy( scope.object.position );
+		scope.zoom0 = scope.object.zoom;
+
+	};
+
+	this.reset = function () {
+
+		scope.target.copy( scope.target0 );
+		scope.object.position.copy( scope.position0 );
+		scope.object.zoom = scope.zoom0;
+
+		scope.object.updateProjectionMatrix();
+		scope.dispatchEvent( changeEvent );
+
+		scope.update();
+
+		state = STATE.NONE;
+
+	};
+
+	// this method is exposed, but perhaps it would be better if we can make it private...
+	this.update = function () {
+
+		var offset = new THREE.Vector3();
+
+		// so camera.up is the orbit axis
+		var quat = new THREE.Quaternion().setFromUnitVectors( object.up, new THREE.Vector3( 0, 1, 0 ) );
+		var quatInverse = quat.clone().inverse();
+
+		var lastPosition = new THREE.Vector3();
+		var lastQuaternion = new THREE.Quaternion();
+
+		return function update() {
+
+			var position = scope.object.position;
+
+			offset.copy( position ).sub( scope.target );
+
+			// rotate offset to "y-axis-is-up" space
+			offset.applyQuaternion( quat );
+
+			// angle from z-axis around y-axis
+			spherical.setFromVector3( offset );
+
+			if ( scope.autoRotate && state === STATE.NONE ) {
+
+				rotateLeft( getAutoRotationAngle() );
+
+			}
+
+			spherical.theta += sphericalDelta.theta;
+			spherical.phi += sphericalDelta.phi;
+
+			// restrict theta to be between desired limits
+			spherical.theta = Math.max( scope.minAzimuthAngle, Math.min( scope.maxAzimuthAngle, spherical.theta ) );
+
+			// restrict phi to be between desired limits
+			spherical.phi = Math.max( scope.minPolarAngle, Math.min( scope.maxPolarAngle, spherical.phi ) );
+
+			spherical.makeSafe();
+
+
+			spherical.radius *= scale;
+
+			// restrict radius to be between desired limits
+			spherical.radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, spherical.radius ) );
+
+			// move target to panned location
+			scope.target.add( panOffset );
+
+			offset.setFromSpherical( spherical );
+
+			// rotate offset back to "camera-up-vector-is-up" space
+			offset.applyQuaternion( quatInverse );
+
+			position.copy( scope.target ).add( offset );
+
+			scope.object.lookAt( scope.target );
+
+			if ( scope.enableDamping === true ) {
+
+				sphericalDelta.theta *= ( 1 - scope.dampingFactor );
+				sphericalDelta.phi *= ( 1 - scope.dampingFactor );
+
+			} else {
+
+				sphericalDelta.set( 0, 0, 0 );
+
+			}
+
+			scale = 1;
+			panOffset.set( 0, 0, 0 );
+
+			// update condition is:
+			// min(camera displacement, camera rotation in radians)^2 > EPS
+			// using small-angle approximation cos(x/2) = 1 - x^2 / 8
+
+			if ( zoomChanged ||
+				lastPosition.distanceToSquared( scope.object.position ) > EPS ||
+				8 * ( 1 - lastQuaternion.dot( scope.object.quaternion ) ) > EPS ) {
+
+				scope.dispatchEvent( changeEvent );
+
+				lastPosition.copy( scope.object.position );
+				lastQuaternion.copy( scope.object.quaternion );
+				zoomChanged = false;
+
+				return true;
+
+			}
+
+			return false;
+
+		};
+
+	}();
+
+	this.dispose = function () {
+
+		scope.domElement.removeEventListener( 'contextmenu', onContextMenu, false );
+		scope.domElement.removeEventListener( 'mousedown', onMouseDown, false );
+		scope.domElement.removeEventListener( 'wheel', onMouseWheel, false );
+
+		scope.domElement.removeEventListener( 'touchstart', onTouchStart, false );
+		scope.domElement.removeEventListener( 'touchend', onTouchEnd, false );
+		scope.domElement.removeEventListener( 'touchmove', onTouchMove, false );
+
+		document.removeEventListener( 'mousemove', onMouseMove, false );
+		document.removeEventListener( 'mouseup', onMouseUp, false );
+
+		window.removeEventListener( 'keydown', onKeyDown, false );
+
+		//scope.dispatchEvent( { type: 'dispose' } ); // should this be added here?
+
+	};
+
+	//
+	// internals
+	//
+
+	var scope = this;
+
+	var changeEvent = { type: 'change' };
+	var startEvent = { type: 'start' };
+	var endEvent = { type: 'end' };
+
+	var STATE = { NONE: - 1, ROTATE: 0, DOLLY: 1, PAN: 2, TOUCH_ROTATE: 3, TOUCH_DOLLY: 4, TOUCH_PAN: 5 };
+
+	var state = STATE.NONE;
+
+	var EPS = 0.000001;
+
+	// current position in spherical coordinates
+	var spherical = new THREE.Spherical();
+	var sphericalDelta = new THREE.Spherical();
+
+	var scale = 1;
+	var panOffset = new THREE.Vector3();
+	var zoomChanged = false;
+
+	var rotateStart = new THREE.Vector2();
+	var rotateEnd = new THREE.Vector2();
+	var rotateDelta = new THREE.Vector2();
+
+	var panStart = new THREE.Vector2();
+	var panEnd = new THREE.Vector2();
+	var panDelta = new THREE.Vector2();
+
+	var dollyStart = new THREE.Vector2();
+	var dollyEnd = new THREE.Vector2();
+	var dollyDelta = new THREE.Vector2();
+
+	function getAutoRotationAngle() {
+
+		return 2 * Math.PI / 60 / 60 * scope.autoRotateSpeed;
+
+	}
+
+	function getZoomScale() {
+
+		return Math.pow( 0.95, scope.zoomSpeed );
+
+	}
+
+	function rotateLeft( angle ) {
+
+		sphericalDelta.theta -= angle;
+
+	}
+
+	function rotateUp( angle ) {
+
+		sphericalDelta.phi -= angle;
+
+	}
+
+	var panLeft = function () {
+
+		var v = new THREE.Vector3();
+
+		return function panLeft( distance, objectMatrix ) {
+
+			v.setFromMatrixColumn( objectMatrix, 0 ); // get X column of objectMatrix
+			v.multiplyScalar( - distance );
+
+			panOffset.add( v );
+
+		};
+
+	}();
+
+	var panUp = function () {
+
+		var v = new THREE.Vector3();
+
+		return function panUp( distance, objectMatrix ) {
+
+			v.setFromMatrixColumn( objectMatrix, 1 ); // get Y column of objectMatrix
+			v.multiplyScalar( distance );
+
+			panOffset.add( v );
+
+		};
+
+	}();
+
+	// deltaX and deltaY are in pixels; right and down are positive
+	var pan = function () {
+
+		var offset = new THREE.Vector3();
+
+		return function pan( deltaX, deltaY ) {
+
+			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+			if ( scope.object instanceof THREE.PerspectiveCamera ) {
+
+				// perspective
+				var position = scope.object.position;
+				offset.copy( position ).sub( scope.target );
+				var targetDistance = offset.length();
+
+				// half of the fov is center to top of screen
+				targetDistance *= Math.tan( ( scope.object.fov / 2 ) * Math.PI / 180.0 );
+
+				// we actually don't use screenWidth, since perspective camera is fixed to screen height
+				panLeft( 2 * deltaX * targetDistance / element.clientHeight, scope.object.matrix );
+				panUp( 2 * deltaY * targetDistance / element.clientHeight, scope.object.matrix );
+
+			} else if ( scope.object instanceof THREE.OrthographicCamera ) {
+
+				// orthographic
+				panLeft( deltaX * ( scope.object.right - scope.object.left ) / scope.object.zoom / element.clientWidth, scope.object.matrix );
+				panUp( deltaY * ( scope.object.top - scope.object.bottom ) / scope.object.zoom / element.clientHeight, scope.object.matrix );
+
+			} else {
+
+				// camera neither orthographic nor perspective
+				console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - pan disabled.' );
+				scope.enablePan = false;
+
+			}
+
+		};
+
+	}();
+
+	function dollyIn( dollyScale ) {
+
+		if ( scope.object instanceof THREE.PerspectiveCamera ) {
+
+			scale /= dollyScale;
+
+		} else if ( scope.object instanceof THREE.OrthographicCamera ) {
+
+			scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom * dollyScale ) );
+			scope.object.updateProjectionMatrix();
+			zoomChanged = true;
+
+		} else {
+
+			console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.' );
+			scope.enableZoom = false;
+
+		}
+
+	}
+
+	function dollyOut( dollyScale ) {
+
+		if ( scope.object instanceof THREE.PerspectiveCamera ) {
+
+			scale *= dollyScale;
+
+		} else if ( scope.object instanceof THREE.OrthographicCamera ) {
+
+			scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / dollyScale ) );
+			scope.object.updateProjectionMatrix();
+			zoomChanged = true;
+
+		} else {
+
+			console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.' );
+			scope.enableZoom = false;
+
+		}
+
+	}
+
+	//
+	// event callbacks - update the object state
+	//
+
+	function handleMouseDownRotate( event ) {
+
+		//console.log( 'handleMouseDownRotate' );
+
+		rotateStart.set( event.clientX, event.clientY );
+
+	}
+
+	function handleMouseDownDolly( event ) {
+
+		//console.log( 'handleMouseDownDolly' );
+
+		dollyStart.set( event.clientX, event.clientY );
+
+	}
+
+	function handleMouseDownPan( event ) {
+
+		//console.log( 'handleMouseDownPan' );
+
+		panStart.set( event.clientX, event.clientY );
+
+	}
+
+	function handleMouseMoveRotate( event ) {
+
+		//console.log( 'handleMouseMoveRotate' );
+
+		rotateEnd.set( event.clientX, event.clientY );
+		rotateDelta.subVectors( rotateEnd, rotateStart );
+
+		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+		// rotating across whole screen goes 360 degrees around
+		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientWidth * scope.rotateSpeed );
+
+		// rotating up and down along whole screen attempts to go 360, but limited to 180
+		rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight * scope.rotateSpeed );
+
+		rotateStart.copy( rotateEnd );
+
+		scope.update();
+
+	}
+
+	function handleMouseMoveDolly( event ) {
+
+		//console.log( 'handleMouseMoveDolly' );
+
+		dollyEnd.set( event.clientX, event.clientY );
+
+		dollyDelta.subVectors( dollyEnd, dollyStart );
+
+		if ( dollyDelta.y > 0 ) {
+
+			dollyIn( getZoomScale() );
+
+		} else if ( dollyDelta.y < 0 ) {
+
+			dollyOut( getZoomScale() );
+
+		}
+
+		dollyStart.copy( dollyEnd );
+
+		scope.update();
+
+	}
+
+	function handleMouseMovePan( event ) {
+
+		//console.log( 'handleMouseMovePan' );
+
+		panEnd.set( event.clientX, event.clientY );
+
+		panDelta.subVectors( panEnd, panStart );
+
+		pan( panDelta.x, panDelta.y );
+
+		panStart.copy( panEnd );
+
+		scope.update();
+
+	}
+
+	function handleMouseUp( event ) {
+
+		// console.log( 'handleMouseUp' );
+
+	}
+
+	function handleMouseWheel( event ) {
+
+		// console.log( 'handleMouseWheel' );
+
+		if ( event.deltaY < 0 ) {
+
+			dollyOut( getZoomScale() );
+
+		} else if ( event.deltaY > 0 ) {
+
+			dollyIn( getZoomScale() );
+
+		}
+
+		scope.update();
+
+	}
+
+	function handleKeyDown( event ) {
+
+		//console.log( 'handleKeyDown' );
+
+		switch ( event.keyCode ) {
+
+			case scope.keys.UP:
+				pan( 0, scope.keyPanSpeed );
+				scope.update();
+				break;
+
+			case scope.keys.BOTTOM:
+				pan( 0, - scope.keyPanSpeed );
+				scope.update();
+				break;
+
+			case scope.keys.LEFT:
+				pan( scope.keyPanSpeed, 0 );
+				scope.update();
+				break;
+
+			case scope.keys.RIGHT:
+				pan( - scope.keyPanSpeed, 0 );
+				scope.update();
+				break;
+
+		}
+
+	}
+
+	function handleTouchStartRotate( event ) {
+
+		//console.log( 'handleTouchStartRotate' );
+
+		rotateStart.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
+
+	}
+
+	function handleTouchStartDolly( event ) {
+
+		//console.log( 'handleTouchStartDolly' );
+
+		var dx = event.touches[ 0 ].pageX - event.touches[ 1 ].pageX;
+		var dy = event.touches[ 0 ].pageY - event.touches[ 1 ].pageY;
+
+		var distance = Math.sqrt( dx * dx + dy * dy );
+
+		dollyStart.set( 0, distance );
+
+	}
+
+	function handleTouchStartPan( event ) {
+
+		//console.log( 'handleTouchStartPan' );
+
+		panStart.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
+
+	}
+
+	function handleTouchMoveRotate( event ) {
+
+		//console.log( 'handleTouchMoveRotate' );
+
+		rotateEnd.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
+		rotateDelta.subVectors( rotateEnd, rotateStart );
+
+		var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+
+		// rotating across whole screen goes 360 degrees around
+		rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientWidth * scope.rotateSpeed );
+
+		// rotating up and down along whole screen attempts to go 360, but limited to 180
+		rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight * scope.rotateSpeed );
+
+		rotateStart.copy( rotateEnd );
+
+		scope.update();
+
+	}
+
+	function handleTouchMoveDolly( event ) {
+
+		//console.log( 'handleTouchMoveDolly' );
+
+		var dx = event.touches[ 0 ].pageX - event.touches[ 1 ].pageX;
+		var dy = event.touches[ 0 ].pageY - event.touches[ 1 ].pageY;
+
+		var distance = Math.sqrt( dx * dx + dy * dy );
+
+		dollyEnd.set( 0, distance );
+
+		dollyDelta.subVectors( dollyEnd, dollyStart );
+
+		if ( dollyDelta.y > 0 ) {
+
+			dollyOut( getZoomScale() );
+
+		} else if ( dollyDelta.y < 0 ) {
+
+			dollyIn( getZoomScale() );
+
+		}
+
+		dollyStart.copy( dollyEnd );
+
+		scope.update();
+
+	}
+
+	function handleTouchMovePan( event ) {
+
+		//console.log( 'handleTouchMovePan' );
+
+		panEnd.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
+
+		panDelta.subVectors( panEnd, panStart );
+
+		pan( panDelta.x, panDelta.y );
+
+		panStart.copy( panEnd );
+
+		scope.update();
+
+	}
+
+	function handleTouchEnd( event ) {
+
+		//console.log( 'handleTouchEnd' );
+
+	}
+
+	//
+	// event handlers - FSM: listen for events and reset state
+	//
+
+	function onMouseDown( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		event.preventDefault();
+
+		switch ( event.button ) {
+
+			case scope.mouseButtons.ORBIT:
+
+				if ( scope.enableRotate === false ) return;
+
+				handleMouseDownRotate( event );
+
+				state = STATE.ROTATE;
+
+				break;
+
+			case scope.mouseButtons.ZOOM:
+
+				if ( scope.enableZoom === false ) return;
+
+				handleMouseDownDolly( event );
+
+				state = STATE.DOLLY;
+
+				break;
+
+			case scope.mouseButtons.PAN:
+
+				if ( scope.enablePan === false ) return;
+
+				handleMouseDownPan( event );
+
+				state = STATE.PAN;
+
+				break;
+
+		}
+
+		if ( state !== STATE.NONE ) {
+
+			document.addEventListener( 'mousemove', onMouseMove, false );
+			document.addEventListener( 'mouseup', onMouseUp, false );
+
+			scope.dispatchEvent( startEvent );
+
+		}
+
+	}
+
+	function onMouseMove( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		event.preventDefault();
+
+		switch ( state ) {
+
+			case STATE.ROTATE:
+
+				if ( scope.enableRotate === false ) return;
+
+				handleMouseMoveRotate( event );
+
+				break;
+
+			case STATE.DOLLY:
+
+				if ( scope.enableZoom === false ) return;
+
+				handleMouseMoveDolly( event );
+
+				break;
+
+			case STATE.PAN:
+
+				if ( scope.enablePan === false ) return;
+
+				handleMouseMovePan( event );
+
+				break;
+
+		}
+
+	}
+
+	function onMouseUp( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		handleMouseUp( event );
+
+		document.removeEventListener( 'mousemove', onMouseMove, false );
+		document.removeEventListener( 'mouseup', onMouseUp, false );
+
+		scope.dispatchEvent( endEvent );
+
+		state = STATE.NONE;
+
+	}
+
+	function onMouseWheel( event ) {
+
+		if ( scope.enabled === false || scope.enableZoom === false || ( state !== STATE.NONE && state !== STATE.ROTATE ) ) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		handleMouseWheel( event );
+
+		scope.dispatchEvent( startEvent ); // not sure why these are here...
+		scope.dispatchEvent( endEvent );
+
+	}
+
+	function onKeyDown( event ) {
+
+		if ( scope.enabled === false || scope.enableKeys === false || scope.enablePan === false ) return;
+
+		handleKeyDown( event );
+
+	}
+
+	function onTouchStart( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		switch ( event.touches.length ) {
+
+			case 1:	// one-fingered touch: rotate
+
+				if ( scope.enableRotate === false ) return;
+
+				handleTouchStartRotate( event );
+
+				state = STATE.TOUCH_ROTATE;
+
+				break;
+
+			case 2:	// two-fingered touch: dolly
+
+				if ( scope.enableZoom === false ) return;
+
+				handleTouchStartDolly( event );
+
+				state = STATE.TOUCH_DOLLY;
+
+				break;
+
+			case 3: // three-fingered touch: pan
+
+				if ( scope.enablePan === false ) return;
+
+				handleTouchStartPan( event );
+
+				state = STATE.TOUCH_PAN;
+
+				break;
+
+			default:
+
+				state = STATE.NONE;
+
+		}
+
+		if ( state !== STATE.NONE ) {
+
+			scope.dispatchEvent( startEvent );
+
+		}
+
+	}
+
+	function onTouchMove( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		switch ( event.touches.length ) {
+
+			case 1: // one-fingered touch: rotate
+
+				if ( scope.enableRotate === false ) return;
+				if ( state !== STATE.TOUCH_ROTATE ) return; // is this needed?...
+
+				handleTouchMoveRotate( event );
+
+				break;
+
+			case 2: // two-fingered touch: dolly
+
+				if ( scope.enableZoom === false ) return;
+				if ( state !== STATE.TOUCH_DOLLY ) return; // is this needed?...
+
+				handleTouchMoveDolly( event );
+
+				break;
+
+			case 3: // three-fingered touch: pan
+
+				if ( scope.enablePan === false ) return;
+				if ( state !== STATE.TOUCH_PAN ) return; // is this needed?...
+
+				handleTouchMovePan( event );
+
+				break;
+
+			default:
+
+				state = STATE.NONE;
+
+		}
+
+	}
+
+	function onTouchEnd( event ) {
+
+		if ( scope.enabled === false ) return;
+
+		handleTouchEnd( event );
+
+		scope.dispatchEvent( endEvent );
+
+		state = STATE.NONE;
+
+	}
+
+	function onContextMenu( event ) {
+
+		event.preventDefault();
+
+	}
+
+	//
+
+	scope.domElement.addEventListener( 'contextmenu', onContextMenu, false );
+
+	scope.domElement.addEventListener( 'mousedown', onMouseDown, false );
+	scope.domElement.addEventListener( 'wheel', onMouseWheel, false );
+
+	scope.domElement.addEventListener( 'touchstart', onTouchStart, false );
+	scope.domElement.addEventListener( 'touchend', onTouchEnd, false );
+	scope.domElement.addEventListener( 'touchmove', onTouchMove, false );
+
+	window.addEventListener( 'keydown', onKeyDown, false );
+
+	// force an update at start
+
+	this.update();
+
+};
+
+THREE.OrbitControls.prototype = Object.create( THREE.EventDispatcher.prototype );
+THREE.OrbitControls.prototype.constructor = THREE.OrbitControls;
+
+Object.defineProperties( THREE.OrbitControls.prototype, {
+
+	center: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .center has been renamed to .target' );
+			return this.target;
+
+		}
+
+	},
+
+	// backward compatibility
+
+	noZoom: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .noZoom has been deprecated. Use .enableZoom instead.' );
+			return ! this.enableZoom;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.OrbitControls: .noZoom has been deprecated. Use .enableZoom instead.' );
+			this.enableZoom = ! value;
+
+		}
+
+	},
+
+	noRotate: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .noRotate has been deprecated. Use .enableRotate instead.' );
+			return ! this.enableRotate;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.OrbitControls: .noRotate has been deprecated. Use .enableRotate instead.' );
+			this.enableRotate = ! value;
+
+		}
+
+	},
+
+	noPan: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .noPan has been deprecated. Use .enablePan instead.' );
+			return ! this.enablePan;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.OrbitControls: .noPan has been deprecated. Use .enablePan instead.' );
+			this.enablePan = ! value;
+
+		}
+
+	},
+
+	noKeys: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .noKeys has been deprecated. Use .enableKeys instead.' );
+			return ! this.enableKeys;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.OrbitControls: .noKeys has been deprecated. Use .enableKeys instead.' );
+			this.enableKeys = ! value;
+
+		}
+
+	},
+
+	staticMoving: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .staticMoving has been deprecated. Use .enableDamping instead.' );
+			return ! this.enableDamping;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.OrbitControls: .staticMoving has been deprecated. Use .enableDamping instead.' );
+			this.enableDamping = ! value;
+
+		}
+
+	},
+
+	dynamicDampingFactor: {
+
+		get: function () {
+
+			console.warn( 'THREE.OrbitControls: .dynamicDampingFactor has been renamed. Use .dampingFactor instead.' );
+			return this.dampingFactor;
+
+		},
+
+		set: function ( value ) {
+
+			console.warn( 'THREE.OrbitControls: .dynamicDampingFactor has been renamed. Use .dampingFactor instead.' );
+			this.dampingFactor = value;
+
+		}
+
+	}
+
+} );

--- a/HoloJS/ThreeJSApp/Scripts/app.js
+++ b/HoloJS/ThreeJSApp/Scripts/app.js
@@ -92,6 +92,12 @@ cone.frustumCulled = false;
 torus.frustumCulled = false;
 cursor.frustumCulled = false;
 
+var controls;
+
+if (window.experimentalHolographic !== true) {
+    controls = new THREE.OrbitControls(camera);    
+}
+
 function initColors (geometry) {
     return geometry.addAttribute('color', new THREE.BufferAttribute(new Float32Array(geometry.attributes.position.array.length).fill(1.0), 3));
 }

--- a/HoloJS/ThreeJSApp/Scripts/app.js
+++ b/HoloJS/ThreeJSApp/Scripts/app.js
@@ -95,7 +95,8 @@ cursor.frustumCulled = false;
 var controls;
 
 if (window.experimentalHolographic !== true) {
-    controls = new THREE.OrbitControls(camera);    
+    camera.position.set(0, 0, 1);
+    controls = new THREE.OrbitControls(camera, canvas);
 }
 
 function initColors (geometry) {

--- a/HoloJS/ThreeJSApp/Scripts/app.json
+++ b/HoloJS/ThreeJSApp/Scripts/app.json
@@ -1,1 +1,1 @@
-{ "scripts" : [ "polyfills.js", "three.js", "three-patches.js", "app.js" ] }
+{ "scripts" : [ "polyfills.js", "three.js", "three-patches.js", "OrbitControls.js", "app.js" ] }

--- a/HoloJS/ThreeJSApp/ThreeJSApp.vcxproj
+++ b/HoloJS/ThreeJSApp/ThreeJSApp.vcxproj
@@ -210,6 +210,9 @@
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
+    <None Include="Scripts\OrbitControls.js">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
     <None Include="ThreeJSApp_TemporaryKey.pfx" />
     <None Include="Scripts\app.js">
       <DeploymentContent>true</DeploymentContent>

--- a/HoloJS/ThreeJSApp/ThreeJSApp.vcxproj.filters
+++ b/HoloJS/ThreeJSApp/ThreeJSApp.vcxproj.filters
@@ -69,8 +69,11 @@
       <Filter>Scripts</Filter>
     </None>
     <None Include="ThreeJSApp_TemporaryKey.pfx" />
-    <None Include="..\prebuilt\angle\win32\debug\libEGL.dll" />
-    <None Include="..\prebuilt\angle\win32\debug\libGLESv2.dll" />
+    <None Include="..\prebuilt\angle\win32\release\libGLESv2.dll" />
+    <None Include="..\prebuilt\angle\win32\release\libEGL.dll" />
+    <None Include="Scripts\OrbitControls.js">
+      <Filter>Scripts</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Image Include="Scripts\texture.png">


### PR DESCRIPTION
Mouse and keyboard input was not captured when running on desktop. This change captures mouse and keyboard input from the current window.

Fix issues related to routing input to the scripting guest: JsValueRef values got garbage collected unintended, causing AVs.  Changed to code to allocate arrays of JsValueRefs on the stack to prevent garbage collection.

Add OrbitControl.js to enable mouse camera control in the ThreeJS app when running on desktop.

Fix misc compiler warnings.

Bubble mouse events to "document", not just "canvas".