### PR TITLE
Spatial input is available in JavaScript

### DIFF
--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj
@@ -223,6 +223,7 @@
     <ClInclude Include="ScriptHostUtilities.h" />
     <ClInclude Include="ScriptResourceTracker.h" />
     <ClInclude Include="ScriptsLoader.h" />
+    <ClInclude Include="SpatialInput.h" />
     <ClInclude Include="System.h" />
     <ClInclude Include="VideoElement.h" />
     <ClInclude Include="WebGLObjects.h" />
@@ -249,6 +250,7 @@
     <ClCompile Include="ScriptHostUtilities.cpp" />
     <ClCompile Include="ScriptResourceTracker.cpp" />
     <ClCompile Include="ScriptsLoader.cpp" />
+    <ClCompile Include="SpatialInput.cpp" />
     <ClCompile Include="System.cpp" />
     <ClCompile Include="VideoElement.cpp" />
     <ClCompile Include="WebGLObjects.cpp" />

--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj
@@ -214,6 +214,7 @@
     <ClInclude Include="HologramJS.h" />
     <ClInclude Include="IBufferOnMemory.h" />
     <ClInclude Include="ImageElement.h" />
+    <ClInclude Include="InputInterface.h" />
     <ClInclude Include="IRelease.h" />
     <ClInclude Include="KeyboardInput.h" />
     <ClInclude Include="MouseInput.h" />

--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
@@ -104,6 +104,9 @@
     <ClInclude Include="SpatialInput.h">
       <Filter>NativeFramework</Filter>
     </ClInclude>
+    <ClInclude Include="InputInterface.h">
+      <Filter>NativeFramework</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
@@ -44,6 +44,9 @@
     <ClCompile Include="RenderingContext2D.cpp">
       <Filter>WebGLRenderer</Filter>
     </ClCompile>
+    <ClCompile Include="SpatialInput.cpp">
+      <Filter>NativeFramework</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="HologramJS.h" />
@@ -97,6 +100,9 @@
     </ClInclude>
     <ClInclude Include="RenderingContext2D.h">
       <Filter>WebGLRenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="SpatialInput.h">
+      <Filter>NativeFramework</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/HoloJS/HoloJsHost/HologramJS.cpp
+++ b/HoloJS/HoloJsHost/HologramJS.cpp
@@ -13,6 +13,7 @@ using namespace Platform;
 using namespace concurrency;
 using namespace Windows::Foundation;
 using namespace std;
+using namespace Windows::Perception::Spatial;
 
 HologramScriptHost::HologramScriptHost()
 {
@@ -165,7 +166,7 @@ HologramScriptHost::RunWebScriptApp(
 }
 
 bool
-HologramScriptHost::EnableHolographicExperimental()
+HologramScriptHost::EnableHolographicExperimental(SpatialStationaryFrameOfReference^ frameOfReference)
 {
 	// Get the global object
 	JsValueRef globalObject;
@@ -182,6 +183,8 @@ HologramScriptHost::EnableHolographicExperimental()
 	RETURN_IF_JS_ERROR(JsBoolToBoolean(true, &holographicValue));
 
 	RETURN_IF_JS_ERROR(JsSetProperty(windowRef, holographicPropertyId, holographicValue, true));
+
+	m_window.SetStationaryFrameOfReference(frameOfReference);
 
 	return true;
 }

--- a/HoloJS/HoloJsHost/HologramJS.h
+++ b/HoloJS/HoloJsHost/HologramJS.h
@@ -13,7 +13,7 @@ namespace HologramJS
 		bool Initialize();
 		void Shutdown();
 
-		bool EnableHolographicExperimental();
+		bool EnableHolographicExperimental(Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ frameOfReference);
 
 		Windows::Foundation::IAsyncOperation<bool>^ RunLocalScriptAppAsync(Platform::String^ jsonFilePath);
 		Windows::Foundation::IAsyncOperation<bool>^ RunWebScriptAppAsync(Platform::String^ jsonUri);

--- a/HoloJS/HoloJsHost/InputInterface.h
+++ b/HoloJS/HoloJsHost/InputInterface.h
@@ -1,0 +1,37 @@
+#pragma once
+
+namespace HologramJS
+{
+	namespace Input
+	{
+		// the mapping of events to values is fixed on the script side;
+		// any changes here must be ported to window.js as well
+		enum class NativeToScriptInputType : int {
+			Resize = 0,
+			Mouse,
+			Keyboard,
+			SpatialInput
+		};
+
+		enum class KeyboardInputEventType : int {
+			KeyDown = 0,
+			KeyUp
+		};
+
+		enum class MouseInputEventType : int {
+			MouseUp = 0,
+			MouseDown,
+			MouseMove,
+			MouseWheel
+		};
+
+		enum class SpatialInputEventType : int {
+			Pressed = 0,
+			Released,
+			Lost,
+			Detected,
+			Update
+		};
+
+	}
+}

--- a/HoloJS/HoloJsHost/KeyboardInput.h
+++ b/HoloJS/HoloJsHost/KeyboardInput.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "InputInterface.h"
 namespace HologramJS
 {
 	namespace Input
@@ -9,19 +10,14 @@ namespace HologramJS
 			KeyboardInput();
 			~KeyboardInput();
 
-			void KeyUp(Windows::UI::Core::KeyEventArgs ^args);
-			void KeyDown(Windows::UI::Core::KeyEventArgs ^args);
-
 			void SetScriptCallback(JsValueRef scriptCallback) { m_scriptCallback = scriptCallback; }
 
 		private:
 			JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
 
-			bool CreateScriptParametersListForKeyboard(
-				const std::wstring& eventName,
-				const std::wstring& actionType,
-				Windows::UI::Core::KeyEventArgs^ args,
-				JsValueRef (&outParams)[4]
+			void CallbackScriptForKeyboardInput(
+				KeyboardInputEventType type,
+				Windows::UI::Core::KeyEventArgs^ args
 			);
 
 			Windows::Foundation::EventRegistrationToken m_keyDownToken;

--- a/HoloJS/HoloJsHost/MouseInput.h
+++ b/HoloJS/HoloJsHost/MouseInput.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "InputInterface.h"
 
 namespace HologramJS
 {
@@ -15,18 +16,10 @@ namespace HologramJS
 		private:
 			JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
 
-			bool CreateScriptParametersListForMouse(
-				const std::wstring& eventName,
-				const std::wstring& actionType,
-				Windows::UI::Core::PointerEventArgs^ args,
-				JsValueRef (&outParams)[6]
+			void CallbackScriptForMouseInput(
+				MouseInputEventType type,
+				Windows::UI::Core::PointerEventArgs^ args
 			);
-
-
-			void MouseDown(Windows::UI::Core::PointerEventArgs^ args);
-			void MouseUp(Windows::UI::Core::PointerEventArgs^ args);
-			void MouseMove(Windows::UI::Core::PointerEventArgs^ args);
-			void MouseWheel(Windows::UI::Core::PointerEventArgs^ args);
 
 			Windows::Foundation::EventRegistrationToken m_mouseDownToken;
 			Windows::Foundation::EventRegistrationToken m_mouseUpToken;

--- a/HoloJS/HoloJsHost/ScriptingFramework/Window.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/Window.js
@@ -13,6 +13,21 @@
         window.drawCallback = callback;
     };
 
+    // Mapping of type ids to strings;
+    // JavaScript side registers events by string but the native side sends events with a numeric type for performance reasons
+    window.nativeEvents = {};
+    window.nativeEvents.spatialInputEvents = ["sourcepress", "sourcerelease", "sourcelost", "sourcedetected", "sourceupdate"];
+    window.nativeEvents.keyboardEvents = ["keydown", "keyup"];
+    window.nativeEvents.mouseEvents = ["mouseup", "mousedown", "mousemove", "mousewheel"];
+
+    window.nativeEvents.events = ["resize", "mouse", "keyboard", "spatialinput"];
+    window.nativeEvents.resize = 0;
+    window.nativeEvents.mouse = 1;
+    window.nativeEvents.keyboard = 2;
+    window.nativeEvents.spatialinput = 3;
+
+    window.nativeEvents.spatialinput = 3;
+
     function onMouseEvent(x, y, button, action) {
         if (!document.canvas) {
             return;
@@ -37,11 +52,11 @@
         mouseEvent.preventDefault = function () { };
         mouseEvent.srcElement = document.canvas;
 
-        document.canvas.fireHandlersByType(action, mouseEvent);
-        document.fireHandlersByType(action, mouseEvent);
+        document.canvas.fireHandlersByType(window.nativeEvents.mouseEvents[action], mouseEvent);
+        document.fireHandlersByType(window.nativeEvents.mouseEvents[action], mouseEvent);
     }
 
-    function onSpatialInputEvent(x, y, z, isPressed, kind) {
+    function onSpatialInputEvent(x, y, z, isPressed, sourceKind, eventType) {
         var spatialInputEvent = {};
 
         spatialInputEvent.isPressed = isPressed;
@@ -49,9 +64,9 @@
 
         spatialInputEvent.preventDefault = function () { };
         spatialInputEvent.srcElement = document.canvas;
-        spatialInputEvent.kind = kind;
+        spatialInputEvent.sourceKind = sourceKind;
 
-        document.canvas.fireHandlersByType("spatialinput", spatialInputEvent);
+        document.canvas.fireHandlersByType(window.nativeEvents.spatialInputEvents[eventType], spatialInputEvent);
     }
 
     function onKeyboardEvent(event) {
@@ -90,14 +105,14 @@
             if (capturedCallback !== null) {
                 capturedCallback();
             }
-        } else if (type === "resize") {
-            window.fireHandlersByType(type);
-        } else if (type === "mouse") {
+        } else if (type === window.nativeEvents.resize) {
+            window.fireHandlersByType(window.nativeEvents.events[type]);
+        } else if (type === window.nativeEvents.mouse) {
             onMouseEvent(arguments[1], arguments[2], arguments[3], arguments[4]);
-        } else if (type === "keyboard") {
+        } else if (type === window.nativeEvents.keyboard) {
             onKeyboardEvent(arguments[1], arguments[2]);
-        } else if (type === "spatialinput") {
-            onSpatialInputEvent(arguments[1], arguments[2], arguments[3], arguments[4], arguments[5])
+        } else if (type === window.nativeEvents.spatialinput) {
+            onSpatialInputEvent(arguments[1], arguments[2], arguments[3], arguments[4], arguments[5], arguments[6])
         }
         else {
             window.fireHandlersByType(type);

--- a/HoloJS/HoloJsHost/ScriptingFramework/Window.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/Window.js
@@ -41,6 +41,19 @@
         document.fireHandlersByType(action, mouseEvent);
     }
 
+    function onSpatialInputEvent(x, y, z, isPressed, kind) {
+        var spatialInputEvent = {};
+
+        spatialInputEvent.isPressed = isPressed;
+        spatialInputEvent.location = { x: x, y: y, z: z };
+
+        spatialInputEvent.preventDefault = function () { };
+        spatialInputEvent.srcElement = document.canvas;
+        spatialInputEvent.kind = kind;
+
+        document.canvas.fireHandlersByType("spatialinput", spatialInputEvent);
+    }
+
     function onKeyboardEvent(event) {
     }
 
@@ -83,6 +96,8 @@
             onMouseEvent(arguments[1], arguments[2], arguments[3], arguments[4]);
         } else if (type === "keyboard") {
             onKeyboardEvent(arguments[1], arguments[2]);
+        } else if (type === "spatialinput") {
+            onSpatialInputEvent(arguments[1], arguments[2], arguments[3], arguments[4], arguments[5])
         }
         else {
             window.fireHandlersByType(type);

--- a/HoloJS/HoloJsHost/SpatialInput.cpp
+++ b/HoloJS/HoloJsHost/SpatialInput.cpp
@@ -14,17 +14,35 @@ SpatialInput::SpatialInput()
 		return;
 	}
 
-	m_eventHandler = ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
+	m_sourcePressedToken = SpatialInteractionManager::GetForCurrentView()->SourcePressed += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
 		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
 	{
-		this->CallbackScriptForSpatialInput(args);
+		CallbackScriptForSpatialInput(SpatialInputEventType::Pressed, args);
 	});
 
-	m_sourcePressedToken = SpatialInteractionManager::GetForCurrentView()->SourcePressed += m_eventHandler;
-	m_sourceReleasedToken = SpatialInteractionManager::GetForCurrentView()->SourceReleased += m_eventHandler;
-	m_sourceDetectedToken = SpatialInteractionManager::GetForCurrentView()->SourceDetected += m_eventHandler;
-	m_sourceLostToken = SpatialInteractionManager::GetForCurrentView()->SourceLost += m_eventHandler;
-	m_sourceUpdateToken = SpatialInteractionManager::GetForCurrentView()->SourceUpdated += m_eventHandler;
+	m_sourceReleasedToken = SpatialInteractionManager::GetForCurrentView()->SourceReleased += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
+		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
+	{
+		CallbackScriptForSpatialInput(SpatialInputEventType::Released, args);
+	});
+
+	m_sourceDetectedToken = SpatialInteractionManager::GetForCurrentView()->SourceDetected += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
+		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
+	{
+		CallbackScriptForSpatialInput(SpatialInputEventType::Detected, args);
+	});
+
+	m_sourceLostToken = SpatialInteractionManager::GetForCurrentView()->SourceLost += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
+		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
+	{
+		CallbackScriptForSpatialInput(SpatialInputEventType::Lost, args);
+	});
+
+	m_sourceUpdateToken = SpatialInteractionManager::GetForCurrentView()->SourceUpdated += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
+		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
+	{
+		CallbackScriptForSpatialInput(SpatialInputEventType::Update, args);
+	});
 
 	m_spatialInputAvailable = true;
 }
@@ -40,33 +58,33 @@ SpatialInput::~SpatialInput()
 }
 
 void
-SpatialInput::CallbackScriptForSpatialInput(Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs^ args)
+SpatialInput::CallbackScriptForSpatialInput(SpatialInputEventType type, Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs^ args)
 {
-	static std::wstring eventName(L"spatialinput");
-
 	EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
 	EXIT_IF_FALSE(m_spatialInputAvailable);
 
-	JsValueRef parameters[7];
+	JsValueRef parameters[8];
 	parameters[0] = m_scriptCallback;
-	JsValueRef* eventNameParam = &parameters[1];
+	JsValueRef* eventTypeParam = &parameters[1];
 	JsValueRef* xParam = &parameters[2];
 	JsValueRef* yParam = &parameters[3];
 	JsValueRef* zParam = &parameters[4];
 	JsValueRef* isPressedParam = &parameters[5];
-	JsValueRef* kindParam = &parameters[6];
+	JsValueRef* sourceKindParam = &parameters[6];
+	JsValueRef* spatialInputTypeParam = &parameters[7];
 
 	const auto location = args->State->Properties->TryGetLocation(m_frameOfReference->CoordinateSystem);
 	const float x = location ? location->Position->Value.x : 0;
 	const float y = location ? location->Position->Value.y : 0;
 	const float z = location ? location->Position->Value.z : 0;
 
-	EXIT_IF_JS_ERROR(JsPointerToString(eventName.c_str(), eventName.length(), eventNameParam));
+	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::SpatialInput), eventTypeParam));
 	EXIT_IF_JS_ERROR(JsDoubleToNumber(x, xParam));
 	EXIT_IF_JS_ERROR(JsDoubleToNumber(y, yParam));
 	EXIT_IF_JS_ERROR(JsDoubleToNumber(z, zParam));
 	EXIT_IF_JS_ERROR(JsBoolToBoolean(args->State->IsPressed, isPressedParam));
-	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(args->State->Source->Kind), kindParam));
+	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(args->State->Source->Kind), sourceKindParam));
+	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(type), spatialInputTypeParam));
 
 	JsValueRef result;
 	EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));

--- a/HoloJS/HoloJsHost/SpatialInput.cpp
+++ b/HoloJS/HoloJsHost/SpatialInput.cpp
@@ -1,0 +1,73 @@
+#include "pch.h"
+#include "SpatialInput.h"
+
+using namespace HologramJS::Input;
+using namespace Windows::UI::Input::Spatial;
+using namespace Windows::Foundation;
+using namespace std;
+using namespace Windows::Perception::Spatial;
+
+SpatialInput::SpatialInput()
+{
+	if (!SpatialInteractionManager::GetForCurrentView())
+	{
+		return;
+	}
+
+	m_eventHandler = ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
+		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
+	{
+		this->CallbackScriptForSpatialInput(args);
+	});
+
+	m_sourcePressedToken = SpatialInteractionManager::GetForCurrentView()->SourcePressed += m_eventHandler;
+	m_sourceReleasedToken = SpatialInteractionManager::GetForCurrentView()->SourceReleased += m_eventHandler;
+	m_sourceDetectedToken = SpatialInteractionManager::GetForCurrentView()->SourceDetected += m_eventHandler;
+	m_sourceLostToken = SpatialInteractionManager::GetForCurrentView()->SourceLost += m_eventHandler;
+	m_sourceUpdateToken = SpatialInteractionManager::GetForCurrentView()->SourceUpdated += m_eventHandler;
+
+	m_spatialInputAvailable = true;
+}
+
+SpatialInput::~SpatialInput()
+{
+	SpatialInteractionManager::GetForCurrentView()->SourceReleased -= m_sourceReleasedToken;
+	SpatialInteractionManager::GetForCurrentView()->SourcePressed -= m_sourcePressedToken;
+	SpatialInteractionManager::GetForCurrentView()->SourceDetected -= m_sourceDetectedToken;
+	SpatialInteractionManager::GetForCurrentView()->SourceLost -= m_sourceLostToken;
+	SpatialInteractionManager::GetForCurrentView()->SourceUpdated -= m_sourceUpdateToken;
+
+}
+
+void
+SpatialInput::CallbackScriptForSpatialInput(Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs^ args)
+{
+	static std::wstring eventName(L"spatialinput");
+
+	EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
+	EXIT_IF_FALSE(m_spatialInputAvailable);
+
+	JsValueRef parameters[7];
+	parameters[0] = m_scriptCallback;
+	JsValueRef* eventNameParam = &parameters[1];
+	JsValueRef* xParam = &parameters[2];
+	JsValueRef* yParam = &parameters[3];
+	JsValueRef* zParam = &parameters[4];
+	JsValueRef* isPressedParam = &parameters[5];
+	JsValueRef* kindParam = &parameters[6];
+
+	const auto location = args->State->Properties->TryGetLocation(m_frameOfReference->CoordinateSystem);
+	const float x = location ? location->Position->Value.x : 0;
+	const float y = location ? location->Position->Value.y : 0;
+	const float z = location ? location->Position->Value.z : 0;
+
+	EXIT_IF_JS_ERROR(JsPointerToString(eventName.c_str(), eventName.length(), eventNameParam));
+	EXIT_IF_JS_ERROR(JsDoubleToNumber(x, xParam));
+	EXIT_IF_JS_ERROR(JsDoubleToNumber(y, yParam));
+	EXIT_IF_JS_ERROR(JsDoubleToNumber(z, zParam));
+	EXIT_IF_JS_ERROR(JsBoolToBoolean(args->State->IsPressed, isPressedParam));
+	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(args->State->Source->Kind), kindParam));
+
+	JsValueRef result;
+	EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
+}

--- a/HoloJS/HoloJsHost/SpatialInput.h
+++ b/HoloJS/HoloJsHost/SpatialInput.h
@@ -1,4 +1,6 @@
 #pragma once
+#include "InputInterface.h"
+
 namespace HologramJS
 {
 	namespace Input
@@ -27,9 +29,7 @@ namespace HologramJS
 
 			bool m_spatialInputAvailable = false;
 
-			Windows::Foundation::TypedEventHandler<Windows::UI::Input::Spatial::SpatialInteractionManager ^, Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs ^>^ m_eventHandler;
-
-			void CallbackScriptForSpatialInput(Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs^ args);
+			void CallbackScriptForSpatialInput(SpatialInputEventType type, Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs^ args);
 
 			JsValueRef m_spatialInputEventName;
 			JsValueRef m_spatialInputSourcePressedName;

--- a/HoloJS/HoloJsHost/SpatialInput.h
+++ b/HoloJS/HoloJsHost/SpatialInput.h
@@ -1,0 +1,42 @@
+#pragma once
+namespace HologramJS
+{
+	namespace Input
+	{
+		class SpatialInput
+		{
+		public:
+			SpatialInput();
+			~SpatialInput();
+
+			void SetScriptCallback(JsValueRef scriptCallback) { m_scriptCallback = scriptCallback; }
+
+			void SetStationaryFrameOfReference(Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ frameOfReference)
+			{
+				m_frameOfReference = frameOfReference;
+			}
+
+		private:
+			JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
+
+			Windows::Foundation::EventRegistrationToken m_sourcePressedToken;
+			Windows::Foundation::EventRegistrationToken m_sourceReleasedToken;
+			Windows::Foundation::EventRegistrationToken m_sourceLostToken;
+			Windows::Foundation::EventRegistrationToken m_sourceDetectedToken;
+			Windows::Foundation::EventRegistrationToken m_sourceUpdateToken;
+
+			bool m_spatialInputAvailable = false;
+
+			Windows::Foundation::TypedEventHandler<Windows::UI::Input::Spatial::SpatialInteractionManager ^, Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs ^>^ m_eventHandler;
+
+			void CallbackScriptForSpatialInput(Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs^ args);
+
+			JsValueRef m_spatialInputEventName;
+			JsValueRef m_spatialInputSourcePressedName;
+			JsValueRef m_spatialInputSourceReleasedName;
+
+			Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ m_frameOfReference;
+		};
+	}
+}
+

--- a/HoloJS/HoloJsHost/WindowElement.cpp
+++ b/HoloJS/HoloJsHost/WindowElement.cpp
@@ -2,9 +2,11 @@
 #include "WindowElement.h"
 
 #include <WindowsNumerics.h>
+#include "InputInterface.h"
 
 using namespace HologramJS::API;
 using namespace HologramJS::Utilities;
+using namespace HologramJS::Input;
 
 WindowElement::WindowElement()
 {
@@ -111,9 +113,9 @@ WindowElement::Resize(int width, int height)
 		{
 			std::vector<JsValueRef> parameters(2);
 			parameters[0] = m_callbackFunction;
-			JsValueRef* eventNameParam = &parameters[1];
+			JsValueRef* eventTypeParam = &parameters[1];
 
-			EXIT_IF_JS_ERROR(JsPointerToString(resizeEventName.c_str(), resizeEventName.length(), eventNameParam));
+			EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::Resize), eventTypeParam));
 
 			JsValueRef result;
 			EXIT_IF_JS_ERROR(JsCallFunction(m_callbackFunction, parameters.data(), (unsigned short)parameters.size(), &result));

--- a/HoloJS/HoloJsHost/WindowElement.cpp
+++ b/HoloJS/HoloJsHost/WindowElement.cpp
@@ -67,6 +67,7 @@ WindowElement::setCallback(
 
 	m_keyboardInput.SetScriptCallback(callback);
 	m_mouseInput.SetScriptCallback(callback);
+	m_spatialInput.SetScriptCallback(callback);
 
 	return JS_INVALID_REFERENCE;
 }

--- a/HoloJS/HoloJsHost/WindowElement.h
+++ b/HoloJS/HoloJsHost/WindowElement.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "SpatialInput.h"
+#include "MouseInput.h"
+#include "KeyboardInput.h"
+
 namespace HologramJS
 {
 	namespace API
@@ -23,12 +27,18 @@ namespace HologramJS
 
 			void SetBaseUrl(const std::wstring& baseUrl) { m_baseUrl.assign(baseUrl); }
 
+			void SetStationaryFrameOfReference(Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ frameOfReference)
+			{
+				m_spatialInput.SetStationaryFrameOfReference(frameOfReference);
+			}
+
 		private:
 
 			std::wstring m_baseUrl;
 
 			Input::KeyboardInput m_keyboardInput;
 			Input::MouseInput m_mouseInput;
+			Input::SpatialInput m_spatialInput;
 
 			int m_width;
 			int m_height;
@@ -112,6 +122,5 @@ namespace HologramJS
 
 			bool CreateViewMatrixStorageAndScriptProjection();
 		};
-
 	}
 }

--- a/HoloJS/HoloJsHost/pch.h
+++ b/HoloJS/HoloJsHost/pch.h
@@ -74,6 +74,3 @@ void Log(PCSTR file, int line);
 #include <windows.storage.streams.h>
 #include <wrl/implements.h>
 #include "IBufferOnMemory.h"
-
-#include "MouseInput.h"
-#include "KeyboardInput.h"

--- a/HoloJS/SampleApp/App.cpp
+++ b/HoloJS/SampleApp/App.cpp
@@ -115,7 +115,7 @@ void App::LoadAndExecuteScript()
 
 	if (mHolographicSpace != nullptr)
 	{
-		m_holoScriptHost->EnableHolographicExperimental();
+		m_holoScriptHost->EnableHolographicExperimental(mStationaryReferenceFrame);
 	}
 
 	eglQuerySurface(mEglDisplay, mEglSurface, EGL_WIDTH, &mPanelWidth);

--- a/HoloJS/SampleApp/Scripts/app.js
+++ b/HoloJS/SampleApp/Scripts/app.js
@@ -43,6 +43,8 @@ var projectionMatrix;
 var viewMatrix;
 var modelMatrix;
 
+var cubeX, cubeY, cubeZ;
+
 //
 // start
 //
@@ -86,17 +88,52 @@ function start() {
 
         initTextures();
 
+        cubeX = cubeY = 0;
+        cubeZ = -1.5;
+
         // Set up a simple translation transform for the cube
         modelMatrix = new Float32Array([
             1.0, 0.0, 0.0, 0.0,
             0.0, 1.0, 0.0, 0.0,
             0.0, 0.0, 1.0, 0.0,
-           -0.0, 0.0, -1.5, 1.0
+            cubeX, cubeY, cubeZ, 1.0
         ]);
 
         // Set up to draw the scene periodically.
 
         window.requestAnimationFrame(drawScene);
+
+        canvas.addEventListener("spatialinput", onSpatialInput);
+    }
+}
+
+var spatialInputTracking = false;
+var lastSpatialInputX = 0;
+var lastSpatialInputY = 0;
+var lastSpatialInputZ = 0;
+
+function onSpatialInput(spatialInputEvent) {
+    if (spatialInputEvent.isPressed === true) {
+        if (spatialInputTracking === true) {
+            cubeX = cubeX + (lastSpatialInputX - spatialInputEvent.location.x);
+            cubeY = cubeY + (lastSpatialInputY - spatialInputEvent.location.y);
+            cubeZ = cubeZ + (lastSpatialInputZ - spatialInputEvent.location.z);
+
+            modelMatrix = new Float32Array([
+                1.0, 0.0, 0.0, 0.0,
+                0.0, 1.0, 0.0, 0.0,
+                0.0, 0.0, 1.0, 0.0,
+                cubeX, -cubeY, cubeZ, 1.0
+            ]);
+        } else {
+            spatialInputTracking = true;
+        }
+
+        lastSpatialInputX = spatialInputEvent.location.x;
+        lastSpatialInputY = spatialInputEvent.location.y;
+        lastSpatialInputZ = spatialInputEvent.location.z;
+    } else {
+        spatialInputTracking = false;
     }
 }
 

--- a/HoloJS/SampleApp/Scripts/app.js
+++ b/HoloJS/SampleApp/Scripts/app.js
@@ -103,6 +103,7 @@ function start() {
 
         window.requestAnimationFrame(drawScene);
 
+        // add event listener for spatial input (hands)
         canvas.addEventListener("spatialinput", onSpatialInput);
     }
 }
@@ -115,20 +116,20 @@ var lastSpatialInputZ = 0;
 function onSpatialInput(spatialInputEvent) {
     if (spatialInputEvent.isPressed === true) {
         if (spatialInputTracking === true) {
+            // Compute new cube position based on hand delta movement
             cubeX = cubeX + (lastSpatialInputX - spatialInputEvent.location.x);
             cubeY = cubeY + (lastSpatialInputY - spatialInputEvent.location.y);
             cubeZ = cubeZ + (lastSpatialInputZ - spatialInputEvent.location.z);
 
-            modelMatrix = new Float32Array([
-                1.0, 0.0, 0.0, 0.0,
-                0.0, 1.0, 0.0, 0.0,
-                0.0, 0.0, 1.0, 0.0,
-                cubeX, -cubeY, cubeZ, 1.0
-            ]);
+            // Move the cube around to follow hand movement
+            modelMatrix[12] = cubeX;
+            modelMatrix[13] = -cubeY;
+            modelMatrix[14] = cubeZ;
         } else {
             spatialInputTracking = true;
         }
 
+        // Remember last hand position
         lastSpatialInputX = spatialInputEvent.location.x;
         lastSpatialInputY = spatialInputEvent.location.y;
         lastSpatialInputZ = spatialInputEvent.location.z;

--- a/HoloJS/SampleApp/Scripts/app.js
+++ b/HoloJS/SampleApp/Scripts/app.js
@@ -104,7 +104,11 @@ function start() {
         window.requestAnimationFrame(drawScene);
 
         // add event listener for spatial input (hands)
-        canvas.addEventListener("spatialinput", onSpatialInput);
+        canvas.addEventListener("sourcepress", onSpatialSourcePress);
+        canvas.addEventListener("sourcerelease", onSpatialSourceRelease);
+        canvas.addEventListener("sourceupdate", onSpatialSourceUpdate);
+        // treat source lost the same way as source release - stop moving the cube when hands input is lost
+        canvas.addEventListener("sourcelost", onSpatialSourceRelease);
     }
 }
 
@@ -113,28 +117,35 @@ var lastSpatialInputX = 0;
 var lastSpatialInputY = 0;
 var lastSpatialInputZ = 0;
 
-function onSpatialInput(spatialInputEvent) {
-    if (spatialInputEvent.isPressed === true) {
-        if (spatialInputTracking === true) {
-            // Compute new cube position based on hand delta movement
-            cubeX = cubeX + (lastSpatialInputX - spatialInputEvent.location.x);
-            cubeY = cubeY + (lastSpatialInputY - spatialInputEvent.location.y);
-            cubeZ = cubeZ + (lastSpatialInputZ - spatialInputEvent.location.z);
+function onSpatialSourcePress(spatialInputEvent) {
+    // Remember last hand position
+    lastSpatialInputX = spatialInputEvent.location.x;
+    lastSpatialInputY = spatialInputEvent.location.y;
+    lastSpatialInputZ = spatialInputEvent.location.z;
 
-            // Move the cube around to follow hand movement
-            modelMatrix[12] = cubeX;
-            modelMatrix[13] = -cubeY;
-            modelMatrix[14] = cubeZ;
-        } else {
-            spatialInputTracking = true;
-        }
+    spatialInputTracking = true;
+}
+
+function onSpatialSourceRelease(spatialInputEvent) {
+    spatialInputTracking = false;
+}
+
+function onSpatialSourceUpdate(spatialInputEvent) {
+    if (spatialInputTracking === true) {
+        // Compute new cube position based on hand delta movement
+        cubeX = cubeX + (lastSpatialInputX - spatialInputEvent.location.x);
+        cubeY = cubeY + (lastSpatialInputY - spatialInputEvent.location.y);
+        cubeZ = cubeZ + (lastSpatialInputZ - spatialInputEvent.location.z);
+
+        // Move the cube around to follow hand movement
+        modelMatrix[12] = cubeX;
+        modelMatrix[13] = -cubeY;
+        modelMatrix[14] = cubeZ;
 
         // Remember last hand position
         lastSpatialInputX = spatialInputEvent.location.x;
         lastSpatialInputY = spatialInputEvent.location.y;
         lastSpatialInputZ = spatialInputEvent.location.z;
-    } else {
-        spatialInputTracking = false;
     }
 }
 

--- a/HoloJS/ThreeJSApp/App.cpp
+++ b/HoloJS/ThreeJSApp/App.cpp
@@ -115,7 +115,7 @@ void App::LoadAndExecuteScript()
 
 	if (mHolographicSpace != nullptr)
 	{
-		m_holoScriptHost->EnableHolographicExperimental();
+		m_holoScriptHost->EnableHolographicExperimental(mStationaryReferenceFrame);
 	}
 
 	eglQuerySurface(mEglDisplay, mEglSurface, EGL_WIDTH, &mPanelWidth);

--- a/HoloJS/ThreeJSApp/Scripts/app.js
+++ b/HoloJS/ThreeJSApp/Scripts/app.js
@@ -107,7 +107,6 @@ function update (delta, elapsed) {
     window.requestAnimationFrame(() => update(clock.getDelta(), clock.getElapsedTime()));
 
     pointLight.position.set(0 + 2.0 * Math.cos(elapsed * 0.5), 0, -1.5 + 2.0 * Math.sin(elapsed * 0.5));
-    cube.rotation.y += 0.01;
     sphere.scale.x = sphere.scale.y = sphere.scale.z = Math.abs(Math.cos(elapsed * 0.3)) * 0.6 + 1.0;
     cone.position.y = Math.sin(elapsed * 0.5) * 0.1;
     torus.position.z = -2 - Math.abs(Math.cos(elapsed * 0.2));
@@ -133,4 +132,21 @@ function update (delta, elapsed) {
 
 function start () {
     update(clock.getDelta(), clock.getElapsedTime());
+}
+
+let lastSpatialInputX = 0;
+let spatialInputTracking = false;
+canvas.addEventListener("spatialinput", onSpatialInput);
+function onSpatialInput(spatialInputEvent) {
+    if (spatialInputEvent.isPressed === true) {
+        if (spatialInputTracking === true) {
+            cube.rotation.y += (lastSpatialInputX - spatialInputEvent.location.x);
+        } else {
+            spatialInputTracking = true;
+        }
+
+        lastSpatialInputX = spatialInputEvent.location.x;
+    } else {
+        spatialInputTracking = false;
+    }
 }

--- a/HoloJS/ThreeJSApp/Scripts/app.js
+++ b/HoloJS/ThreeJSApp/Scripts/app.js
@@ -134,12 +134,15 @@ function start () {
     update(clock.getDelta(), clock.getElapsedTime());
 }
 
+// Listen to spatial input events
+canvas.addEventListener("spatialinput", onSpatialInput);
+
 let lastSpatialInputX = 0;
 let spatialInputTracking = false;
-canvas.addEventListener("spatialinput", onSpatialInput);
 function onSpatialInput(spatialInputEvent) {
     if (spatialInputEvent.isPressed === true) {
         if (spatialInputTracking === true) {
+            // rotate the cube proportional to hand movement on X axis
             cube.rotation.y += (lastSpatialInputX - spatialInputEvent.location.x);
         } else {
             spatialInputTracking = true;

--- a/HoloJS/ThreeJSApp/Scripts/app.js
+++ b/HoloJS/ThreeJSApp/Scripts/app.js
@@ -134,22 +134,29 @@ function start () {
     update(clock.getDelta(), clock.getElapsedTime());
 }
 
-// Listen to spatial input events
-canvas.addEventListener("spatialinput", onSpatialInput);
+// Listen to spatial input events (hands)
+canvas.addEventListener("sourcepress", onSpatialSourcePress);
+canvas.addEventListener("sourcerelease", onSpatialSourceRelease);
+canvas.addEventListener("sourceupdate", onSpatialSourceUpdate);
+// treat source lost the same way as source release - stop moving the cube when hands input is lost
+canvas.addEventListener("sourcelost", onSpatialSourceRelease);
 
 let lastSpatialInputX = 0;
 let spatialInputTracking = false;
-function onSpatialInput(spatialInputEvent) {
-    if (spatialInputEvent.isPressed === true) {
-        if (spatialInputTracking === true) {
-            // rotate the cube proportional to hand movement on X axis
-            cube.rotation.y += (lastSpatialInputX - spatialInputEvent.location.x);
-        } else {
-            spatialInputTracking = true;
-        }
 
+function onSpatialSourcePress(spatialInputEvent) {
+    lastSpatialInputX = spatialInputEvent.location.x;
+    spatialInputTracking = true;
+}
+
+function onSpatialSourceRelease(spatialInputEvent) {
+    spatialInputTracking = false;
+}
+
+function onSpatialSourceUpdate(spatialInputEvent) {
+    if (spatialInputTracking === true) {
+        // rotate the cube proportional to hand movement on X axis
+        cube.rotation.y += (lastSpatialInputX - spatialInputEvent.location.x);
         lastSpatialInputX = spatialInputEvent.location.x;
-    } else {
-        spatialInputTracking = false;
     }
 }


### PR DESCRIPTION
Make spatial input available to JavaScript.

Registering for spatial input is done through <canvas_element>.addEventListener("spatialinput", ...)

The event callback get a spatialInputEvent parameter containing:
- isPressed bool property
- location property: {x, y, z}
- kind property: controller, hand, voice, other. See [https://docs.microsoft.com/en-us/uwp/api/windows.ui.input.spatial.spatialinteractionsourcekind] for details

The input coordinates are relative to the original stationary frame of reference - the origin of the scene.