### PR TITLE
Print JS Exceptions to console.

### DIFF
--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj
@@ -221,6 +221,7 @@
     <ClInclude Include="ObjectEvents.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="RenderingContext2D.h" />
+    <ClInclude Include="ScriptErrorHandling.h" />
     <ClInclude Include="ScriptHostUtilities.h" />
     <ClInclude Include="ScriptResourceTracker.h" />
     <ClInclude Include="ScriptsLoader.h" />

--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
@@ -113,6 +113,9 @@
     <ClInclude Include="SpatialMapping.h">
       <Filter>NativeFramework</Filter>
     </ClInclude>
+    <ClInclude Include="ScriptErrorHandling.h">
+      <Filter>NativeFramework</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/HoloJS/HoloJsHost/HologramJS.cpp
+++ b/HoloJS/HoloJsHost/HologramJS.cpp
@@ -4,9 +4,9 @@
 #include "WindowElement.h"
 #include "ImageElement.h"
 #include "System.h"
+#include "ScriptsLoader.h"
 #include "HologramJS.h"
 #include "WebGLProjections.h"
-#include "ScriptsLoader.h"
 
 using namespace HologramJS;
 using namespace Platform;
@@ -105,11 +105,7 @@ HologramScriptHost::RunLocalScriptApp(
 
 		m_window.SetBaseUrl(basePath);
 
-		for (const auto& script : loader->LoadedScripts())
-		{
-			JsValueRef result;
-			RETURN_IF_JS_ERROR(JsRunScript(script.c_str(), m_jsSourceContext++, L"", &result));
-		}
+		loader->ExecuteScripts();
 	}
 
 	return true;
@@ -155,11 +151,8 @@ HologramScriptHost::RunWebScriptApp(
 		API::ImageElement::BaseUrl.assign(basePath);
 		API::VideoElement::BaseUrl.assign(basePath);
 
-		for (const auto& script : loader->LoadedScripts())
-		{
-			JsValueRef result;
-			RETURN_IF_JS_ERROR(JsRunScript(script.c_str(), m_jsSourceContext++, L"", &result));
-		}
+		loader->ExecuteScripts();
+
 	}
 
 	return true;

--- a/HoloJS/HoloJsHost/HologramJS.h
+++ b/HoloJS/HoloJsHost/HologramJS.h
@@ -24,7 +24,6 @@ namespace HologramJS
 	private:
 		JsRuntimeHandle m_jsRuntime = nullptr;
 		JsContextRef m_jsContext = nullptr;
-		JsSourceContext m_jsSourceContext = 0;
 
 		concurrency::task<bool> RunLocalScriptApp(std::wstring jsonFilePath);
 		concurrency::task<bool> RunWebScriptApp(std::wstring jsonFilePath);

--- a/HoloJS/HoloJsHost/KeyboardInput.cpp
+++ b/HoloJS/HoloJsHost/KeyboardInput.cpp
@@ -46,6 +46,6 @@ KeyboardInput::CallbackScriptForKeyboardInput(
 	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(type), actionTypeParam));
 
 	JsValueRef result;
-	EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
+	HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
 }
 

--- a/HoloJS/HoloJsHost/MouseInput.cpp
+++ b/HoloJS/HoloJsHost/MouseInput.cpp
@@ -87,6 +87,8 @@ MouseInput::CallbackScriptForMouseInput(
 	Windows::UI::Core::PointerEventArgs^ args
 )
 {
+	EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
+
 	JsValueRef parameters[6];
 	parameters[0] = m_scriptCallback;
 	JsValueRef* eventTypeParam = &parameters[1];
@@ -102,5 +104,5 @@ MouseInput::CallbackScriptForMouseInput(
 	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(type), actionParam));
 
 	JsValueRef result;
-	EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
+	HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
 }

--- a/HoloJS/HoloJsHost/ObjectEvents.h
+++ b/HoloJS/HoloJsHost/ObjectEvents.h
@@ -44,12 +44,7 @@ namespace HologramJS
 			{
 				JsValueRef result;
 				parameters.insert(parameters.begin(), m_scriptCallbackContext);
-				RETURN_IF_JS_ERROR(
-					JsCallFunction(
-						m_scriptCallback,
-						parameters.data(),
-						static_cast<unsigned short>(parameters.size()),
-						&result));
+				HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters.data(), static_cast<unsigned short>(parameters.size()), &result));
 
 				return true;
 			}

--- a/HoloJS/HoloJsHost/ScriptErrorHandling.h
+++ b/HoloJS/HoloJsHost/ScriptErrorHandling.h
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace HologramJS
+{
+	class ScriptErrorHandling {
+	public:
+		static void PrintException() {
+			// Get error message
+			JsValueRef exception;
+			JsGetAndClearException(&exception);
+
+			JsPropertyIdRef messageName;
+			JsGetPropertyIdFromName(L"stack", &messageName);
+
+			JsValueRef messageValue;
+			JsGetProperty(exception, messageName, &messageValue);
+
+			const wchar_t *message;
+			size_t length;
+			JsStringToPointer(messageValue, &message, &length);
+
+			std::wstring output = L"";
+			output += message;
+			output += L"\r\n";
+			OutputDebugString(output.c_str());
+		}
+	};
+}

--- a/HoloJS/HoloJsHost/ScriptsLoader.h
+++ b/HoloJS/HoloJsHost/ScriptsLoader.h
@@ -2,6 +2,11 @@
 
 namespace HologramJS
 {
+	struct Script {
+		std::wstring path;
+		std::wstring code;
+	};
+
 	class ScriptsLoader
 	{
 	public:
@@ -10,8 +15,6 @@ namespace HologramJS
 
 		concurrency::task<bool> LoadScripts(Windows::Storage::StorageFolder^ root, const std::wstring& jsonPath);
 		concurrency::task<bool> DownloadScripts(const std::wstring& uri);
-
-		const std::list<std::wstring>& LoadedScripts() { return m_loadedScripts; }
 
 		static std::list<std::wstring> SplitPath(const std::wstring& path);
 
@@ -36,7 +39,11 @@ namespace HologramJS
 
 		static std::wstring GetFileSystemBasePathForJsonPath(const std::wstring& jsonFilePath);
 		static std::wstring GetBaseUriForJsonUri(const std::wstring& jsonUri);
+	
+		void ExecuteScripts();
 
-		std::list<std::wstring> m_loadedScripts;
+		std::list<std::shared_ptr<Script>> m_loadedScripts;
+		JsSourceContext m_jsSourceContext = 0;
+
 	};
 }

--- a/HoloJS/HoloJsHost/SpatialInput.cpp
+++ b/HoloJS/HoloJsHost/SpatialInput.cpp
@@ -104,7 +104,7 @@ SpatialInput::CallbackScriptForSpatialInput(const SpatialEventData& eventData)
 	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(eventData.type), spatialInputTypeParam));
 
 	JsValueRef result;
-	EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
+	HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
 }
 
 void
@@ -143,7 +143,7 @@ SpatialInput::QueueEventOrFireCallback(SpatialInputEventType type, Windows::UI::
 		EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(type), spatialInputTypeParam));
 
 		JsValueRef result;
-		EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
+		HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
 	}
 	else
 	{

--- a/HoloJS/HoloJsHost/SpatialMapping.cpp
+++ b/HoloJS/HoloJsHost/SpatialMapping.cpp
@@ -186,7 +186,7 @@ SpatialMapping::ProcessOneSpatialMappingDataUpdate()
 
 	// Invoke JS callback
 	JsValueRef result;
-	EXIT_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
+	HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
 
 	m_meshIds.pop_front();
 	m_vertexBuffers.pop_front();

--- a/HoloJS/HoloJsHost/System.cpp
+++ b/HoloJS/HoloJsHost/System.cpp
@@ -184,7 +184,7 @@ System::setTimeout(
 
 		// Call the script
 		JsValueRef result;
-		JsCallFunction(timeout->ScriptCallback, timeout->ScriptCallbackParameters.data(), static_cast<unsigned short>(timeout->ScriptCallbackParameters.size()), &result);
+		HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(timeout->ScriptCallback, timeout->ScriptCallbackParameters.data(), static_cast<unsigned short>(timeout->ScriptCallbackParameters.size()), &result));
 
 		// Release script resources
 		unsigned int refCount;

--- a/HoloJS/HoloJsHost/WindowElement.cpp
+++ b/HoloJS/HoloJsHost/WindowElement.cpp
@@ -120,7 +120,7 @@ WindowElement::Resize(int width, int height)
 			EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::Resize), eventTypeParam));
 
 			JsValueRef result;
-			EXIT_IF_JS_ERROR(JsCallFunction(m_callbackFunction, parameters.data(), (unsigned short)parameters.size(), &result));
+			HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_callbackFunction, parameters.data(), static_cast<unsigned short>(parameters.size()), &result));
 		}
 	}
 }
@@ -157,7 +157,7 @@ WindowElement::VSync(Windows::Foundation::Numerics::float4x4 viewMatrix)
 		std::vector<JsValueRef> parameters(1);
 		parameters[0] = m_callbackFunction;
 		JsValueRef result;
-		EXIT_IF_JS_ERROR(JsCallFunction(m_callbackFunction, parameters.data(), static_cast<unsigned short>(parameters.size()), &result));
+		HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_callbackFunction, parameters.data(), static_cast<unsigned short>(parameters.size()), &result));
 	}
 }
 

--- a/HoloJS/HoloJsHost/pch.h
+++ b/HoloJS/HoloJsHost/pch.h
@@ -64,8 +64,10 @@ void Log(PCSTR file, int line);
 #define RETURN_INVALID_REF_IF_FAILED(x) do { if (FAILED(x)) { Log(__FILE__, __LINE__); return JS_INVALID_REFERENCE; } } while (0, 0)
 #define RETURN_INVALID_REF_IF_NULL(x) do { if ((x) == nullptr) { Log(__FILE__, __LINE__); return JS_INVALID_REFERENCE; } } while (0, 0)
 #define RETURN_INVALID_REF_IF_JS_ERROR(x) do { if ((x) != JsNoError) { Log(__FILE__, __LINE__); return JS_INVALID_REFERENCE; } } while (0, 0)
+#define HANDLE_EXCEPTION_IF_JS_ERROR(x) if ((x) != JsNoError) { HologramJS::ScriptErrorHandling::PrintException();}
 
 #include "IRelease.h"
+#include "ScriptErrorHandling.h"
 #include "ObjectEvents.h"
 #include "ExternalObject.h"
 #include "ScriptHostUtilities.h"


### PR DESCRIPTION
At the moment, if there's a mistake in the JavaScript code, there's no useful feedback about what went wrong making debugging difficult. This pull request provides the developer with a normal JavaScript exception error.