### PR TITLE
Explicitly execute spatial input callbacks on the JS thread

### DIFF
--- a/HoloJS/HoloJsHost/SpatialInput.cpp
+++ b/HoloJS/HoloJsHost/SpatialInput.cpp
@@ -18,31 +18,31 @@ SpatialInput::SpatialInput()
 		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
 	{
 		CallbackScriptForSpatialInput(SpatialInputEventType::Pressed, args);
-	});
+	}, Platform::CallbackContext::Same);
 
 	m_sourceReleasedToken = SpatialInteractionManager::GetForCurrentView()->SourceReleased += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
 		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
 	{
 		CallbackScriptForSpatialInput(SpatialInputEventType::Released, args);
-	});
+	}, Platform::CallbackContext::Same);
 
 	m_sourceDetectedToken = SpatialInteractionManager::GetForCurrentView()->SourceDetected += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
 		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
 	{
 		CallbackScriptForSpatialInput(SpatialInputEventType::Detected, args);
-	});
+	}, Platform::CallbackContext::Same);
 
 	m_sourceLostToken = SpatialInteractionManager::GetForCurrentView()->SourceLost += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
 		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
 	{
 		CallbackScriptForSpatialInput(SpatialInputEventType::Lost, args);
-	});
+	}, Platform::CallbackContext::Same);
 
 	m_sourceUpdateToken = SpatialInteractionManager::GetForCurrentView()->SourceUpdated += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
 		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
 	{
 		CallbackScriptForSpatialInput(SpatialInputEventType::Update, args);
-	});
+	}, Platform::CallbackContext::Same);
 
 	m_spatialInputAvailable = true;
 }

--- a/HoloJS/HoloJsHost/SpatialInput.cpp
+++ b/HoloJS/HoloJsHost/SpatialInput.cpp
@@ -17,32 +17,32 @@ SpatialInput::SpatialInput()
 	m_sourcePressedToken = SpatialInteractionManager::GetForCurrentView()->SourcePressed += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
 		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
 	{
-		CallbackScriptForSpatialInput(SpatialInputEventType::Pressed, args);
-	}, Platform::CallbackContext::Same);
+		QueueEventOrFireCallback(SpatialInputEventType::Pressed, args);
+	});
 
 	m_sourceReleasedToken = SpatialInteractionManager::GetForCurrentView()->SourceReleased += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
 		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
 	{
-		CallbackScriptForSpatialInput(SpatialInputEventType::Released, args);
-	}, Platform::CallbackContext::Same);
+		QueueEventOrFireCallback(SpatialInputEventType::Released, args);
+	});
 
 	m_sourceDetectedToken = SpatialInteractionManager::GetForCurrentView()->SourceDetected += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
 		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
 	{
-		CallbackScriptForSpatialInput(SpatialInputEventType::Detected, args);
-	}, Platform::CallbackContext::Same);
+		QueueEventOrFireCallback(SpatialInputEventType::Detected, args);
+	});
 
 	m_sourceLostToken = SpatialInteractionManager::GetForCurrentView()->SourceLost += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
 		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
 	{
-		CallbackScriptForSpatialInput(SpatialInputEventType::Lost, args);
-	}, Platform::CallbackContext::Same);
+		QueueEventOrFireCallback(SpatialInputEventType::Lost, args);
+	});
 
 	m_sourceUpdateToken = SpatialInteractionManager::GetForCurrentView()->SourceUpdated += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
 		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
 	{
-		CallbackScriptForSpatialInput(SpatialInputEventType::Update, args);
-	}, Platform::CallbackContext::Same);
+		QueueEventOrFireCallback(SpatialInputEventType::Update, args);
+	});
 
 	m_spatialInputAvailable = true;
 }
@@ -58,7 +58,57 @@ SpatialInput::~SpatialInput()
 }
 
 void
-SpatialInput::CallbackScriptForSpatialInput(SpatialInputEventType type, Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs^ args)
+SpatialInput::DrainQueuedSpatialInputEvents()
+{
+	// Quick check if there's something in the queue
+	// Technically there could be a race condition in checking the size outside of the lock
+	// but worst case scenario event1 will be delivered on the next vsync
+	if (m_queuedEvents.size() == 0)
+	{
+		return;
+	}
+
+	std::lock_guard<std::mutex> guard(m_eventsQueue);
+
+	for (const auto& eventData : m_queuedEvents)
+	{
+		CallbackScriptForSpatialInput(eventData);
+	}
+
+	m_queuedEvents.clear();
+}
+
+void
+SpatialInput::CallbackScriptForSpatialInput(const SpatialEventData& eventData)
+{
+
+	EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
+	EXIT_IF_FALSE(m_spatialInputAvailable);
+
+	JsValueRef parameters[8];
+	parameters[0] = m_scriptCallback;
+	JsValueRef* eventTypeParam = &parameters[1];
+	JsValueRef* xParam = &parameters[2];
+	JsValueRef* yParam = &parameters[3];
+	JsValueRef* zParam = &parameters[4];
+	JsValueRef* isPressedParam = &parameters[5];
+	JsValueRef* sourceKindParam = &parameters[6];
+	JsValueRef* spatialInputTypeParam = &parameters[7];
+
+	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::SpatialInput), eventTypeParam));
+	EXIT_IF_JS_ERROR(JsDoubleToNumber(eventData.position.x, xParam));
+	EXIT_IF_JS_ERROR(JsDoubleToNumber(eventData.position.y, yParam));
+	EXIT_IF_JS_ERROR(JsDoubleToNumber(eventData.position.z, zParam));
+	EXIT_IF_JS_ERROR(JsBoolToBoolean(eventData.isPressed, isPressedParam));
+	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(eventData.kind), sourceKindParam));
+	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(eventData.type), spatialInputTypeParam));
+
+	JsValueRef result;
+	EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
+}
+
+void
+SpatialInput::QueueEventOrFireCallback(SpatialInputEventType type, Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs^ args)
 {
 	EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
 	EXIT_IF_FALSE(m_spatialInputAvailable);
@@ -78,14 +128,28 @@ SpatialInput::CallbackScriptForSpatialInput(SpatialInputEventType type, Windows:
 	const float y = location ? location->Position->Value.y : 0;
 	const float z = location ? location->Position->Value.z : 0;
 
-	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::SpatialInput), eventTypeParam));
-	EXIT_IF_JS_ERROR(JsDoubleToNumber(x, xParam));
-	EXIT_IF_JS_ERROR(JsDoubleToNumber(y, yParam));
-	EXIT_IF_JS_ERROR(JsDoubleToNumber(z, zParam));
-	EXIT_IF_JS_ERROR(JsBoolToBoolean(args->State->IsPressed, isPressedParam));
-	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(args->State->Source->Kind), sourceKindParam));
-	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(type), spatialInputTypeParam));
+	JsContextRef currentContext = nullptr;
+	EXIT_IF_JS_ERROR(JsGetCurrentContext(&currentContext));
 
-	JsValueRef result;
-	EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
+	if (currentContext != nullptr)
+	{
+		// We are on the UI thread; prepare the parameters and fire the callback to the script guest
+		EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::SpatialInput), eventTypeParam));
+		EXIT_IF_JS_ERROR(JsDoubleToNumber(x, xParam));
+		EXIT_IF_JS_ERROR(JsDoubleToNumber(y, yParam));
+		EXIT_IF_JS_ERROR(JsDoubleToNumber(z, zParam));
+		EXIT_IF_JS_ERROR(JsBoolToBoolean(args->State->IsPressed, isPressedParam));
+		EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(args->State->Source->Kind), sourceKindParam));
+		EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(type), spatialInputTypeParam));
+
+		JsValueRef result;
+		EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
+	}
+	else
+	{
+		// We are not on the JS thread; queue the event and it will be picked up later
+		// by the message pump on the UI/JS thread.
+		std::lock_guard<std::mutex> guard(m_eventsQueue);
+		m_queuedEvents.emplace_back(SpatialEventData(args->State->Source->Kind, type, args->State->IsPressed, (location ? location->Position->Value : Windows::Foundation::Numerics::float3())));
+	}
 }

--- a/HoloJS/HoloJsHost/SpatialInput.h
+++ b/HoloJS/HoloJsHost/SpatialInput.h
@@ -18,6 +18,11 @@ namespace HologramJS
 				m_frameOfReference = frameOfReference;
 			}
 
+			// Called on the UI thread to drain all events that were queued on worker threads
+			// Remove this once RS1 is no longer supported; in RS2+ spatial input events are
+			// guaranteed to come on the UI thread
+			void DrainQueuedSpatialInputEvents();
+
 		private:
 			JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
 
@@ -29,13 +34,39 @@ namespace HologramJS
 
 			bool m_spatialInputAvailable = false;
 
-			void CallbackScriptForSpatialInput(SpatialInputEventType type, Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs^ args);
+			// Stores decoded information about a spatial event
+			struct SpatialEventData
+			{
+				Windows::UI::Input::Spatial::SpatialInteractionSourceKind kind;
+				SpatialInputEventType type;
+				bool isPressed;
+				Windows::Foundation::Numerics::float3 position;
+
+				SpatialEventData(Windows::UI::Input::Spatial::SpatialInteractionSourceKind kind, SpatialInputEventType type, bool isPressed, Windows::Foundation::Numerics::float3 position)
+				{
+					this->kind = kind;
+					this->type = type;
+					this->isPressed = isPressed;
+					this->position = position;
+				}
+			};
+
+			void CallbackScriptForSpatialInput(const SpatialEventData& eventData);
+			void QueueEventOrFireCallback(SpatialInputEventType type, Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs^ args);
 
 			JsValueRef m_spatialInputEventName;
 			JsValueRef m_spatialInputSourcePressedName;
 			JsValueRef m_spatialInputSourceReleasedName;
 
 			Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ m_frameOfReference;
+
+			// Lock to synchronize access to the queued events vector
+			std::mutex m_eventsQueue;
+
+			// List of events that were queued because they came on a non-UI thread;
+			// This list is drained on v-sync
+			std::vector<SpatialEventData> m_queuedEvents;
+
 		};
 	}
 }

--- a/HoloJS/HoloJsHost/WindowElement.cpp
+++ b/HoloJS/HoloJsHost/WindowElement.cpp
@@ -126,6 +126,10 @@ WindowElement::Resize(int width, int height)
 void
 WindowElement::VSync(Windows::Foundation::Numerics::float4x4 viewMatrix)
 {
+	// Workaround for RS1: spatial input events can be delivered on non-UI threads; in this case m_spatialInput
+	// queued events internally and since now we're on the UI thread we drain them
+	m_spatialInput.DrainQueuedSpatialInputEvents();
+
 	if (m_callbackFunction != JS_INVALID_REFERENCE)
 	{
 		if (m_viewMatrixStoragePointer != nullptr)


### PR DESCRIPTION
Explicitly request spatial input callbacks on the current thread at registration time.

In RS1, callbacks are delivered on random threads and the JS context is bound to the UI thread.
In RS2, callbacks are already delivered on the same thread as registration, so this change is a no-op.