### PR TITLE
Spatial mapping data is available to scripts

### DIFF
--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj
@@ -225,6 +225,7 @@
     <ClInclude Include="ScriptResourceTracker.h" />
     <ClInclude Include="ScriptsLoader.h" />
     <ClInclude Include="SpatialInput.h" />
+    <ClInclude Include="SpatialMapping.h" />
     <ClInclude Include="System.h" />
     <ClInclude Include="VideoElement.h" />
     <ClInclude Include="WebGLObjects.h" />
@@ -252,6 +253,7 @@
     <ClCompile Include="ScriptResourceTracker.cpp" />
     <ClCompile Include="ScriptsLoader.cpp" />
     <ClCompile Include="SpatialInput.cpp" />
+    <ClCompile Include="SpatialMapping.cpp" />
     <ClCompile Include="System.cpp" />
     <ClCompile Include="VideoElement.cpp" />
     <ClCompile Include="WebGLObjects.cpp" />

--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
@@ -47,6 +47,9 @@
     <ClCompile Include="SpatialInput.cpp">
       <Filter>NativeFramework</Filter>
     </ClCompile>
+    <ClCompile Include="SpatialMapping.cpp">
+      <Filter>NativeFramework</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="HologramJS.h" />
@@ -105,6 +108,9 @@
       <Filter>NativeFramework</Filter>
     </ClInclude>
     <ClInclude Include="InputInterface.h">
+      <Filter>NativeFramework</Filter>
+    </ClInclude>
+    <ClInclude Include="SpatialMapping.h">
       <Filter>NativeFramework</Filter>
     </ClInclude>
   </ItemGroup>

--- a/HoloJS/HoloJsHost/InputInterface.h
+++ b/HoloJS/HoloJsHost/InputInterface.h
@@ -10,7 +10,8 @@ namespace HologramJS
 			Resize = 0,
 			Mouse,
 			Keyboard,
-			SpatialInput
+			SpatialInput,
+			SpatialMapping
 		};
 
 		enum class KeyboardInputEventType : int {

--- a/HoloJS/HoloJsHost/ScriptingFramework/Window.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/Window.js
@@ -14,9 +14,22 @@
         window.drawCallback = callback;
     };
 
-    window.requestSpatialMappingData = function (callback) {
+    window.requestSpatialMappingData = function (callback, options) {
         window.addEventListener("spatialmapping", callback);
-        return nativeInterface.window.requestSpatialMappingData();
+        
+        var extentX, extentY, extentZ;
+        if (options && options.scanExtentMeters) {
+            extentX = options.scanExtentMeters.x;
+            extentY = options.scanExtentMeters.y;
+            extentZ = options.scanExtentMeters.z;
+        } else {
+            extentX = 10;
+            extentY = 5;
+            extentZ = 10;
+        }
+
+        var trianglesPerCubicMeter = (options && options.trianglesPerCubicMeter ? options.trianglesPerCubicMeter : 1000);
+        return nativeInterface.window.requestSpatialMappingData(extentX, extentY, extentZ, trianglesPerCubicMeter);
     };
 
     // Mapping of type ids to strings;

--- a/HoloJS/HoloJsHost/ScriptingFramework/Window.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/Window.js
@@ -14,7 +14,8 @@
         window.drawCallback = callback;
     };
 
-    window.requestSpatialMappingData = function () {
+    window.requestSpatialMappingData = function (callback) {
+        window.addEventListener("spatialmapping", callback);
         return nativeInterface.window.requestSpatialMappingData();
     };
 
@@ -74,7 +75,7 @@
     }
 
     function onSpatialMappingEvent(surfaceData) {
-        document.canvas.fireHandlersByType(window.nativeEvents.events[window.nativeEvents.spatialmapping], surfaceData);
+        window.fireHandlersByType(window.nativeEvents.events[window.nativeEvents.spatialmapping], surfaceData);
     }
 
     function onKeyboardEvent(event) {

--- a/HoloJS/HoloJsHost/ScriptingFramework/Window.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/Window.js
@@ -7,10 +7,15 @@
     }
     
     window.drawCallback = null;
+    window.spatialMappingCallback = null;
     window.location = new makeLocation(nativeInterface.window.getBaseUrl());
 
     window.requestAnimationFrame = function (callback) {
         window.drawCallback = callback;
+    };
+
+    window.requestSpatialMappingData = function () {
+        return nativeInterface.window.requestSpatialMappingData();
     };
 
     // Mapping of type ids to strings;
@@ -20,13 +25,12 @@
     window.nativeEvents.keyboardEvents = ["keydown", "keyup"];
     window.nativeEvents.mouseEvents = ["mouseup", "mousedown", "mousemove", "mousewheel"];
 
-    window.nativeEvents.events = ["resize", "mouse", "keyboard", "spatialinput"];
+    window.nativeEvents.events = ["resize", "mouse", "keyboard", "spatialinput", "spatialmapping"];
     window.nativeEvents.resize = 0;
     window.nativeEvents.mouse = 1;
     window.nativeEvents.keyboard = 2;
     window.nativeEvents.spatialinput = 3;
-
-    window.nativeEvents.spatialinput = 3;
+    window.nativeEvents.spatialmapping = 4;
 
     function onMouseEvent(x, y, button, action) {
         if (!document.canvas) {
@@ -67,6 +71,10 @@
         spatialInputEvent.sourceKind = sourceKind;
 
         document.canvas.fireHandlersByType(window.nativeEvents.spatialInputEvents[eventType], spatialInputEvent);
+    }
+
+    function onSpatialMappingEvent(surfaceData) {
+        document.canvas.fireHandlersByType(window.nativeEvents.events[window.nativeEvents.spatialmapping], surfaceData);
     }
 
     function onKeyboardEvent(event) {
@@ -113,6 +121,8 @@
             onKeyboardEvent(arguments[1], arguments[2]);
         } else if (type === window.nativeEvents.spatialinput) {
             onSpatialInputEvent(arguments[1], arguments[2], arguments[3], arguments[4], arguments[5], arguments[6])
+        } else if (type === window.nativeEvents.spatialmapping) {
+            onSpatialMappingEvent(arguments[1])
         }
         else {
             window.fireHandlersByType(type);

--- a/HoloJS/HoloJsHost/SpatialMapping.cpp
+++ b/HoloJS/HoloJsHost/SpatialMapping.cpp
@@ -197,6 +197,12 @@ SpatialMapping::ProcessSurface(
 		memcpy(typedArrayBuffer, GetPointerToData(mesh->VertexPositions->Data), mesh->VertexPositions->Data->Length);
 		EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObject, L"vertices", positionsArray));
 
+		// Add mesh ID
+		JsValueRef meshIdRef;
+		const auto meshGuidString = mesh->SurfaceInfo->Id.ToString();
+		EXIT_IF_JS_ERROR(JsPointerToString(meshGuidString->Data(), meshGuidString->Length(), &meshIdRef));
+		EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObject, L"id", meshIdRef));
+
 		// Create JS callback parameters
 		JsValueRef parameters[3];
 		parameters[0] = m_scriptCallback;

--- a/HoloJS/HoloJsHost/SpatialMapping.cpp
+++ b/HoloJS/HoloJsHost/SpatialMapping.cpp
@@ -1,0 +1,210 @@
+#include "pch.h"
+#include "SpatialMapping.h"
+#include <WindowsNumerics.h>
+#include <Robuffer.h>
+#include "InputInterface.h"
+#include <DirectXMath.h>
+
+using namespace HologramJS::Input;
+using namespace Windows::Perception::Spatial;
+using namespace concurrency;
+using namespace Windows::Perception::Spatial::Surfaces;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::Graphics::DirectX;
+using namespace HologramJS::Utilities;
+using namespace DirectX;
+
+SpatialMapping::SpatialMapping()
+{
+}
+
+
+SpatialMapping::~SpatialMapping()
+{
+}
+
+JsValueRef
+SpatialMapping::GetSpatialData()
+{
+	RETURN_INVALID_REF_IF_FALSE(m_surfaceAccessAllowed);
+	RETURN_INVALID_REF_IF_FALSE(CreateSurfaceObserver());
+
+	auto mapContainingSurfaceCollection = m_surfaceObserver->GetObservedSurfaces();
+
+	int counter = 0;
+	for (auto const& pair : mapContainingSurfaceCollection)
+	{
+		// Store the ID and metadata for each surface.
+		auto const& id = pair->Key;
+		auto const& surfaceInfo = pair->Value;
+		ProcessSurface(pair->Value);
+	}
+	
+	return JS_INVALID_REFERENCE;
+}
+
+void
+SpatialMapping::EnableSpatialMapping(SpatialStationaryFrameOfReference^ frameOfReference)
+{
+	m_frameOfReference = frameOfReference;
+
+	auto initSurfaceObserverTask = create_task(SpatialSurfaceObserver::RequestAccessAsync());
+	initSurfaceObserverTask.then([this](Windows::Perception::Spatial::SpatialPerceptionAccessStatus status)
+	{
+ 		switch (status)
+		{
+		case SpatialPerceptionAccessStatus::Allowed:
+			m_surfaceAccessAllowed = true;
+			break;
+		default:
+			// Access was denied. This usually happens because your AppX manifest file does not declare the
+			// spatialPerception capability.
+			// For info on what else can cause this, see: http://msdn.microsoft.com/library/windows/apps/mt621422.aspx
+			m_surfaceAccessAllowed = false;
+			break;
+		}
+	});
+}
+
+bool
+SpatialMapping::CreateSurfaceObserver()
+{
+	RETURN_IF_FALSE(m_surfaceAccessAllowed);
+
+	if (m_surfaceObserver != nullptr)
+	{
+		return true;
+	}
+
+	SpatialBoundingBox axisAlignedBoundingBox =
+	{
+		{ 0.f,  0.f, 0.f },
+		{ 20.f, 20.f, 5.f },
+	};
+	SpatialBoundingVolume^ bounds = SpatialBoundingVolume::FromBox(m_frameOfReference->CoordinateSystem, axisAlignedBoundingBox);
+		
+	m_surfaceMeshOptions = ref new SpatialSurfaceMeshOptions();
+	IVectorView<DirectXPixelFormat>^ supportedVertexPositionFormats = m_surfaceMeshOptions->SupportedVertexPositionFormats;
+	unsigned int formatIndex = 0;
+	if (supportedVertexPositionFormats->IndexOf(DirectXPixelFormat::R16G16B16A16IntNormalized, &formatIndex))
+	{
+		m_surfaceMeshOptions->VertexPositionFormat = DirectXPixelFormat::R16G16B16A16IntNormalized;
+	}
+
+	IVectorView<DirectXPixelFormat>^ supportedVertexNormalFormats = m_surfaceMeshOptions->SupportedVertexNormalFormats;
+	if (supportedVertexNormalFormats->IndexOf(DirectXPixelFormat::R8G8B8A8IntNormalized, &formatIndex))
+	{
+		m_surfaceMeshOptions->VertexNormalFormat = DirectXPixelFormat::R8G8B8A8IntNormalized;
+	}
+
+	m_surfaceMeshOptions->IncludeVertexNormals = true;
+
+	// Create the observer.
+	m_surfaceObserver = ref new SpatialSurfaceObserver();
+	RETURN_IF_NULL(m_surfaceObserver);
+	
+	m_surfaceObserver->SetBoundingVolume(bounds);
+
+	return true;
+}
+
+byte* GetPointerToData(Windows::Storage::Streams::IBuffer^ buffer)
+{
+	Microsoft::WRL::ComPtr<Windows::Storage::Streams::IBufferByteAccess> bufferByteAccess;
+	reinterpret_cast<IInspectable*>(buffer)->QueryInterface(IID_PPV_ARGS(&bufferByteAccess));
+
+	byte* pointer;
+	bufferByteAccess->Buffer(&pointer);
+
+	return pointer;
+}
+
+void
+SpatialMapping::ProcessSurface(
+	SpatialSurfaceInfo^ surface
+)
+{
+	auto computeMeshTask = create_task(surface->TryComputeLatestMeshAsync(10000, m_surfaceMeshOptions));
+
+	computeMeshTask.then([this](SpatialSurfaceMesh^ mesh)
+	{
+		JsTypedArrayType arrayType;
+		int elementSize;
+		float* typedArrayBuffer;
+		unsigned int typedArraySize;
+
+		if (mesh == nullptr)
+		{
+			return;
+		}
+
+		JsValueRef meshObject;
+		EXIT_IF_JS_ERROR(JsCreateObject(&meshObject));
+
+		// Combine origin transform with mesh scale to create position transform
+		auto originToSurface = mesh->CoordinateSystem->TryGetTransformTo(m_frameOfReference->CoordinateSystem);
+		DirectX::XMMATRIX translationMat = XMLoadFloat4x4(&originToSurface->Value);
+		XMMATRIX scaleMat = XMMatrixScaling(mesh->VertexPositionScale.x, mesh->VertexPositionScale.y, mesh->VertexPositionScale.z);
+		XMMATRIX posTransformMat = scaleMat *translationMat;
+		XMFLOAT4X4 posTransformf4;
+		XMStoreFloat4x4(&posTransformf4, posTransformMat);
+
+		// Store position transform
+		JsValueRef originToSurfaceJsArray;
+		EXIT_IF_JS_ERROR(JsCreateTypedArray(JsArrayTypeFloat32, JS_INVALID_REFERENCE, 0, 16, &originToSurfaceJsArray));
+		EXIT_IF_JS_ERROR(JsGetTypedArrayStorage(originToSurfaceJsArray, reinterpret_cast<BYTE**>(&typedArrayBuffer), &typedArraySize, &arrayType, &elementSize));
+		EXIT_IF_FALSE(typedArraySize == sizeof(posTransformf4));
+		memcpy(typedArrayBuffer, posTransformf4.m, sizeof(posTransformf4));
+		EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObject, L"originToSurfaceTransform", originToSurfaceJsArray));
+
+		// Compute normals transform
+		// Normals transforms for non-uniform scaling require the inverse transpose of the original transform
+		XMMATRIX normTransformMat = XMMatrixTranspose(XMMatrixInverse(nullptr, posTransformMat));
+		XMFLOAT4X4 normTransformf4;
+		XMStoreFloat4x4(&normTransformf4, posTransformMat);
+
+		// Store normals transform
+		JsValueRef normalsTransformJsArray;
+		EXIT_IF_JS_ERROR(JsCreateTypedArray(JsArrayTypeFloat32, JS_INVALID_REFERENCE, 0, 16, &normalsTransformJsArray));
+		EXIT_IF_JS_ERROR(JsGetTypedArrayStorage(normalsTransformJsArray, reinterpret_cast<BYTE**>(&typedArrayBuffer), &typedArraySize, &arrayType, &elementSize));
+		EXIT_IF_FALSE(typedArraySize == sizeof(normTransformf4));
+		memcpy(typedArrayBuffer, normTransformf4.m, sizeof(normTransformf4));
+		EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObject, L"normalTransform", normalsTransformJsArray));
+
+		// Store normals array;
+		JsValueRef normalsJsArray;
+		const auto normalsElementCount = 4 * mesh->VertexNormals->ElementCount; // 4 * R8G8B8A8IntNormalized
+		EXIT_IF_JS_ERROR(JsCreateTypedArray(JsArrayTypeInt8, JS_INVALID_REFERENCE, 0, normalsElementCount, &normalsJsArray));
+		EXIT_IF_JS_ERROR(JsGetTypedArrayStorage(normalsJsArray, reinterpret_cast<BYTE**>(&typedArrayBuffer), &typedArraySize, &arrayType, &elementSize));
+		EXIT_IF_FALSE(typedArraySize == mesh->VertexNormals->Data->Length);
+		memcpy(typedArrayBuffer, GetPointerToData(mesh->VertexNormals->Data), mesh->VertexNormals->Data->Length);
+		EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObject, L"normals", normalsJsArray));
+
+		// Store indices array
+		JsValueRef indicesArray;
+		EXIT_IF_JS_ERROR(JsCreateTypedArray(JsArrayTypeInt16, JS_INVALID_REFERENCE, 0, mesh->TriangleIndices->ElementCount, &indicesArray));
+		EXIT_IF_JS_ERROR(JsGetTypedArrayStorage(indicesArray, reinterpret_cast<BYTE**>(&typedArrayBuffer), &typedArraySize, &arrayType, &elementSize));
+		EXIT_IF_FALSE(typedArraySize == mesh->TriangleIndices->Data->Length);
+		memcpy(typedArrayBuffer, GetPointerToData(mesh->TriangleIndices->Data), mesh->TriangleIndices->Data->Length);
+		EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObject, L"indices", indicesArray));
+
+		//Store positions array
+		JsValueRef positionsArray;
+		const auto positionsElementCount = 4 * mesh->VertexPositions->ElementCount; // 4 * R16G16B16A16
+		EXIT_IF_JS_ERROR(JsCreateTypedArray(JsArrayTypeInt16, JS_INVALID_REFERENCE, 0, positionsElementCount, &positionsArray));
+		EXIT_IF_JS_ERROR(JsGetTypedArrayStorage(positionsArray, reinterpret_cast<BYTE**>(&typedArrayBuffer), &typedArraySize, &arrayType, &elementSize));
+		EXIT_IF_FALSE(typedArraySize == mesh->VertexPositions->Data->Length);
+		memcpy(typedArrayBuffer, GetPointerToData(mesh->VertexPositions->Data), mesh->VertexPositions->Data->Length);
+		EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObject, L"vertices", positionsArray));
+
+		// Create JS callback parameters
+		JsValueRef parameters[3];
+		parameters[0] = m_scriptCallback;
+		EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::SpatialMapping), &parameters[1]));
+		parameters[2] = meshObject;
+
+		// Invoke JS callback
+		JsValueRef result;
+		EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
+	});
+}

--- a/HoloJS/HoloJsHost/SpatialMapping.h
+++ b/HoloJS/HoloJsHost/SpatialMapping.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <list>
 namespace HologramJS
 {
 	namespace Input
@@ -16,6 +17,8 @@ namespace HologramJS
 
 			JsValueRef GetSpatialData();
 
+			void ProcessOneSpatialMappingDataUpdate();
+
 		private:
 
 			JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
@@ -28,6 +31,16 @@ namespace HologramJS
 			bool CreateSurfaceObserver();
 
 			void ProcessSurface(Windows::Perception::Spatial::Surfaces::SpatialSurfaceInfo^ surface);
+
+			std::mutex m_processingLock;
+
+			std::list<std::vector<short int>> m_indexBuffers;
+			std::list<std::vector<float>> m_vertexBuffers;
+			std::list<std::vector<byte>> m_normalBuffers;
+			std::list<std::vector<float>> m_originToSurfaces;
+			std::list<std::vector<byte>> m_meshIds;
+
+			bool m_spatialMappingDataAvailable = false;
 		};
 
 

--- a/HoloJS/HoloJsHost/SpatialMapping.h
+++ b/HoloJS/HoloJsHost/SpatialMapping.h
@@ -1,0 +1,36 @@
+#pragma once
+namespace HologramJS
+{
+	namespace Input
+	{
+		class SpatialMapping
+		{
+		public:
+			SpatialMapping();
+			~SpatialMapping();
+
+			void EnableSpatialMapping(Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ frameOfReference);
+			void DisableSpatialMapping() { m_frameOfReference = nullptr; }
+
+			void SetScriptCallback(JsValueRef scriptCallback) { m_scriptCallback = scriptCallback; }
+
+			JsValueRef GetSpatialData();
+
+		private:
+
+			JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
+
+			Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ m_frameOfReference;
+			bool m_surfaceAccessAllowed = false;
+			Windows::Perception::Spatial::Surfaces::SpatialSurfaceObserver^ m_surfaceObserver;
+			Windows::Perception::Spatial::Surfaces::SpatialSurfaceMeshOptions^ m_surfaceMeshOptions;
+
+			bool CreateSurfaceObserver();
+
+			void ProcessSurface(Windows::Perception::Spatial::Surfaces::SpatialSurfaceInfo^ surface);
+		};
+
+
+	}
+}
+

--- a/HoloJS/HoloJsHost/SpatialMapping.h
+++ b/HoloJS/HoloJsHost/SpatialMapping.h
@@ -15,7 +15,7 @@ namespace HologramJS
 
 			void SetScriptCallback(JsValueRef scriptCallback) { m_scriptCallback = scriptCallback; }
 
-			JsValueRef GetSpatialData();
+			JsValueRef GetSpatialData(float extentX, float extentY, float extentZ, int trianglesPerCubicMeter);
 
 			void ProcessOneSpatialMappingDataUpdate();
 
@@ -28,7 +28,7 @@ namespace HologramJS
 			Windows::Perception::Spatial::Surfaces::SpatialSurfaceObserver^ m_surfaceObserver;
 			Windows::Perception::Spatial::Surfaces::SpatialSurfaceMeshOptions^ m_surfaceMeshOptions;
 
-			bool CreateSurfaceObserver();
+			bool CreateSurfaceObserver(float extentX, float extentY, float extentZ);
 
 			void ProcessSurface(Windows::Perception::Spatial::Surfaces::SpatialSurfaceInfo^ surface);
 
@@ -41,6 +41,8 @@ namespace HologramJS
 			std::list<std::vector<byte>> m_meshIds;
 
 			bool m_spatialMappingDataAvailable = false;
+
+			int m_trianglesResolution = 1000;
 		};
 
 

--- a/HoloJS/HoloJsHost/WindowElement.cpp
+++ b/HoloJS/HoloJsHost/WindowElement.cpp
@@ -35,6 +35,7 @@ WindowElement::Initialize()
 	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getHeight", L"window", getHeightStatic, this, &m_getHeightFunction));
 	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getBaseUrl", L"window", getBaseUrlStatic, this, &m_getBaseUrlFunction));
 	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"setCallback", L"window", setCallbackStatic, this, &m_setCallbackFunction));
+	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"requestSpatialMappingData", L"window", requestSpatialMappingStatic, this, &m_setCallbackFunction));
 
 	RETURN_IF_FALSE(CreateViewMatrixStorageAndScriptProjection());
 
@@ -70,6 +71,7 @@ WindowElement::setCallback(
 	m_keyboardInput.SetScriptCallback(callback);
 	m_mouseInput.SetScriptCallback(callback);
 	m_spatialInput.SetScriptCallback(callback);
+	m_spatialMapping.SetScriptCallback(callback);
 
 	return JS_INVALID_REFERENCE;
 }
@@ -192,4 +194,13 @@ WindowElement::CreateViewMatrixStorageAndScriptProjection()
 	}
 
 	return true;
+}
+
+JsValueRef
+WindowElement::requestSpatialMapping(
+	JsValueRef* arguments,
+	unsigned short argumentCount
+)
+{
+	return m_spatialMapping.GetSpatialData();
 }

--- a/HoloJS/HoloJsHost/WindowElement.cpp
+++ b/HoloJS/HoloJsHost/WindowElement.cpp
@@ -132,6 +132,8 @@ WindowElement::VSync(Windows::Foundation::Numerics::float4x4 viewMatrix)
 	// queued events internally and since now we're on the UI thread we drain them
 	m_spatialInput.DrainQueuedSpatialInputEvents();
 
+	m_spatialMapping.ProcessOneSpatialMappingDataUpdate();
+
 	if (m_callbackFunction != JS_INVALID_REFERENCE)
 	{
 		if (m_viewMatrixStoragePointer != nullptr)

--- a/HoloJS/HoloJsHost/WindowElement.cpp
+++ b/HoloJS/HoloJsHost/WindowElement.cpp
@@ -208,5 +208,12 @@ WindowElement::requestSpatialMapping(
 	unsigned short argumentCount
 )
 {
-	return m_spatialMapping.GetSpatialData();
+	RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
+
+	const auto extentX = ScriptHostUtilities::GLfloatFromJsRef(arguments[1]);
+	const auto extentY = ScriptHostUtilities::GLfloatFromJsRef(arguments[2]);
+	const auto extentZ = ScriptHostUtilities::GLfloatFromJsRef(arguments[3]);
+	const auto trianglesPerCubicMeter = ScriptHostUtilities::GLintFromJsRef(arguments[4]);
+
+	return m_spatialMapping.GetSpatialData(extentX, extentY, extentZ, trianglesPerCubicMeter);
 }

--- a/HoloJS/HoloJsHost/WindowElement.h
+++ b/HoloJS/HoloJsHost/WindowElement.h
@@ -3,6 +3,7 @@
 #include "SpatialInput.h"
 #include "MouseInput.h"
 #include "KeyboardInput.h"
+#include "SpatialMapping.h"
 
 namespace HologramJS
 {
@@ -30,6 +31,7 @@ namespace HologramJS
 			void SetStationaryFrameOfReference(Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ frameOfReference)
 			{
 				m_spatialInput.SetStationaryFrameOfReference(frameOfReference);
+				m_spatialMapping.EnableSpatialMapping(frameOfReference);
 			}
 
 		private:
@@ -39,6 +41,7 @@ namespace HologramJS
 			Input::KeyboardInput m_keyboardInput;
 			Input::MouseInput m_mouseInput;
 			Input::SpatialInput m_spatialInput;
+			Input::SpatialMapping m_spatialMapping;
 
 			int m_width;
 			int m_height;
@@ -109,6 +112,23 @@ namespace HologramJS
 			}
 
 			JsValueRef setCallback(
+				JsValueRef* arguments,
+				unsigned short argumentCount
+			);
+
+			JsValueRef m_requestSpatialMapping = JS_INVALID_REFERENCE;
+			static JsValueRef CHAKRA_CALLBACK requestSpatialMappingStatic(
+				JsValueRef callee,
+				bool isConstructCall,
+				JsValueRef* arguments,
+				unsigned short argumentCount,
+				PVOID callbackData
+			)
+			{
+				return reinterpret_cast<WindowElement*>(callbackData)->requestSpatialMapping(arguments, argumentCount);
+			}
+
+			JsValueRef requestSpatialMapping(
 				JsValueRef* arguments,
 				unsigned short argumentCount
 			);

--- a/HoloJS/ThreeJSApp/Package.appxmanifest
+++ b/HoloJS/ThreeJSApp/Package.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2" IgnorableNamespaces="uap mp uap2">
   <Identity Name="ThreeJSApp" Publisher="CN=crispet" Version="1.0.0.0" />
   <mp:PhoneIdentity PhoneProductId="9d66072c-871e-4001-b8c3-ef10579a63d3" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -24,5 +24,6 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClient" />
+	<uap2:Capability Name="spatialPerception" />
   </Capabilities>
 </Package>

--- a/HoloJS/ThreeJSApp/Scripts/app.js
+++ b/HoloJS/ThreeJSApp/Scripts/app.js
@@ -27,8 +27,7 @@ let scene = new THREE.Scene();
 let camera = window.experimentalHolographic === true ? new HolographicCamera() : new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.01, 1000);
 let clock = new THREE.Clock();
 let loader = new THREE.TextureLoader();
-let material = new THREE.MeshPhongMaterial({ color: 0xFFFFFF });
-//let material = new THREE.MeshLambertMaterial({color : 0x55BBBB});
+let material = new THREE.MeshStandardMaterial({ vertexColors: THREE.VertexColors, map: new THREE.DataTexture(new Uint8Array(3).fill(255), 1, 1, THREE.RGBFormat) });
 
 let ambientLight = new THREE.AmbientLight(0xFFFFFF, 0.8);
 let directionalLight = new THREE.DirectionalLight(0xFFFFFF, 0.5);
@@ -42,7 +41,7 @@ let torus = new THREE.Mesh(initColors(new THREE.TorusKnotBufferGeometry(0.2, 0.0
 renderer.setSize(window.innerWidth, window.innerHeight);
 loader.setCrossOrigin('anonymous');
 
-directionalLight.position.set(0, 4, 0);
+directionalLight.position.set(0, 1, 1);
 
 cube.position.set(0, 0, -1.5);
 cube.geometry.addAttribute('color', new THREE.BufferAttribute(Float32Array.from([
@@ -53,7 +52,7 @@ cube.geometry.addAttribute('color', new THREE.BufferAttribute(Float32Array.from(
     0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, // back - cyan
     1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, // front - purple
 ]), 3));
-//loader.load('texture.png', tex => { cube.material.map = tex; start(); }, x => x, err => start());
+loader.load('texture.png', tex => { cube.material.map = tex; start(); }, x => x, err => start());
 
 sphere.position.set(0.4, 0, -1.5);
 sphere.material.color.set(0xff0000);
@@ -113,7 +112,7 @@ function start () {
     canvas.addEventListener("sourcepress", onSpatialSourcePress);
 
     // Initial request for spatial mapping data
-    window.requestSpatialMappingData(onSurfaceAvailable);
+    //window.requestSpatialMappingData(onSurfaceAvailable);
 }
 
 function SpatialMappingMeshes(scene) {
@@ -133,10 +132,24 @@ function SpatialMappingMeshes(scene) {
         }
     };
 
+    function idEquals(id1, id2) {
+        if (id1.length != id2.length) {
+            return false;
+        }
+
+        for (var i = 0; i < id1.length; i++) {
+            if (id1[i] != id2[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     this.clearMeshData = function (id) {
         if (id != undefined) {
             for (var meshIndex in self.meshObjects) {
-                if (self.meshObjects[meshIndex].id == id) {
+                if (idEquals(self.meshObjects[meshIndex].id, id)) {
                     self.scene.remove(self.meshObjects[meshIndex].mesh);
                     self.meshObjects[meshIndex].mesh.geometry.dispose();
                     self.meshObjects[meshIndex].mesh.material.dispose();
@@ -149,12 +162,36 @@ function SpatialMappingMeshes(scene) {
 
     this.setMeshData = function (surfaceData) {
         self.clearMeshData(surfaceData.id);
-        var newMeshObject = createMeshObject(surfaceData);
+        //var newMeshObject = createMeshObject(surfaceData);
+        var newMeshObject = createMeshObjectBuffered(surfaceData);
 
         self.scene.add(newMeshObject.mesh);
         self.meshObjects.push(newMeshObject);
     }
 
+    // This method is faster to render the mesh, but does not allow easy
+    // manipulation of the surface; the buffers are passed through directly to the
+    // GPU
+    function createMeshObjectBuffered(surface) {
+        var geometry = new THREE.BufferGeometry();
+
+        // Make copies of the incoming buffers; they get recycled after this returns
+        var indices = new Uint16Array(surface.indices);
+        var vertices = new Float32Array(surface.vertices);
+        var normals = new Uint8Array(surface.normals);
+
+        geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+        geometry.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
+        geometry.addAttribute('normal', new THREE.BufferAttribute(normals, 3, true));
+        
+        var vertexTransform = new THREE.Matrix4();
+        vertexTransform.fromArray(surface.originToSurfaceTransform);
+        geometry.applyMatrix(vertexTransform);
+
+        return { id: surface.id, mesh: new THREE.Mesh(geometry, material) };
+    }
+
+    // This method is slower than the one above, but allows for mesh manipulation
     function createMeshObject(surface) {
         var geometry = new THREE.Geometry();
 
@@ -166,12 +203,11 @@ function SpatialMappingMeshes(scene) {
 
         var vertexIndex = 0;
         // Iterate over vertices, normals and indices and add them to the new geometry object
-        for (vertexIndex = 0; vertexIndex <= surface.vertices.length - 4; vertexIndex += 4) {
-            geometry.vertices.push(new THREE.Vector4(
-                surface.vertices[vertexIndex] / 32767,
-                surface.vertices[vertexIndex + 1] / 32767,
-                surface.vertices[vertexIndex + 2] / 32767,
-                surface.vertices[vertexIndex + 3] / 32767
+        for (vertexIndex = 0; vertexIndex <= surface.vertices.length - 3; vertexIndex += 3) {
+            geometry.vertices.push(new THREE.Vector3(
+                surface.vertices[vertexIndex],
+                surface.vertices[vertexIndex + 1],
+                surface.vertices[vertexIndex + 2]
             ));
         }
 
@@ -180,20 +216,19 @@ function SpatialMappingMeshes(scene) {
         for (var indiceIndex = 0; indiceIndex <= surface.indices.length - 3; indiceIndex += 3) {
             var vertexNormals = [];
             for (var normalIndex = 0; normalIndex < 3; normalIndex++) {
-                vertexNormals[normalIndex] = new THREE.Vector4(
+                vertexNormals[normalIndex] = new THREE.Vector3(
                     surface.normals[surface.indices[indiceIndex + normalIndex]],
                     surface.normals[surface.indices[indiceIndex + normalIndex] + 1],
-                    surface.normals[surface.indices[indiceIndex + normalIndex] + 2],
-                    surface.normals[surface.indices[indiceIndex + normalIndex] + 3]
+                    surface.normals[surface.indices[indiceIndex + normalIndex] + 2]
                 );
                 vertexNormals[normalIndex].applyMatrix4(normalTransform);
             }
             geometry.faces.push(
                 //Data passed back from surface reconstruction uses front CW winding order
                 new THREE.Face3(
-                    surface.indices[indiceIndex + 2],
-                    surface.indices[indiceIndex + 1],
                     surface.indices[indiceIndex],
+                    surface.indices[indiceIndex + 1],
+                    surface.indices[indiceIndex + 2],
                     vertexNormals));
         }
 

--- a/HoloJS/ThreeJSApp/Scripts/app.js
+++ b/HoloJS/ThreeJSApp/Scripts/app.js
@@ -240,7 +240,8 @@ function onSurfaceAvailable(surfaceData) {
 }
 
 function onSpatialSourcePress(spatialInputEvent) {
-    window.requestSpatialMappingData(onSurfaceAvailable);
+    var mappingOptions = { scanExtentMeters: { x: 5, y: 5, z: 3 }, trianglesPerCubicMeter: 100 };
+    window.requestSpatialMappingData(onSurfaceAvailable, mappingOptions);
 }
 
 start();

--- a/HoloJS/ThreeJSApp/Scripts/app.js
+++ b/HoloJS/ThreeJSApp/Scripts/app.js
@@ -25,10 +25,10 @@ class HolographicCamera extends THREE.Camera {
 let renderer = new THREE.WebGLRenderer({ canvas: canvas, antialias: true });
 let scene = new THREE.Scene();
 let camera = window.experimentalHolographic === true ? new HolographicCamera() : new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.01, 1000);
-let raycaster = new THREE.Raycaster();
 let clock = new THREE.Clock();
 let loader = new THREE.TextureLoader();
-let material = new THREE.MeshStandardMaterial({ vertexColors: THREE.VertexColors, map: new THREE.DataTexture(new Uint8Array(3).fill(255), 1, 1, THREE.RGBFormat) });
+let material = new THREE.MeshPhongMaterial({ color: 0xFFFFFF });
+//let material = new THREE.MeshLambertMaterial({color : 0x55BBBB});
 
 let ambientLight = new THREE.AmbientLight(0xFFFFFF, 0.8);
 let directionalLight = new THREE.DirectionalLight(0xFFFFFF, 0.5);
@@ -38,13 +38,11 @@ let cube = new THREE.Mesh(new THREE.BoxBufferGeometry(0.2, 0.2, 0.2), material.c
 let sphere = new THREE.Mesh(initColors(new THREE.SphereBufferGeometry(0.1, 20, 20)), material.clone());
 let cone = new THREE.Mesh(initColors(new THREE.ConeBufferGeometry(0.1, 0.2, 20, 20)), material.clone());
 let torus = new THREE.Mesh(initColors(new THREE.TorusKnotBufferGeometry(0.2, 0.02, 100, 100)), material.clone());
-let cursor = new THREE.Mesh(initColors(new THREE.RingBufferGeometry(0.001, 0.003, 20, 20)), material.clone());
 
 renderer.setSize(window.innerWidth, window.innerHeight);
 loader.setCrossOrigin('anonymous');
-material.map.needsUpdate = true;
 
-directionalLight.position.set(0, 1, 1);
+directionalLight.position.set(0, 4, 0);
 
 cube.position.set(0, 0, -1.5);
 cube.geometry.addAttribute('color', new THREE.BufferAttribute(Float32Array.from([
@@ -55,7 +53,7 @@ cube.geometry.addAttribute('color', new THREE.BufferAttribute(Float32Array.from(
     0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, // back - cyan
     1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, // front - purple
 ]), 3));
-loader.load('texture.png', tex => { cube.material.map = tex; start(); }, x => x, err => start());
+//loader.load('texture.png', tex => { cube.material.map = tex; start(); }, x => x, err => start());
 
 sphere.position.set(0.4, 0, -1.5);
 sphere.material.color.set(0xff0000);
@@ -71,26 +69,20 @@ torus.material.color.set(0x00ff00);
 torus.material.roughness = 0.5;
 torus.material.metalness = 1.0;
 
-cursor.position.set(0, 0, -0.5);
-cursor.material.transparent = true;
-cursor.material.opacity = 0.5;
-
 scene.add(ambientLight);
 scene.add(directionalLight);
 scene.add(pointLight);
 
-scene.add(cube);
-scene.add(sphere);
-scene.add(cone);
+//scene.add(cube);
+//scene.add(sphere);
+//scene.add(cone);
 scene.add(torus);
-camera.add(cursor);
 scene.add(camera);
 
 cube.frustumCulled = false;
 sphere.frustumCulled = false;
 cone.frustumCulled = false;
 torus.frustumCulled = false;
-cursor.frustumCulled = false;
 
 var controls;
 
@@ -107,23 +99,6 @@ function update (delta, elapsed) {
     window.requestAnimationFrame(() => update(clock.getDelta(), clock.getElapsedTime()));
 
     pointLight.position.set(0 + 2.0 * Math.cos(elapsed * 0.5), 0, -1.5 + 2.0 * Math.sin(elapsed * 0.5));
-    sphere.scale.x = sphere.scale.y = sphere.scale.z = Math.abs(Math.cos(elapsed * 0.3)) * 0.6 + 1.0;
-    cone.position.y = Math.sin(elapsed * 0.5) * 0.1;
-    torus.position.z = -2 - Math.abs(Math.cos(elapsed * 0.2));
-
-    raycaster.ray.origin.setFromMatrixPosition(camera.matrixWorld);
-    raycaster.ray.direction.set(0, 0, -1).transformDirection(camera.matrixWorld);
-    let intersects = raycaster.intersectObjects(scene.children);
-    if (intersects.length > 0) {
-        cursor.material.color.set(0xFFFF00);
-        cursor.material.opacity = 0.8;
-        cursor.scale.set(2, 2, 2);
-    }
-    else {
-        cursor.material.color.set(0xFFFFFF);
-        cursor.material.opacity = 0.5;
-        cursor.scale.set(1, 1, 1);
-    }
 
     if (camera.update) camera.update();
 
@@ -136,27 +111,140 @@ function start () {
 
 // Listen to spatial input events (hands)
 canvas.addEventListener("sourcepress", onSpatialSourcePress);
-canvas.addEventListener("sourcerelease", onSpatialSourceRelease);
-canvas.addEventListener("sourceupdate", onSpatialSourceUpdate);
-// treat source lost the same way as source release - stop moving the cube when hands input is lost
-canvas.addEventListener("sourcelost", onSpatialSourceRelease);
-
-let lastSpatialInputX = 0;
-let spatialInputTracking = false;
+canvas.addEventListener("spatialmapping", onSurfaceAvailable);
 
 function onSpatialSourcePress(spatialInputEvent) {
-    lastSpatialInputX = spatialInputEvent.location.x;
-    spatialInputTracking = true;
+    var spatialMapData = window.requestSpatialMappingData();
 }
 
-function onSpatialSourceRelease(spatialInputEvent) {
-    spatialInputTracking = false;
-}
+function SRSurfaceMesh(scene) {
+    var self = this;
+    this.meshObjects = [];
+    this.scene = scene;
+    this.lowestPoint = Number.MAX_VALUE;
 
-function onSpatialSourceUpdate(spatialInputEvent) {
-    if (spatialInputTracking === true) {
-        // rotate the cube proportional to hand movement on X axis
-        cube.rotation.y += (lastSpatialInputX - spatialInputEvent.location.x);
-        lastSpatialInputX = spatialInputEvent.location.x;
+    self.objFormatMesh = [];
+
+    this.updatePositionRelativeToAttachedFor = function (originData) {
+        if (originData.OriginToAttachedFor) {
+            var matrix = getMatrixFromRestArray(originData.OriginToAttachedFor);
+            matrix.transpose();
+
+            for (var meshIndex in self.meshObjects) {
+                self.meshObjects[meshIndex].Mesh.matrix = matrix;
+            }
+        }
+    };
+
+    function hideMeshData() {
+        for (var meshIndex in self.meshObjects) {
+            self.scene.remove(self.meshObjects[meshIndex].Mesh);
+        }
+    }
+
+    function showMeshData() {
+        for (var meshIndex in self.meshObjects) {
+            self.scene.add(self.meshObjects[meshIndex].Mesh);
+        }
+    }
+
+    this.clearMeshData = function (guid) {
+        if (guid != undefined) {
+            for (var meshIndex in self.meshObjects) {
+                if (self.meshObjects[meshIndex].SurfaceId == guid) {
+                    self.scene.remove(self.meshObjects[meshIndex].Mesh);
+                    self.meshObjects[meshIndex].Mesh.geometry.dispose();
+                    self.meshObjects[meshIndex].Mesh.material.dispose();
+                    self.meshObjects.splice(meshIndex, 1);
+                    break;
+                }
+            }
+        }
+        else {
+            self.lowestPoint = Number.MAX_VALUE;
+            for (var i in self.meshObjects) {
+                self.scene.remove(self.meshObjects[i].Mesh);
+                self.meshObjects[i].Mesh.geometry.dispose();
+                self.meshObjects[i].Mesh.material.dispose();
+            }
+            self.meshObjects.splice(0, self.meshObjects.length);
+        }
+
+    };
+
+    this.setMeshData = function (surfaceData) {
+        //self.clearMeshData(newMeshData.Surface.SurfaceId);
+        createMeshObjects(surfaceData);
+    }
+
+    function getTotalTriangles() {
+        var totalTriangles = 0;
+        for (var meshIndex in self.meshObjects) {
+            totalTriangles += self.meshObjects[meshIndex].triCount;
+        }
+
+        return totalTriangles;
+    }
+
+    function createMeshObjects(surface) {
+        var geometry = new THREE.Geometry();
+
+        var vertexTransform = new THREE.Matrix4();
+        vertexTransform.fromArray(surface.originToSurfaceTransform);
+        vertexTransform.transpose();
+
+        var normalTransform = new THREE.Matrix4();
+        normalTransform.fromArray(surface.normalTransform);
+        normalTransform.transpose();
+
+        var vertexIndex = 0;
+        // Iterate over vertices, normals and indices and add them to the new geometry object
+        for (vertexIndex = 0; vertexIndex <= surface.vertices.length - 4; vertexIndex += 4) {
+            geometry.vertices.push(new THREE.Vector4(
+                surface.vertices[vertexIndex] / 32767,
+                surface.vertices[vertexIndex + 1] / 32767,
+                surface.vertices[vertexIndex + 2] / 32767,
+                surface.vertices[vertexIndex + 3] / 32767
+            ));
+        }
+
+        geometry.applyMatrix(vertexTransform);
+
+        for (var indiceIndex = 0; indiceIndex <= surface.indices.length - 3; indiceIndex += 3) {
+            var vertexNormals = [];
+            for (var normalIndex = 0; normalIndex < 3; normalIndex++) {
+                vertexNormals[normalIndex] = new THREE.Vector4(
+                    surface.normals[surface.indices[indiceIndex + normalIndex]],
+                    surface.normals[surface.indices[indiceIndex + normalIndex] + 1],
+                    surface.normals[surface.indices[indiceIndex + normalIndex] + 2],
+                    surface.normals[surface.indices[indiceIndex + normalIndex] + 3]
+                );
+                vertexNormals[normalIndex].applyMatrix4(normalTransform);
+            }
+            geometry.faces.push(
+                //Data passed back from surface reconstruction uses front CW winding order
+                new THREE.Face3(
+                    surface.indices[indiceIndex + 2],
+                    surface.indices[indiceIndex + 1],
+                    surface.indices[indiceIndex],
+                    vertexNormals));
+        }
+
+        //geometry.computeFaceNormals();
+        //geometry.computeVertexNormals();
+        self.scene.add(new THREE.Mesh(geometry, material));
     }
 }
+
+var meshManager = new SRSurfaceMesh(scene);
+
+var added = false;
+function onSurfaceAvailable(surfaceData) {
+    //if (added === false) {
+        meshManager.setMeshData(surfaceData);
+        added = true;
+    //}
+}
+
+start();
+

--- a/HoloJS/ThreeJSApp/Scripts/app.js
+++ b/HoloJS/ThreeJSApp/Scripts/app.js
@@ -40,8 +40,9 @@ let torus = new THREE.Mesh(initColors(new THREE.TorusKnotBufferGeometry(0.2, 0.0
 
 renderer.setSize(window.innerWidth, window.innerHeight);
 loader.setCrossOrigin('anonymous');
+material.map.needsUpdate = true;
 
-directionalLight.position.set(0, 1, 1);
+directionalLight.position.set(0, 2, 0);
 
 cube.position.set(0, 0, -1.5);
 cube.geometry.addAttribute('color', new THREE.BufferAttribute(Float32Array.from([
@@ -72,9 +73,9 @@ scene.add(ambientLight);
 scene.add(directionalLight);
 scene.add(pointLight);
 
-//scene.add(cube);
-//scene.add(sphere);
-//scene.add(cone);
+scene.add(cube);
+scene.add(sphere);
+scene.add(cone);
 scene.add(torus);
 scene.add(camera);
 
@@ -110,9 +111,6 @@ function start () {
     // Listen to spatial input events (hands)
     // On press, spatial mapping data is requested and the visible meshes are updated
     canvas.addEventListener("sourcepress", onSpatialSourcePress);
-
-    // Initial request for spatial mapping data
-    //window.requestSpatialMappingData(onSurfaceAvailable);
 }
 
 function SpatialMappingMeshes(scene) {
@@ -188,7 +186,7 @@ function SpatialMappingMeshes(scene) {
         vertexTransform.fromArray(surface.originToSurfaceTransform);
         geometry.applyMatrix(vertexTransform);
 
-        return { id: surface.id, mesh: new THREE.Mesh(geometry, material) };
+        return { id: surface.id, mesh: new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({ color: 0xFFFFFF })) };
     }
 
     // This method is slower than the one above, but allows for mesh manipulation
@@ -232,7 +230,7 @@ function SpatialMappingMeshes(scene) {
                     vertexNormals));
         }
 
-        return { id: surface.id, mesh: new THREE.Mesh(geometry, material) };
+        return { id: surface.id, mesh: new THREE.Mesh(geometry, new THREE.MeshPhongMaterial({ color: 0xFFFFFF })) };
     }
 }
 


### PR DESCRIPTION
Implement retrieval of spatial mapping data from script.

The script can specify the extents from the origin of the scene to include in the scan. The script can also request a triangle density.

Upon spatial mapping data becoming available, the specified callback is invoked, one scanned surface at a time. Indices, vertexes, normals and the transform to origin of the surface is provided.

Added ThreeJS sample for constructing a Mesh object from the received data. Two methods for building geometry from the buffers are provided. The buffered mode is faster, the basic Geometry mode is slower but allows arbitrary manipulation of the data before rendering.

Mapping data is processed off the UI thread to not block rendering; after the data is available, callbacks into the script are done on the UI thread, at most one callback (surface) per VSync.