### PR TITLE
Implement more timers and XHR methods to fix socket.io

### DIFF
--- a/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
@@ -3,6 +3,7 @@ var navigator;
 var console;
 
 var setTimeout = nativeInterface.system.setTimeout;
+var clearTimeout = nativeInterface.system.clearTimeout;
 
 function Source() {
 

--- a/HoloJS/HoloJsHost/ScriptingFramework/XmlHttpRequest.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/XmlHttpRequest.js
@@ -9,8 +9,12 @@
             this.statusText = arguments[3];
             this.responseType = arguments[4];
 
-            if (this.readyState === XMLHttpRequest.DONE && this.status === 200) {
-                this.fireHandlersByType("load", { target: this });
+            if (this.readyState === XMLHttpRequest.DONE) {
+                if (this.status >= 200 && this.status <= 205) {
+                    this.fireHandlersByType("load", { target: this });
+                } else {
+                    this.fireHandlersByType("error", { target: this });
+                }
             }
         }
     };

--- a/HoloJS/HoloJsHost/ScriptingFramework/XmlHttpRequest.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/XmlHttpRequest.js
@@ -43,10 +43,19 @@
     this.open = function (method, url) {
         this.method = method;
         this.url = url;
+        this.headers = [];
     };
 
+    this.setRequestHeader = function (header, value) {
+        nativeInterface.xhr.setHeader(this.native, header, value);
+    }
+
+    this.getResponseHeader = function (header) {
+        return nativeInterface.xhr.getHeader(this.native, header);
+    }
+
     this.send = function () {
-        nativeInterface.xhr.send(this.native, this.method, this.url, (this.responseType ? this.responseType : "text"));
+        nativeInterface.xhr.send(this.native, this.method, this.url, (this.responseType ? this.responseType : "text"), this.headers);
     };
 
     Object.defineProperty(this, "responseText", {

--- a/HoloJS/HoloJsHost/ScriptingFramework/XmlHttpRequest.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/XmlHttpRequest.js
@@ -43,7 +43,6 @@
     this.open = function (method, url) {
         this.method = method;
         this.url = url;
-        this.headers = [];
     };
 
     this.setRequestHeader = function (header, value) {
@@ -55,7 +54,7 @@
     }
 
     this.send = function () {
-        nativeInterface.xhr.send(this.native, this.method, this.url, (this.responseType ? this.responseType : "text"), this.headers);
+        nativeInterface.xhr.send(this.native, this.method, this.url, (this.responseType ? this.responseType : "text"));
     };
 
     Object.defineProperty(this, "responseText", {

--- a/HoloJS/HoloJsHost/ScriptsLoader.cpp
+++ b/HoloJS/HoloJsHost/ScriptsLoader.cpp
@@ -89,7 +89,7 @@ ScriptsLoader::LoadScripts(
 
 		// Allow mixing Web scripts with local scripts
 		// When referencing web scripts in a local app, only absolute URIs are allowed
-		if (scriptPath.find(L"https://") == 0 || scriptPath.find(L"https://") == 0)
+		if (scriptPath.find(L"https://") == 0 || scriptPath.find(L"http://") == 0)
 		{
 			auto scriptUri = ref new Uri(Platform::StringReference(scriptPath.c_str()));
 			auto scriptPlatformText = await DownloadTextFromURI(scriptUri);

--- a/HoloJS/HoloJsHost/ScriptsLoader.cpp
+++ b/HoloJS/HoloJsHost/ScriptsLoader.cpp
@@ -86,7 +86,20 @@ ScriptsLoader::LoadScripts(
 	for (const auto& scriptPath : scriptsList)
 	{
 		auto scriptPathElements = SplitPath(scriptPath);
-		if (!scriptPathElements.empty())
+
+		// Allow mixing Web scripts with local scripts
+		// When referencing web scripts in a local app, only absolute URIs are allowed
+		if (scriptPath.find(L"https://") == 0 || scriptPath.find(L"https://") == 0)
+		{
+			auto scriptUri = ref new Uri(Platform::StringReference(scriptPath.c_str()));
+			auto scriptPlatformText = await DownloadTextFromURI(scriptUri);
+			wstring scriptText = scriptPlatformText->Data();
+			if (!scriptText.empty())
+			{
+				m_loadedScripts.emplace_back(std::move(scriptText));
+			}
+		}
+		else if (!scriptPathElements.empty())
 		{
 			auto scriptName = scriptPathElements.front();
 			scriptPathElements.erase(scriptPathElements.begin());

--- a/HoloJS/HoloJsHost/System.cpp
+++ b/HoloJS/HoloJsHost/System.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 #include "System.h"
-#include <agents.h>
+
 
 using namespace HologramJS::API;
 using namespace HologramJS::Utilities;
@@ -20,6 +20,7 @@ bool
 System::Initialize()
 {
 	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"setTimeout", L"system", setTimeoutStatic, this, &m_setTimeoutFunction));
+	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"clearTimeout", L"system", clearTimeoutStatic, this, &m_clearTimeoutFunction));
 	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"log", L"system", logStatic, this, &m_logFunction));
 
 	return true;
@@ -44,6 +45,56 @@ System::log(
 }
 
 JsValueRef
+System::clearTimeout(
+	JsValueRef callee,
+	JsValueRef* arguments,
+	unsigned short argumentCount
+)
+{
+	RETURN_INVALID_REF_IF_TRUE(argumentCount < 2);
+
+	int timeoutId;
+	RETURN_INVALID_REF_IF_JS_ERROR(JsNumberToInt(arguments[1], &timeoutId));
+
+	shared_ptr<Timeout> timeout;
+	// Lookup and remove the timer from the list
+	{
+		// Lock the timeouts list
+		std::lock_guard<std::mutex> guard(m_timeoutsLock);
+
+		// Lookup the ID in the timeouts list
+		for (auto& timeoutInstance : m_timeouts)
+		{
+			if (timeoutId == timeoutInstance->ID)
+			{
+				// Found it; remove it
+				timeout = timeoutInstance;
+				m_timeouts.remove(timeout);
+				break;
+			}
+		}
+	}
+
+	if (!timeout)
+	{
+		// The timeout must have fired already; return
+		return JS_INVALID_REFERENCE;
+	}
+
+	timeout->Timer->stop();
+
+	// Release JS resources
+	unsigned int refCount;
+	JsRelease(timeout->ScriptCallback, &refCount);
+	for (const auto& parameter : timeout->ScriptCallbackParameters)
+	{
+		JsRelease(parameter, &refCount);
+	}
+
+	return JS_INVALID_REFERENCE;
+}
+
+JsValueRef
 System::setTimeout(
 	JsValueRef callee,
 	JsValueRef* arguments,
@@ -52,58 +103,95 @@ System::setTimeout(
 {
 	RETURN_INVALID_REF_IF_FALSE(argumentCount >= 3);
 
-	JsValueRef callback = arguments[1];
+	shared_ptr<Timeout> timeout = make_shared<Timeout>();
 
-	int timeout;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsNumberToInt(arguments[2], &timeout));
+	timeout->ScriptCallback = arguments[1];
+
+	int timeoutValue;
+	RETURN_INVALID_REF_IF_JS_ERROR(JsNumberToInt(arguments[2], &timeoutValue));
 
 	unsigned int refCount;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsAddRef(callback, &refCount));
+	RETURN_INVALID_REF_IF_JS_ERROR(JsAddRef(timeout->ScriptCallback, &refCount));
 
-	vector<JsValueRef> callbackParameters(argumentCount - 2);
-	callbackParameters[0] = callee;
+	timeout->ScriptCallbackParameters.resize(argumentCount - 2);
+	timeout->ScriptCallbackParameters[0] = callee;
 	JsAddRef(callee, &refCount);
 	for (int i = 3; i < argumentCount; i++)
 	{
 		JsAddRef(arguments[i], &refCount);
-		callbackParameters[i - 2] = arguments[i];
+		timeout->ScriptCallbackParameters[i - 2] = arguments[i];
 	}
 
+	timeout->Timer = make_unique<timer<int>>(timeoutValue, 0, nullptr, false);
 	task_completion_event<void> tce;
-
-	// Create a non-repeating timer.
-	auto fire_once = new timer<int>(timeout, 0, nullptr, false);
-	auto timerCallback = new call<int>([tce](int)
+	timeout->Callback = make_unique<call<int>>([tce](int)
 	{
 		tce.set();
 	});
 
 	// Connect the timer to the callback and start the timer.
-	fire_once->link_target(timerCallback);
-	fire_once->start();
+	timeout->Timer->link_target(timeout->Callback.get());
+	timeout->Timer->start();
+	timeout->Continuation = make_unique<task<void>>(tce);
+	timeout->ID = 0;
 
-	task<void> event_set(tce);
-
-	// Create a continuation task that cleans up resources and
-	// and return that continuation task.
-	event_set.then([timerCallback, fire_once, callback, callbackParameters]() mutable
+	// Insert the timeout in the list and assign it an ID
 	{
+		std::lock_guard<std::mutex> guard(m_timeoutsLock);
+
+		for (const auto& timeoutInstance : m_timeouts)
+		{
+			if (timeout->ID <= timeoutInstance->ID)
+			{
+				timeout->ID = timeoutInstance->ID + 1;
+			}
+		}
+		m_timeouts.push_back(timeout);
+	}
+
+	int id = timeout->ID;
+
+	timeout->Continuation->then([this, id]()
+	{
+		shared_ptr<Timeout> timeout;
+		// Lookup and remove the firing timer from the list of timers
+		{
+			// Lock the list of timeouts
+			std::lock_guard<std::mutex> guard(m_timeoutsLock);
+
+			// Lookup the ID in the timeouts list
+			for (auto& timeoutInstance : m_timeouts)
+			{
+				if (id == timeoutInstance->ID)
+				{
+					// Found it; remove it
+					timeout = timeoutInstance;
+					m_timeouts.remove(timeout);
+					break;
+				}
+			}
+		}
+		
+		if (!timeout)
+		{
+			// The timeout must have been cleared; return
+			return;
+		}
+
+		// Call the script
 		JsValueRef result;
-		JsCallFunction(callback, callbackParameters.data(), static_cast<unsigned short>(callbackParameters.size()), &result);
+		JsCallFunction(timeout->ScriptCallback, timeout->ScriptCallbackParameters.data(), static_cast<unsigned short>(timeout->ScriptCallbackParameters.size()), &result);
 
+		// Release script resources
 		unsigned int refCount;
-		JsRelease(callback, &refCount);
-
-		for (const auto& parameter : callbackParameters)
+		JsRelease(timeout->ScriptCallback, &refCount);
+		for (const auto& parameter : timeout->ScriptCallbackParameters)
 		{
 			JsRelease(parameter, &refCount);
 		}
-
-		delete timerCallback;
-		delete fire_once;
 	}, task_continuation_context::use_current());
 
 	JsValueRef retValue;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(0, &retValue));
+	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(timeout->ID, &retValue));
 	return retValue;
 }

--- a/HoloJS/HoloJsHost/System.cpp
+++ b/HoloJS/HoloJsHost/System.cpp
@@ -113,6 +113,8 @@ System::setTimeout(
 	unsigned int refCount;
 	RETURN_INVALID_REF_IF_JS_ERROR(JsAddRef(timeout->ScriptCallback, &refCount));
 
+	// Capture the parameters intended for the callback function;
+	// Increase the ref count to prevent garbage collection before the timer fires
 	timeout->ScriptCallbackParameters.resize(argumentCount - 2);
 	timeout->ScriptCallbackParameters[0] = callee;
 	JsAddRef(callee, &refCount);
@@ -122,6 +124,7 @@ System::setTimeout(
 		timeout->ScriptCallbackParameters[i - 2] = arguments[i];
 	}
 
+	// Create a timer object to be inserted in our list of active timers
 	timeout->Timer = make_unique<timer<int>>(timeoutValue, 0, nullptr, false);
 	task_completion_event<void> tce;
 	timeout->Callback = make_unique<call<int>>([tce](int)
@@ -151,6 +154,7 @@ System::setTimeout(
 
 	int id = timeout->ID;
 
+	// Declare the code to be executed when the timer fires
 	timeout->Continuation->then([this, id]()
 	{
 		shared_ptr<Timeout> timeout;

--- a/HoloJS/HoloJsHost/System.h
+++ b/HoloJS/HoloJsHost/System.h
@@ -27,7 +27,11 @@ namespace HologramJS
 				int ID;
 			};
 
+			// Lock for the list of active timers
 			std::mutex m_timeoutsLock;
+			
+			// List of active timers
+			// On timer clear or timer firing, it is removed from this list
 			std::list<std::shared_ptr<Timeout>> m_timeouts;
 
 			JsValueRef m_setTimeoutFunction = JS_INVALID_REFERENCE;

--- a/HoloJS/HoloJsHost/System.h
+++ b/HoloJS/HoloJsHost/System.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <agents.h>
+
 namespace HologramJS
 {
 	namespace API
@@ -14,6 +16,20 @@ namespace HologramJS
 
 		private:
 
+			class Timeout
+			{
+			public:
+				std::unique_ptr<concurrency::timer<int>> Timer;
+				std::unique_ptr<concurrency::call<int>> Callback;
+				std::unique_ptr<concurrency::task<void>> Continuation;
+				JsValueRef ScriptCallback;
+				std::vector<JsValueRef> ScriptCallbackParameters;
+				int ID;
+			};
+
+			std::mutex m_timeoutsLock;
+			std::list<std::shared_ptr<Timeout>> m_timeouts;
+
 			JsValueRef m_setTimeoutFunction = JS_INVALID_REFERENCE;
 			static JsValueRef CHAKRA_CALLBACK setTimeoutStatic(
 				JsValueRef callee,
@@ -24,6 +40,18 @@ namespace HologramJS
 			)
 			{
 				return reinterpret_cast<System*>(callbackData)->setTimeout(callee, arguments, argumentCount);
+			}
+
+			JsValueRef m_clearTimeoutFunction = JS_INVALID_REFERENCE;
+			static JsValueRef CHAKRA_CALLBACK clearTimeoutStatic(
+				JsValueRef callee,
+				bool isConstructCall,
+				JsValueRef* arguments,
+				unsigned short argumentCount,
+				PVOID callbackData
+			)
+			{
+				return reinterpret_cast<System*>(callbackData)->clearTimeout(callee, arguments, argumentCount);
 			}
 
 			JsValueRef m_logFunction = JS_INVALID_REFERENCE;
@@ -39,6 +67,12 @@ namespace HologramJS
 			}
 
 			JsValueRef setTimeout(
+				JsValueRef callee,
+				JsValueRef* arguments,
+				unsigned short argumentCount
+			);
+
+			JsValueRef clearTimeout(
 				JsValueRef callee,
 				JsValueRef* arguments,
 				unsigned short argumentCount

--- a/HoloJS/HoloJsHost/XmlHttpRequest.cpp
+++ b/HoloJS/HoloJsHost/XmlHttpRequest.cpp
@@ -94,9 +94,10 @@ XmlHttpRequest::getHeader(
 	wstring header;
 	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[2], header));
 
-	if (xhr->m_responseHeaders->HasKey(Platform::StringReference(header.c_str())))
+	auto headerRef = Platform::StringReference(header.c_str());
+	if (xhr->m_responseHeaders->HasKey(headerRef))
 	{
-		auto valueRef = xhr->m_responseHeaders->Lookup(Platform::StringReference(header.c_str()));
+		auto valueRef = xhr->m_responseHeaders->Lookup(headerRef);
 		JsValueRef returnValue;
 		RETURN_INVALID_REF_IF_JS_ERROR(JsPointerToString(valueRef->Data(), valueRef->Length(), &returnValue));
 
@@ -119,7 +120,7 @@ XmlHttpRequest::sendXHR(
 	PVOID callbackData
 )
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
+	RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
 	auto xhr = ScriptResourceTracker::ExternalToObject<XmlHttpRequest>(arguments[1]);
 	RETURN_INVALID_REF_IF_NULL(xhr);
 

--- a/HoloJS/HoloJsHost/XmlHttpRequest.h
+++ b/HoloJS/HoloJsHost/XmlHttpRequest.h
@@ -29,6 +29,8 @@ namespace HologramJS
 
 			std::wstring m_url;
 			std::wstring m_method;
+			std::vector<std::pair<std::wstring, std::wstring>> m_requestHeaders;
+			Windows::Web::Http::Headers::HttpResponseHeaderCollection^ m_responseHeaders;
 			std::wstring m_responseType = L"";
 
 			std::wstring m_responseText;
@@ -80,6 +82,24 @@ namespace HologramJS
 
 			static JsValueRef m_getResponseFunction;
 			static JsValueRef CHAKRA_CALLBACK getResponse(
+				_In_ JsValueRef callee,
+				_In_ bool isConstructCall,
+				_In_ JsValueRef *arguments,
+				_In_ unsigned short argumentCount,
+				_In_ PVOID callbackData
+			);
+
+			static JsValueRef m_setHeaderFunction;
+			static JsValueRef CHAKRA_CALLBACK setHeader(
+				_In_ JsValueRef callee,
+				_In_ bool isConstructCall,
+				_In_ JsValueRef *arguments,
+				_In_ unsigned short argumentCount,
+				_In_ PVOID callbackData
+			);
+
+			static JsValueRef m_getHeaderFunction;
+			static JsValueRef CHAKRA_CALLBACK getHeader(
 				_In_ JsValueRef callee,
 				_In_ bool isConstructCall,
 				_In_ JsValueRef *arguments,


### PR DESCRIPTION
clearTimeout and some XHR methods were missing and prevented socket.io to work properly.

Catch exceptions in HttpClient::GetAsync; they become XHR errors and don't crash the host.