### PR TITLE
Allow mixing local and web scripts in app.json

### DIFF
--- a/HoloJS/HoloJsHost/ScriptsLoader.cpp
+++ b/HoloJS/HoloJsHost/ScriptsLoader.cpp
@@ -89,7 +89,7 @@ ScriptsLoader::LoadScripts(
 
 		// Allow mixing Web scripts with local scripts
 		// When referencing web scripts in a local app, only absolute URIs are allowed
-		if (scriptPath.find(L"https://") == 0 || scriptPath.find(L"https://") == 0)
+		if (scriptPath.find(L"https://") == 0 || scriptPath.find(L"http://") == 0)
 		{
 			auto scriptUri = ref new Uri(Platform::StringReference(scriptPath.c_str()));
 			auto scriptPlatformText = await DownloadTextFromURI(scriptUri);

--- a/HoloJS/HoloJsHost/ScriptsLoader.cpp
+++ b/HoloJS/HoloJsHost/ScriptsLoader.cpp
@@ -86,7 +86,20 @@ ScriptsLoader::LoadScripts(
 	for (const auto& scriptPath : scriptsList)
 	{
 		auto scriptPathElements = SplitPath(scriptPath);
-		if (!scriptPathElements.empty())
+
+		// Allow mixing Web scripts with local scripts
+		// When referencing web scripts in a local app, only absolute URIs are allowed
+		if (scriptPath.find(L"https://") == 0 || scriptPath.find(L"https://") == 0)
+		{
+			auto scriptUri = ref new Uri(Platform::StringReference(scriptPath.c_str()));
+			auto scriptPlatformText = await DownloadTextFromURI(scriptUri);
+			wstring scriptText = scriptPlatformText->Data();
+			if (!scriptText.empty())
+			{
+				m_loadedScripts.emplace_back(std::move(scriptText));
+			}
+		}
+		else if (!scriptPathElements.empty())
 		{
 			auto scriptName = scriptPathElements.front();
 			scriptPathElements.erase(scriptPathElements.begin());


### PR DESCRIPTION
For a local app.json, allow adding web scripts to the list of scripts to be loaded.

Web scripts must be added using a full URI - relative paths won't work for web scripts in local apps.