### PR TITLE
Run clang-format to normalize coding style

### DIFF
--- a/HoloJS/.clang-format
+++ b/HoloJS/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 120
+AlignAfterOpenBracket: Align
+BinPackParameters: false
+BinPackArguments: false
+BreakBeforeBraces: Custom
+BraceWrapping: 
+   AfterFunction:         true 

--- a/HoloJS/.clang-format
+++ b/HoloJS/.clang-format
@@ -7,3 +7,11 @@ BinPackArguments: false
 BreakBeforeBraces: Custom
 BraceWrapping: 
    AfterFunction:         true 
+
+IncludeCategories:
+  - Regex:           'pch.h'
+    Priority:        -1
+  - Regex:           'jsrt.h'
+    Priority:        5
+  - Regex:           'chakrart.h'
+    Priority:        6

--- a/HoloJS/HoloJS.sln
+++ b/HoloJS/HoloJS.sln
@@ -9,6 +9,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SampleApp", "SampleApp\Samp
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ThreeJSApp", "ThreeJSApp\ThreeJSApp.vcxproj", "{2EA1228F-38D2-481E-AF6E-87BAED33D906}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CADE011E-A37C-469C-8E6C-3185C156B108}"
+	ProjectSection(SolutionItems) = preProject
+		.clang-format = .clang-format
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86

--- a/HoloJS/HoloJsHost/ChakraForHoloJS.h
+++ b/HoloJS/HoloJsHost/ChakraForHoloJS.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <windows.h>
+
+// The Chakra headers in the SDK do not expose some functions for store apps, even
+// though they are documented as store compatible on MSDN. This header
+// fudges #defines to get access to those functions
+#define USE_EDGEMODE_JSRT
+#define CHAKRA_CALLBACK CALLBACK
+#define CHAKRA_API STDAPI_(JsErrorCode)
+typedef DWORD_PTR ChakraCookie;
+typedef BYTE* ChakraBytePtr;
+
+#include <jsrt.h>
+#include <chakrart.h>

--- a/HoloJS/HoloJsHost/ErrorHandling.h
+++ b/HoloJS/HoloJsHost/ErrorHandling.h
@@ -1,0 +1,24 @@
+#pragma once
+
+void Log(PCSTR file, int line);
+
+#define EXIT_IF_JS_ERROR(x) do { if ((x) != JsNoError) { Log(__FILE__, __LINE__); return; } } while (0, 0)
+#define EXIT_IF_FALSE(x) do { if ((x) == false) { Log(__FILE__, __LINE__); return; } } while (0, 0)
+#define EXIT_IF_TRUE(x) do { if ((x) == true) { Log(__FILE__, __LINE__); return; } } while (0, 0)
+#define EXIT_IF_FAILED(x) do { if (FAILED(x)) { Log(__FILE__, __LINE__); return; } } while (0, 0)
+#define RETURN_IF_JS_ERROR(x) do { if ((x) != JsNoError) { Log(__FILE__, __LINE__); return false; } } while (0, 0)
+#define RETURN_IF_FAILED(x) do { if (FAILED(x)) { Log(__FILE__, __LINE__); return false; } } while (0, 0)
+#define RETURN_NULL_IF_JS_ERROR(x) do { if ((x) != JsNoError) { Log(__FILE__, __LINE__); return nullptr; } } while (0, 0)
+#define RETURN_IF_FALSE(x) do { if ((x) == false) { Log(__FILE__, __LINE__); return false; } } while (0, 0)
+#define RETURN_IF_TRUE(x) do { if ((x) == true) { Log(__FILE__, __LINE__); return false; } } while (0, 0)
+#define RETURN_IF_NULL(x) do { if ((x) == nullptr) { Log(__FILE__, __LINE__); return false; } } while (0, 0)
+#define RETURN_NULL_IF_FALSE(x) do { if ((x) == false) { Log(__FILE__, __LINE__); return nullptr; } } while (0, 0)
+#define RETURN_NULL_IF_FAILED(x) do { if (FAILED(x)) { Log(__FILE__, __LINE__); return nullptr; } } while (0, 0)
+#define RETURN_INVALID_REF_IF_FALSE(x) do { if ((x) == false) { Log(__FILE__, __LINE__); return JS_INVALID_REFERENCE; } } while (0, 0)
+#define RETURN_INVALID_REF_IF_TRUE(x) do { if ((x) == true) { Log(__FILE__, __LINE__); return JS_INVALID_REFERENCE; } } while (0, 0)
+#define RETURN_INVALID_REF_IF_FAILED(x) do { if (FAILED(x)) { Log(__FILE__, __LINE__); return JS_INVALID_REFERENCE; } } while (0, 0)
+#define RETURN_INVALID_REF_IF_NULL(x) do { if ((x) == nullptr) { Log(__FILE__, __LINE__); return JS_INVALID_REFERENCE; } } while (0, 0)
+#define RETURN_INVALID_REF_IF_JS_ERROR(x) do { if ((x) != JsNoError) { Log(__FILE__, __LINE__); return JS_INVALID_REFERENCE; } } while (0, 0)
+
+#define HANDLE_EXCEPTION_IF_JS_ERROR(x) if ((x) != JsNoError) { HologramJS::ScriptErrorHandling::PrintException();}
+#define RETURN_ON_SCRIPT_ERROR(x) if ((x) != JsNoError) { HologramJS::ScriptErrorHandling::PrintException(); return false; }

--- a/HoloJS/HoloJsHost/ExternalObject.h
+++ b/HoloJS/HoloJsHost/ExternalObject.h
@@ -1,55 +1,56 @@
 #pragma once
 
-namespace HologramJS
-{
-	namespace Utilities
-	{
-		class ScriptResourceTracker;
-	}
-	namespace API
-	{
-		class ExternalObject
-		{
-		public:
-			ExternalObject() {}
+#include "IRelease.h"
+#include "ObjectEvents.h"
 
-			template<typename T> bool Initialize(T* object)
-			{
-				Utilities::IRelease* releaseInterface = dynamic_cast<Utilities::IRelease*>(object);
-
-				RETURN_IF_NULL(releaseInterface);
-
-				m_object = object;
-				m_objectEventsInterface = dynamic_cast<Utilities::ElementWithEvents*>(object);
-				m_releaseInterface = releaseInterface;
-
-				return true;
-			}
-
-			virtual ~ExternalObject()
-			{
-				if (m_releaseInterface)
-				{
-					delete m_releaseInterface;
-					m_object = nullptr;
-					m_releaseInterface = nullptr;
-					m_objectEventsInterface = nullptr;
-				}
-			}
-
-			PVOID Data() { return m_object; }
-			Utilities::ElementWithEvents* EventsInterface() { return m_objectEventsInterface; }
-
-			void SetResourceTracker(HologramJS::Utilities::ScriptResourceTracker* resourceTracker) { m_resourceTracker = resourceTracker; }
-			HologramJS::Utilities::ScriptResourceTracker* GetResourceTracker() { return m_resourceTracker; }
-
-		private:
-			PVOID m_object = nullptr;
-			Utilities::ElementWithEvents* m_objectEventsInterface = nullptr;
-			Utilities::IRelease* m_releaseInterface = nullptr;
-
-			HologramJS::Utilities::ScriptResourceTracker* m_resourceTracker;
-		};
-	}
+namespace HologramJS {
+namespace Utilities {
+class ScriptResourceTracker;
 }
+namespace API {
+class ExternalObject {
+   public:
+    ExternalObject() {}
 
+    template <typename T>
+    bool Initialize(T* object)
+    {
+        Utilities::IRelease* releaseInterface = dynamic_cast<Utilities::IRelease*>(object);
+
+        RETURN_IF_NULL(releaseInterface);
+
+        m_object = object;
+        m_objectEventsInterface = dynamic_cast<Utilities::ElementWithEvents*>(object);
+        m_releaseInterface = releaseInterface;
+
+        return true;
+    }
+
+    virtual ~ExternalObject()
+    {
+        if (m_releaseInterface) {
+            delete m_releaseInterface;
+            m_object = nullptr;
+            m_releaseInterface = nullptr;
+            m_objectEventsInterface = nullptr;
+        }
+    }
+
+    PVOID Data() { return m_object; }
+    Utilities::ElementWithEvents* EventsInterface() { return m_objectEventsInterface; }
+
+    void SetResourceTracker(HologramJS::Utilities::ScriptResourceTracker* resourceTracker)
+    {
+        m_resourceTracker = resourceTracker;
+    }
+    HologramJS::Utilities::ScriptResourceTracker* GetResourceTracker() { return m_resourceTracker; }
+
+   private:
+    PVOID m_object = nullptr;
+    Utilities::ElementWithEvents* m_objectEventsInterface = nullptr;
+    Utilities::IRelease* m_releaseInterface = nullptr;
+
+    HologramJS::Utilities::ScriptResourceTracker* m_resourceTracker;
+};
+}  // namespace API
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/FileSystemLoader.cpp
+++ b/HoloJS/HoloJsHost/FileSystemLoader.cpp
@@ -1,0 +1,114 @@
+#include "pch.h"
+#include "FileSystemLoader.h"
+
+using namespace concurrency;
+using namespace std;
+using namespace Windows::Web;
+using namespace Windows::Foundation;
+using namespace Windows::Storage;
+using namespace Windows::Data::Json;
+using namespace Windows::Storage::Streams;
+using namespace Windows::Web::Http;
+using namespace HologramJS::Loaders;
+
+FileSystemLoader::FileSystemLoader() {}
+
+FileSystemLoader::~FileSystemLoader() {}
+
+concurrency::task<IBuffer ^> FileSystemLoader::ReadBinaryFromFileAsync(StorageFolder ^ rootFolder, const wstring& path)
+{
+    auto mainPathElements = SplitPath(path);
+
+    if (mainPathElements.size() == 0) {
+        return nullptr;
+    }
+
+    auto fileName = mainPathElements.front();
+    mainPathElements.erase(mainPathElements.begin());
+
+    return await ReadBinaryFromFileAsync(rootFolder, mainPathElements, fileName);
+}
+
+concurrency::task<Platform::String ^> FileSystemLoader::ReadTextFromFileAsync(StorageFolder ^ rootFolder,
+                                                                              const wstring& path)
+{
+    auto mainPathElements = SplitPath(path);
+
+    if (mainPathElements.size() == 0) {
+        return nullptr;
+    }
+
+    auto fileName = mainPathElements.front();
+    mainPathElements.erase(mainPathElements.begin());
+
+    return await ReadTextFromFileAsync(rootFolder, mainPathElements, fileName);
+}
+
+task<Platform::String ^> FileSystemLoader::ReadTextFromFileAsync(StorageFolder ^ rootFolder,
+                                                                 list<std::wstring>& pathElements,
+                                                                 wstring& fileName)
+{
+    auto currentFolder = rootFolder;
+    for (const auto& folder : pathElements) {
+        currentFolder = await currentFolder->GetFolderAsync(Platform::StringReference(folder.c_str()));
+    }
+
+    auto file = await currentFolder->GetFileAsync(Platform::StringReference(fileName.c_str()));
+    return await FileIO::ReadTextAsync(file);
+}
+
+task<IBuffer ^> FileSystemLoader::ReadBinaryFromFileAsync(StorageFolder ^ rootFolder,
+                                                          const list<wstring>& pathElements,
+                                                          const wstring& fileName)
+{
+    auto currentFolder = rootFolder;
+    for (const auto& folder : pathElements) {
+        currentFolder = await currentFolder->GetFolderAsync(Platform::StringReference(folder.c_str()));
+    }
+
+    auto file = await currentFolder->GetFileAsync(Platform::StringReference(fileName.c_str()));
+    return await FileIO::ReadBufferAsync(file);
+}
+
+task<IRandomAccessStreamWithContentType ^> FileSystemLoader::GetStreamFromFileAsync(StorageFolder ^ rootFolder,
+                                                                                    const list<wstring>& pathElements,
+                                                                                    const wstring& fileName)
+{
+    auto currentFolder = rootFolder;
+    for (const auto& folder : pathElements) {
+        currentFolder = await currentFolder->GetFolderAsync(Platform::StringReference(folder.c_str()));
+    }
+
+    auto file = await currentFolder->GetFileAsync(Platform::StringReference(fileName.c_str()));
+    auto fileStream = await file->OpenReadAsync();
+    return fileStream;
+}
+
+list<wstring> FileSystemLoader::SplitPath(const std::wstring& path)
+{
+    list<wstring> pathElements;
+    if (path.empty()) {
+        return pathElements;
+    }
+
+    std::experimental::filesystem::path parsedPath(path);
+    auto fileName = parsedPath.filename();
+    auto subPath = parsedPath.parent_path();
+
+    while (!subPath.empty()) {
+        auto folderName = subPath.filename();
+        if (!folderName.empty() && (folderName.compare("\\") != 0) && (folderName.compare("/") != 0)) {
+            pathElements.push_back(folderName.c_str());
+        }
+
+        subPath = subPath.parent_path();
+    }
+
+    if (!fileName.empty()) {
+        pathElements.push_back(fileName.c_str());
+    }
+
+    pathElements.reverse();
+
+    return pathElements;
+}

--- a/HoloJS/HoloJsHost/FileSystemLoader.h
+++ b/HoloJS/HoloJsHost/FileSystemLoader.h
@@ -1,0 +1,38 @@
+#pragma once
+
+namespace HologramJS {
+namespace Loaders {
+class FileSystemLoader {
+   public:
+    FileSystemLoader();
+    ~FileSystemLoader();
+
+    static concurrency::task<Windows::Storage::Streams::IBuffer ^> ReadBinaryFromFileAsync(
+        Windows::Storage::StorageFolder ^ rootFolder, const std::wstring& path);
+
+    static concurrency::task<Platform::String ^> ReadTextFromFileAsync(Windows::Storage::StorageFolder ^ rootFolder,
+                                                                       const std::wstring& path);
+
+    static concurrency::task<Windows::Storage::Streams::IRandomAccessStreamWithContentType ^> GetStreamFromFileAsync(
+        Windows::Storage::StorageFolder ^ rootFolder, const std::wstring& path);
+
+   protected:
+    static concurrency::task<Windows::Storage::Streams::IBuffer ^> ReadBinaryFromFileAsync(
+        Windows::Storage::StorageFolder ^ rootFolder,
+        const std::list<std::wstring>& pathElements,
+        const std::wstring& fileName);
+
+    static concurrency::task<Platform::String ^> ReadTextFromFileAsync(Windows::Storage::StorageFolder ^ rootFolder,
+                                                                       std::list<std::wstring>& pathElements,
+                                                                       std::wstring& fileName);
+
+    static concurrency::task<Windows::Storage::Streams::IRandomAccessStreamWithContentType ^> GetStreamFromFileAsync(
+        Windows::Storage::StorageFolder ^ rootFolder,
+        const std::list<std::wstring>& pathElements,
+        const std::wstring& fileName);
+
+    static std::list<std::wstring> SplitPath(const std::wstring& path);
+};
+
+}  // namespace Loaders
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj
@@ -244,6 +244,7 @@
     <ClCompile Include="HologramJS.cpp" />
     <ClCompile Include="ImageElement.cpp" />
     <ClCompile Include="KeyboardInput.cpp" />
+    <ClCompile Include="Log.cpp" />
     <ClCompile Include="MouseInput.cpp" />
     <ClCompile Include="ObjectEvents.cpp" />
     <ClCompile Include="pch.cpp">

--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj
@@ -211,6 +211,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="ChakraForHoloJS.h" />
+    <ClInclude Include="ErrorHandling.h" />
     <ClInclude Include="ExternalObject.h" />
     <ClInclude Include="FileSystemLoader.h" />
     <ClInclude Include="HologramJS.h" />

--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj
@@ -212,6 +212,7 @@
   <ItemGroup>
     <ClInclude Include="ChakraForHoloJS.h" />
     <ClInclude Include="ExternalObject.h" />
+    <ClInclude Include="FileSystemLoader.h" />
     <ClInclude Include="HologramJS.h" />
     <ClInclude Include="IBufferOnMemory.h" />
     <ClInclude Include="ImageElement.h" />
@@ -234,10 +235,12 @@
     <ClInclude Include="WebGLObjects.h" />
     <ClInclude Include="WebGLProjections.h" />
     <ClInclude Include="WebGLRenderingContext.h" />
+    <ClInclude Include="WebLoader.h" />
     <ClInclude Include="WindowElement.h" />
     <ClInclude Include="XmlHttpRequest.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="FileSystemLoader.cpp" />
     <ClCompile Include="HologramJS.cpp" />
     <ClCompile Include="ImageElement.cpp" />
     <ClCompile Include="KeyboardInput.cpp" />
@@ -263,6 +266,7 @@
     <ClCompile Include="WebGLObjects.cpp" />
     <ClCompile Include="WebGLProjections.cpp" />
     <ClCompile Include="WebGLRenderingContext.cpp" />
+    <ClCompile Include="WebLoader.cpp" />
     <ClCompile Include="WindowElement.cpp" />
     <ClCompile Include="XmlHttpRequest.cpp" />
   </ItemGroup>

--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj
@@ -210,6 +210,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="ChakraForHoloJS.h" />
     <ClInclude Include="ExternalObject.h" />
     <ClInclude Include="HologramJS.h" />
     <ClInclude Include="IBufferOnMemory.h" />

--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
@@ -14,18 +14,6 @@
     <ClCompile Include="WindowElement.cpp">
       <Filter>Interface\NativeSide</Filter>
     </ClCompile>
-    <ClCompile Include="KeyboardInput.cpp">
-      <Filter>Runtime</Filter>
-    </ClCompile>
-    <ClCompile Include="MouseInput.cpp">
-      <Filter>Runtime</Filter>
-    </ClCompile>
-    <ClCompile Include="ScriptHostUtilities.cpp">
-      <Filter>Runtime</Filter>
-    </ClCompile>
-    <ClCompile Include="ScriptResourceTracker.cpp">
-      <Filter>Runtime</Filter>
-    </ClCompile>
     <ClCompile Include="System.cpp">
       <Filter>Runtime</Filter>
     </ClCompile>
@@ -37,12 +25,6 @@
     </ClCompile>
     <ClCompile Include="WebGLRenderingContext.cpp">
       <Filter>Render\WebGL</Filter>
-    </ClCompile>
-    <ClCompile Include="SpatialInput.cpp">
-      <Filter>Runtime</Filter>
-    </ClCompile>
-    <ClCompile Include="SpatialMapping.cpp">
-      <Filter>Runtime</Filter>
     </ClCompile>
     <ClCompile Include="Timers.cpp">
       <Filter>Runtime</Filter>
@@ -62,11 +44,29 @@
     <ClCompile Include="RenderingContext2D.cpp">
       <Filter>Render\2D</Filter>
     </ClCompile>
-    <ClCompile Include="Log.cpp">
-      <Filter>Runtime</Filter>
-    </ClCompile>
     <ClCompile Include="pch.cpp">
       <Filter>Include</Filter>
+    </ClCompile>
+    <ClCompile Include="KeyboardInput.cpp">
+      <Filter>Runtime\Input</Filter>
+    </ClCompile>
+    <ClCompile Include="MouseInput.cpp">
+      <Filter>Runtime\Input</Filter>
+    </ClCompile>
+    <ClCompile Include="SpatialInput.cpp">
+      <Filter>Runtime\Input</Filter>
+    </ClCompile>
+    <ClCompile Include="SpatialMapping.cpp">
+      <Filter>Runtime\SpatialMapping</Filter>
+    </ClCompile>
+    <ClCompile Include="ScriptHostUtilities.cpp">
+      <Filter>Runtime\Utilities</Filter>
+    </ClCompile>
+    <ClCompile Include="ScriptResourceTracker.cpp">
+      <Filter>Runtime\Utilities</Filter>
+    </ClCompile>
+    <ClCompile Include="Log.cpp">
+      <Filter>Runtime\Utilities</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -89,21 +89,6 @@
     <ClInclude Include="WindowElement.h">
       <Filter>Interface\NativeSide</Filter>
     </ClInclude>
-    <ClInclude Include="IBufferOnMemory.h">
-      <Filter>Runtime</Filter>
-    </ClInclude>
-    <ClInclude Include="KeyboardInput.h">
-      <Filter>Runtime</Filter>
-    </ClInclude>
-    <ClInclude Include="MouseInput.h">
-      <Filter>Runtime</Filter>
-    </ClInclude>
-    <ClInclude Include="ScriptHostUtilities.h">
-      <Filter>Runtime</Filter>
-    </ClInclude>
-    <ClInclude Include="ScriptResourceTracker.h">
-      <Filter>Runtime</Filter>
-    </ClInclude>
     <ClInclude Include="System.h">
       <Filter>Runtime</Filter>
     </ClInclude>
@@ -116,19 +101,7 @@
     <ClInclude Include="WebGLRenderingContext.h">
       <Filter>Render\WebGL</Filter>
     </ClInclude>
-    <ClInclude Include="SpatialInput.h">
-      <Filter>Runtime</Filter>
-    </ClInclude>
-    <ClInclude Include="InputInterface.h">
-      <Filter>Runtime</Filter>
-    </ClInclude>
-    <ClInclude Include="SpatialMapping.h">
-      <Filter>Runtime</Filter>
-    </ClInclude>
     <ClInclude Include="Timers.h">
-      <Filter>Runtime</Filter>
-    </ClInclude>
-    <ClInclude Include="ScriptErrorHandling.h">
       <Filter>Runtime</Filter>
     </ClInclude>
     <ClInclude Include="FileSystemLoader.h">
@@ -150,6 +123,36 @@
       <Filter>Include</Filter>
     </ClInclude>
     <ClInclude Include="pch.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="InputInterface.h">
+      <Filter>Runtime\Input</Filter>
+    </ClInclude>
+    <ClInclude Include="KeyboardInput.h">
+      <Filter>Runtime\Input</Filter>
+    </ClInclude>
+    <ClInclude Include="MouseInput.h">
+      <Filter>Runtime\Input</Filter>
+    </ClInclude>
+    <ClInclude Include="SpatialInput.h">
+      <Filter>Runtime\Input</Filter>
+    </ClInclude>
+    <ClInclude Include="SpatialMapping.h">
+      <Filter>Runtime\SpatialMapping</Filter>
+    </ClInclude>
+    <ClInclude Include="ScriptHostUtilities.h">
+      <Filter>Runtime\Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="ScriptResourceTracker.h">
+      <Filter>Runtime\Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="IBufferOnMemory.h">
+      <Filter>Runtime\Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="ScriptErrorHandling.h">
+      <Filter>Runtime\Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="ErrorHandling.h">
       <Filter>Include</Filter>
     </ClInclude>
   </ItemGroup>
@@ -210,6 +213,15 @@
     </Filter>
     <Filter Include="Include">
       <UniqueIdentifier>{82ea3f82-1b16-4a7c-9189-23fe78dfb89c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Runtime\Input">
+      <UniqueIdentifier>{fb800fd0-c592-4b83-b601-5e0efc78b70f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Runtime\SpatialMapping">
+      <UniqueIdentifier>{902dfde1-6a39-4994-9054-e00c0c633532}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Runtime\Utilities">
+      <UniqueIdentifier>{96031bc1-c829-4b84-b8ce-446cd05f9f38}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
@@ -53,6 +53,12 @@
     <ClCompile Include="Timers.cpp">
       <Filter>NativeFramework</Filter>
     </ClCompile>
+    <ClCompile Include="FileSystemLoader.cpp">
+      <Filter>Loaders</Filter>
+    </ClCompile>
+    <ClCompile Include="WebLoader.cpp">
+      <Filter>Loaders</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="HologramJS.h" />
@@ -123,6 +129,12 @@
       <Filter>NativeFramework</Filter>
     </ClInclude>
     <ClInclude Include="ChakraForHoloJS.h" />
+    <ClInclude Include="FileSystemLoader.h">
+      <Filter>Loaders</Filter>
+    </ClInclude>
+    <ClInclude Include="WebLoader.h">
+      <Filter>Loaders</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -164,6 +176,9 @@
     </Filter>
     <Filter Include="API">
       <UniqueIdentifier>{29f9bcec-9229-4ad7-9d4d-31ffc9c331e8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Loaders">
+      <UniqueIdentifier>{10eafaf8-e776-40d8-9013-018f503650ef}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
@@ -2,56 +2,50 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="HologramJS.cpp" />
-    <ClCompile Include="ObjectEvents.cpp" />
-    <ClCompile Include="pch.cpp" />
-    <ClCompile Include="ScriptsLoader.cpp" />
     <ClCompile Include="ImageElement.cpp">
-      <Filter>API</Filter>
+      <Filter>Interface\NativeSide</Filter>
     </ClCompile>
     <ClCompile Include="VideoElement.cpp">
-      <Filter>API</Filter>
+      <Filter>Interface\NativeSide</Filter>
     </ClCompile>
     <ClCompile Include="XmlHttpRequest.cpp">
-      <Filter>API</Filter>
+      <Filter>Interface\NativeSide</Filter>
     </ClCompile>
     <ClCompile Include="WindowElement.cpp">
-      <Filter>API</Filter>
+      <Filter>Interface\NativeSide</Filter>
     </ClCompile>
     <ClCompile Include="KeyboardInput.cpp">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClCompile>
     <ClCompile Include="MouseInput.cpp">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClCompile>
     <ClCompile Include="ScriptHostUtilities.cpp">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClCompile>
     <ClCompile Include="ScriptResourceTracker.cpp">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClCompile>
     <ClCompile Include="System.cpp">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClCompile>
     <ClCompile Include="WebGLObjects.cpp">
-      <Filter>WebGLRenderer</Filter>
+      <Filter>Render\WebGL</Filter>
     </ClCompile>
     <ClCompile Include="WebGLProjections.cpp">
-      <Filter>WebGLRenderer</Filter>
+      <Filter>Render\WebGL</Filter>
     </ClCompile>
     <ClCompile Include="WebGLRenderingContext.cpp">
-      <Filter>WebGLRenderer</Filter>
-    </ClCompile>
-    <ClCompile Include="RenderingContext2D.cpp">
-      <Filter>WebGLRenderer</Filter>
+      <Filter>Render\WebGL</Filter>
     </ClCompile>
     <ClCompile Include="SpatialInput.cpp">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClCompile>
     <ClCompile Include="SpatialMapping.cpp">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClCompile>
     <ClCompile Include="Timers.cpp">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClCompile>
     <ClCompile Include="FileSystemLoader.cpp">
       <Filter>Loaders</Filter>
@@ -59,126 +53,163 @@
     <ClCompile Include="WebLoader.cpp">
       <Filter>Loaders</Filter>
     </ClCompile>
+    <ClCompile Include="ScriptsLoader.cpp">
+      <Filter>Loaders</Filter>
+    </ClCompile>
+    <ClCompile Include="ObjectEvents.cpp">
+      <Filter>Interface\NativeSide</Filter>
+    </ClCompile>
+    <ClCompile Include="RenderingContext2D.cpp">
+      <Filter>Render\2D</Filter>
+    </ClCompile>
+    <ClCompile Include="Log.cpp">
+      <Filter>Runtime</Filter>
+    </ClCompile>
+    <ClCompile Include="pch.cpp">
+      <Filter>Include</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="HologramJS.h" />
-    <ClInclude Include="ObjectEvents.h" />
-    <ClInclude Include="pch.h" />
-    <ClInclude Include="ScriptsLoader.h" />
     <ClInclude Include="ExternalObject.h">
-      <Filter>API</Filter>
+      <Filter>Interface\NativeSide</Filter>
     </ClInclude>
     <ClInclude Include="ImageElement.h">
-      <Filter>API</Filter>
+      <Filter>Interface\NativeSide</Filter>
     </ClInclude>
     <ClInclude Include="VideoElement.h">
-      <Filter>API</Filter>
+      <Filter>Interface\NativeSide</Filter>
     </ClInclude>
     <ClInclude Include="IRelease.h">
-      <Filter>API</Filter>
+      <Filter>Interface\NativeSide</Filter>
     </ClInclude>
     <ClInclude Include="XmlHttpRequest.h">
-      <Filter>API</Filter>
+      <Filter>Interface\NativeSide</Filter>
     </ClInclude>
     <ClInclude Include="WindowElement.h">
-      <Filter>API</Filter>
+      <Filter>Interface\NativeSide</Filter>
     </ClInclude>
     <ClInclude Include="IBufferOnMemory.h">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClInclude>
     <ClInclude Include="KeyboardInput.h">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClInclude>
     <ClInclude Include="MouseInput.h">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClInclude>
     <ClInclude Include="ScriptHostUtilities.h">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClInclude>
     <ClInclude Include="ScriptResourceTracker.h">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClInclude>
     <ClInclude Include="System.h">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClInclude>
     <ClInclude Include="WebGLObjects.h">
-      <Filter>WebGLRenderer</Filter>
+      <Filter>Render\WebGL</Filter>
     </ClInclude>
     <ClInclude Include="WebGLProjections.h">
-      <Filter>WebGLRenderer</Filter>
+      <Filter>Render\WebGL</Filter>
     </ClInclude>
     <ClInclude Include="WebGLRenderingContext.h">
-      <Filter>WebGLRenderer</Filter>
-    </ClInclude>
-    <ClInclude Include="RenderingContext2D.h">
-      <Filter>WebGLRenderer</Filter>
+      <Filter>Render\WebGL</Filter>
     </ClInclude>
     <ClInclude Include="SpatialInput.h">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClInclude>
     <ClInclude Include="InputInterface.h">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClInclude>
     <ClInclude Include="SpatialMapping.h">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClInclude>
     <ClInclude Include="Timers.h">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClInclude>
     <ClInclude Include="ScriptErrorHandling.h">
-      <Filter>NativeFramework</Filter>
+      <Filter>Runtime</Filter>
     </ClInclude>
-    <ClInclude Include="ChakraForHoloJS.h" />
     <ClInclude Include="FileSystemLoader.h">
       <Filter>Loaders</Filter>
     </ClInclude>
     <ClInclude Include="WebLoader.h">
       <Filter>Loaders</Filter>
     </ClInclude>
+    <ClInclude Include="ScriptsLoader.h">
+      <Filter>Loaders</Filter>
+    </ClInclude>
+    <ClInclude Include="ObjectEvents.h">
+      <Filter>Interface\NativeSide</Filter>
+    </ClInclude>
+    <ClInclude Include="RenderingContext2D.h">
+      <Filter>Render\2D</Filter>
+    </ClInclude>
+    <ClInclude Include="ChakraForHoloJS.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="pch.h">
+      <Filter>Include</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="ScriptingFramework\framework.json" />
     <None Include="ScriptingFramework\Canvas2D.js">
-      <Filter>ScriptingFramework</Filter>
+      <Filter>Interface\ScriptSide</Filter>
     </None>
     <None Include="ScriptingFramework\DOM.js">
-      <Filter>ScriptingFramework</Filter>
+      <Filter>Interface\ScriptSide</Filter>
     </None>
     <None Include="ScriptingFramework\FrameworkHelpers.js">
-      <Filter>ScriptingFramework</Filter>
+      <Filter>Interface\ScriptSide</Filter>
     </None>
     <None Include="ScriptingFramework\Image.js">
-      <Filter>ScriptingFramework</Filter>
+      <Filter>Interface\ScriptSide</Filter>
     </None>
     <None Include="ScriptingFramework\Video.js">
-      <Filter>ScriptingFramework</Filter>
+      <Filter>Interface\ScriptSide</Filter>
     </None>
     <None Include="ScriptingFramework\WebGL.js">
-      <Filter>ScriptingFramework</Filter>
+      <Filter>Interface\ScriptSide</Filter>
     </None>
     <None Include="ScriptingFramework\Window.js">
-      <Filter>ScriptingFramework</Filter>
+      <Filter>Interface\ScriptSide</Filter>
     </None>
     <None Include="ScriptingFramework\XmlHttpRequest.js">
-      <Filter>ScriptingFramework</Filter>
+      <Filter>Interface\ScriptSide</Filter>
+    </None>
+    <None Include="ScriptingFramework\framework.json">
+      <Filter>Interface\ScriptSide</Filter>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Filter Include="ScriptingFramework">
-      <UniqueIdentifier>{f96e322c-e22c-4eb9-9ed5-adff6ecffd1b}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="WebGLRenderer">
-      <UniqueIdentifier>{bf596f6d-a613-42c0-a055-a4899212936f}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="NativeFramework">
-      <UniqueIdentifier>{1882b52c-8128-4f39-a2b0-be06e72f40b5}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="API">
-      <UniqueIdentifier>{29f9bcec-9229-4ad7-9d4d-31ffc9c331e8}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Loaders">
       <UniqueIdentifier>{10eafaf8-e776-40d8-9013-018f503650ef}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Interface">
+      <UniqueIdentifier>{5be2926f-3d04-43bb-8b3d-af90c7d44525}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Interface\NativeSide">
+      <UniqueIdentifier>{29f9bcec-9229-4ad7-9d4d-31ffc9c331e8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Interface\ScriptSide">
+      <UniqueIdentifier>{f96e322c-e22c-4eb9-9ed5-adff6ecffd1b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Runtime">
+      <UniqueIdentifier>{1882b52c-8128-4f39-a2b0-be06e72f40b5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Render">
+      <UniqueIdentifier>{878e2265-02b2-4ed6-9f59-6dfe77855486}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Render\WebGL">
+      <UniqueIdentifier>{bf596f6d-a613-42c0-a055-a4899212936f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Render\2D">
+      <UniqueIdentifier>{7892b7c7-0129-427f-936d-ab155042c5d3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Include">
+      <UniqueIdentifier>{82ea3f82-1b16-4a7c-9189-23fe78dfb89c}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj.filters
@@ -122,6 +122,7 @@
     <ClInclude Include="ScriptErrorHandling.h">
       <Filter>NativeFramework</Filter>
     </ClInclude>
+    <ClInclude Include="ChakraForHoloJS.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/HoloJS/HoloJsHost/HologramJS.cpp
+++ b/HoloJS/HoloJsHost/HologramJS.cpp
@@ -70,12 +70,12 @@ IAsyncOperation<bool> ^ HologramScriptHost::RunLocalScriptAppAsync(Platform::Str
 task<bool> HologramScriptHost::RunLocalScriptApp(wstring jsonFilePath)
 {
     unique_ptr<HologramJS::ScriptsLoader> loader(new ScriptsLoader());
-    auto loadResult = await loader->LoadScripts(Package::Current->InstalledLocation,
+    auto loadResult = await loader->LoadScriptsAsync(Package::Current->InstalledLocation,
                                                 L"hologramjs\\scriptingframework\\framework.json");
 
     if (loadResult) {
         loadResult =
-            await loader->LoadScripts(Package::Current->InstalledLocation, jsonFilePath);
+            await loader->LoadScriptsAsync(Package::Current->InstalledLocation, jsonFilePath);
     }
 
     if (loadResult) {
@@ -105,11 +105,11 @@ task<bool> HologramScriptHost::RunWebScriptApp(wstring jsonUri)
 {
     unique_ptr<HologramJS::ScriptsLoader> loader(new HologramJS::ScriptsLoader());
     wstring jsonUriString = jsonUri;
-    auto loadResult = await loader->LoadScripts(Package::Current->InstalledLocation,
+    auto loadResult = await loader->LoadScriptsAsync(Package::Current->InstalledLocation,
                                                 L"hologramjs\\scriptingframework\\framework.json");
 
     if (loadResult) {
-        loadResult = await loader->DownloadScripts(jsonUriString);
+        loadResult = await loader->DownloadScriptsAsync(jsonUriString);
     }
 
     if (loadResult) {

--- a/HoloJS/HoloJsHost/HologramJS.cpp
+++ b/HoloJS/HoloJsHost/HologramJS.cpp
@@ -1,11 +1,12 @@
 ﻿#include "pch.h"
-#include "XmlHttpRequest.h"
-#include "VideoElement.h"
-#include "ImageElement.h"
-#include "System.h"
-#include "ScriptsLoader.h"
 #include "HologramJS.h"
+#include "ImageElement.h"
+#include "ScriptsLoader.h"
+#include "System.h"
+#include "VideoElement.h"
 #include "WebGLProjections.h"
+#include "XmlHttpRequest.h"
+#include "ScriptHostUtilities.h"
 
 using namespace HologramJS;
 using namespace Platform;
@@ -13,172 +14,143 @@ using namespace concurrency;
 using namespace Windows::Foundation;
 using namespace std;
 using namespace Windows::Perception::Spatial;
+using namespace Windows::ApplicationModel;
 
-HologramScriptHost::HologramScriptHost()
+HologramScriptHost::HologramScriptHost() {}
+
+HologramScriptHost::~HologramScriptHost() { Shutdown(); }
+
+void HologramScriptHost::Shutdown()
 {
+    m_window.Close();
+
+    if (m_jsContext != nullptr) {
+        JsSetCurrentContext(nullptr);
+        m_jsContext = nullptr;
+    }
+
+    if (m_jsRuntime != nullptr) {
+        JsDisposeRuntime(m_jsRuntime);
+        m_jsRuntime = nullptr;
+    }
 }
 
-HologramScriptHost::~HologramScriptHost()
+bool HologramScriptHost::Initialize()
 {
-	Shutdown();
+    RETURN_IF_JS_ERROR(JsCreateRuntime(JsRuntimeAttributeNone, nullptr, &m_jsRuntime));
+    RETURN_IF_JS_ERROR(JsCreateContext(m_jsRuntime, &m_jsContext));
+
+    RETURN_IF_JS_ERROR(JsSetCurrentContext(m_jsContext));
+
+    JsStartDebugging();
+
+    RETURN_IF_FALSE(m_scriptEventsManager.Initialize());
+
+    RETURN_IF_FALSE(API::XmlHttpRequest::Initialize());
+
+    RETURN_IF_FALSE(API::ImageElement::Initialize());
+    RETURN_IF_FALSE(API::VideoElement::Initialize());
+
+    RETURN_IF_FALSE(WebGL::WebGLProjections::Initialize());
+
+    RETURN_IF_FALSE(m_window.Initialize());
+
+    RETURN_IF_FALSE(m_system.Initialize());
+
+    RETURN_IF_FALSE(m_timers.Initialize());
+
+    return true;
 }
 
-void
-HologramScriptHost::Shutdown()
+IAsyncOperation<bool> ^ HologramScriptHost::RunLocalScriptAppAsync(Platform::String ^ jsonFilePath)
 {
-	m_window.Close();
-
-	if (m_jsContext != nullptr)
-	{
-		JsSetCurrentContext(nullptr);
-		m_jsContext = nullptr;
-	}
-
-	if (m_jsRuntime != nullptr)
-	{
-		JsDisposeRuntime(m_jsRuntime);
-		m_jsRuntime = nullptr;
-	}
+    return create_async([this, jsonFilePath]() -> task<bool> { return RunLocalScriptApp(jsonFilePath->Data()); });
 }
 
-bool
-HologramScriptHost::Initialize()
+task<bool> HologramScriptHost::RunLocalScriptApp(wstring jsonFilePath)
 {
-	RETURN_IF_JS_ERROR(JsCreateRuntime(JsRuntimeAttributeNone, nullptr, &m_jsRuntime));
-	RETURN_IF_JS_ERROR(JsCreateContext(m_jsRuntime, &m_jsContext));
+    unique_ptr<HologramJS::ScriptsLoader> loader(new ScriptsLoader());
+    auto loadResult = await loader->LoadScripts(Package::Current->InstalledLocation,
+                                                L"hologramjs\\scriptingframework\\framework.json");
 
-	RETURN_IF_JS_ERROR(JsSetCurrentContext(m_jsContext));
+    if (loadResult) {
+        loadResult =
+            await loader->LoadScripts(Package::Current->InstalledLocation, jsonFilePath);
+    }
 
-	JsStartDebugging();
+    if (loadResult) {
+        API::XmlHttpRequest::UseFileSystem = true;
+        API::ImageElement::UseFileSystem = true;
+        API::VideoElement::UseFileSystem = true;
 
-	RETURN_IF_FALSE(m_scriptEventsManager.Initialize());
+        const wstring basePath = ScriptsLoader::GetFileSystemBasePathForJsonPath(jsonFilePath);
+        API::XmlHttpRequest::BasePath = basePath;
+        API::ImageElement::BasePath = basePath;
+        API::VideoElement::BasePath = basePath;
 
-	RETURN_IF_FALSE(API::XmlHttpRequest::Initialize());
+        m_window.SetBaseUrl(basePath);
 
-	RETURN_IF_FALSE(API::ImageElement::Initialize());
-	RETURN_IF_FALSE(API::VideoElement::Initialize());
+        loader->ExecuteScripts();
+    }
 
-	RETURN_IF_FALSE(WebGL::WebGLProjections::Initialize());
-
-	RETURN_IF_FALSE(m_window.Initialize());
-
-	RETURN_IF_FALSE(m_system.Initialize());
-
-	RETURN_IF_FALSE(m_timers.Initialize());
-
-	return true;
+    return true;
 }
 
-IAsyncOperation<bool>^
-HologramScriptHost::RunLocalScriptAppAsync(
-	Platform::String^ jsonFilePath
-	)
+IAsyncOperation<bool> ^ HologramScriptHost::RunWebScriptAppAsync(Platform::String ^ jsonUri)
 {
-	return create_async([this, jsonFilePath]() -> task<bool>
-	{
-		return RunLocalScriptApp(jsonFilePath->Data());
-	});
+    return create_async([this, jsonUri]() -> task<bool> { return RunWebScriptApp(jsonUri->Data()); });
 }
 
-task<bool>
-HologramScriptHost::RunLocalScriptApp(
-	wstring jsonFilePath
-)
+task<bool> HologramScriptHost::RunWebScriptApp(wstring jsonUri)
 {
-	unique_ptr<HologramJS::ScriptsLoader> loader(new HologramJS::ScriptsLoader());
-	auto loadResult = await loader->LoadScripts(Windows::ApplicationModel::Package::Current->InstalledLocation, L"hologramjs\\scriptingframework\\framework.json");
+    unique_ptr<HologramJS::ScriptsLoader> loader(new HologramJS::ScriptsLoader());
+    wstring jsonUriString = jsonUri;
+    auto loadResult = await loader->LoadScripts(Package::Current->InstalledLocation,
+                                                L"hologramjs\\scriptingframework\\framework.json");
 
-	if (loadResult)
-	{
-		loadResult = await loader->LoadScripts(Windows::ApplicationModel::Package::Current->InstalledLocation, jsonFilePath);
-	}
+    if (loadResult) {
+        loadResult = await loader->DownloadScripts(jsonUriString);
+    }
 
-	if (loadResult)
-	{
-		API::XmlHttpRequest::UseFileSystem = true;
-		API::ImageElement::UseFileSystem = true;
-		API::VideoElement::UseFileSystem = true;
+    if (loadResult) {
+        API::XmlHttpRequest::UseFileSystem = false;
+        API::ImageElement::UseFileSystem = false;
+        API::VideoElement::UseFileSystem = false;
 
-		const wstring basePath = ScriptsLoader::GetFileSystemBasePathForJsonPath(jsonFilePath);
-		API::XmlHttpRequest::BasePath = basePath;
-		API::ImageElement::BasePath = basePath;
-		API::VideoElement::BasePath = basePath;
+        // Build base path without the .json file name it in
+        wstring basePath = ScriptsLoader::GetBaseUriForJsonUri(jsonUriString);
 
-		m_window.SetBaseUrl(basePath);
+        m_window.SetBaseUrl(basePath);
 
-		loader->ExecuteScripts();
-	}
+        API::XmlHttpRequest::BaseUrl.assign(basePath);
+        API::ImageElement::BaseUrl.assign(basePath);
+        API::VideoElement::BaseUrl.assign(basePath);
 
-	return true;
+        loader->ExecuteScripts();
+    }
+
+    return true;
 }
 
-IAsyncOperation<bool>^
-HologramScriptHost::RunWebScriptAppAsync(
-	Platform::String^ jsonUri
-	)
+bool HologramScriptHost::EnableHolographicExperimental(SpatialStationaryFrameOfReference ^ frameOfReference)
 {
-	return create_async([this, jsonUri]() -> task<bool>
-	{
-		return RunWebScriptApp(jsonUri->Data());
-	});
-}
+    // Get the global object
+    JsValueRef globalObject;
 
-task<bool>
-HologramScriptHost::RunWebScriptApp(
-	wstring jsonUri
-)
-{
-	unique_ptr<HologramJS::ScriptsLoader> loader(new HologramJS::ScriptsLoader());
-	wstring jsonUriString = jsonUri;
-	auto loadResult = await loader->LoadScripts(Windows::ApplicationModel::Package::Current->InstalledLocation, L"hologramjs\\scriptingframework\\framework.json");
+    RETURN_IF_JS_ERROR(JsGetGlobalObject(&globalObject));
 
-	if (loadResult)
-	{
-		loadResult = await loader->DownloadScripts(jsonUriString);
-	}
+    // Create or get global.nativeInterface
+    JsValueRef windowRef;
+    RETURN_IF_FALSE(Utilities::ScriptHostUtilities::GetJsProperty(globalObject, L"window", &windowRef));
 
-	if (loadResult)
-	{
-		API::XmlHttpRequest::UseFileSystem = false;
-		API::ImageElement::UseFileSystem = false;
-		API::VideoElement::UseFileSystem = false;
+    JsPropertyIdRef holographicPropertyId;
+    RETURN_IF_JS_ERROR(JsGetPropertyIdFromName(L"experimentalHolographic", &holographicPropertyId));
+    JsValueRef holographicValue;
+    RETURN_IF_JS_ERROR(JsBoolToBoolean(true, &holographicValue));
 
-		// Build base path without the .json file name it in
-		wstring basePath = ScriptsLoader::GetBaseUriForJsonUri(jsonUriString);
+    RETURN_IF_JS_ERROR(JsSetProperty(windowRef, holographicPropertyId, holographicValue, true));
 
-		m_window.SetBaseUrl(basePath);
+    m_window.SetStationaryFrameOfReference(frameOfReference);
 
-		API::XmlHttpRequest::BaseUrl.assign(basePath);
-		API::ImageElement::BaseUrl.assign(basePath);
-		API::VideoElement::BaseUrl.assign(basePath);
-
-		loader->ExecuteScripts();
-
-	}
-
-	return true;
-}
-
-bool
-HologramScriptHost::EnableHolographicExperimental(SpatialStationaryFrameOfReference^ frameOfReference)
-{
-	// Get the global object
-	JsValueRef globalObject;
-
-	RETURN_IF_JS_ERROR(JsGetGlobalObject(&globalObject));
-
-	// Create or get global.nativeInterface
-	JsValueRef windowRef;
-	RETURN_IF_FALSE(Utilities::ScriptHostUtilities::GetJsProperty(globalObject, L"window", &windowRef));
-
-	JsPropertyIdRef holographicPropertyId;
-	RETURN_IF_JS_ERROR(JsGetPropertyIdFromName(L"experimentalHolographic", &holographicPropertyId));
-	JsValueRef holographicValue;
-	RETURN_IF_JS_ERROR(JsBoolToBoolean(true, &holographicValue));
-
-	RETURN_IF_JS_ERROR(JsSetProperty(windowRef, holographicPropertyId, holographicValue, true));
-
-	m_window.SetStationaryFrameOfReference(frameOfReference);
-
-	return true;
+    return true;
 }

--- a/HoloJS/HoloJsHost/HologramJS.h
+++ b/HoloJS/HoloJsHost/HologramJS.h
@@ -1,40 +1,41 @@
 ﻿#pragma once
 
-#include "Timers.h"
 #include "System.h"
+#include "Timers.h"
 #include "WindowElement.h"
+#include "ObjectEvents.h"
+#include "ChakraForHoloJS.h"
+#include <ppltasks.h>
 
-namespace HologramJS
-{
-	[Windows::Foundation::Metadata::WebHostHidden]
-	public ref class HologramScriptHost sealed
-	{
-	public:
-		HologramScriptHost();
+namespace HologramJS {
+[Windows::Foundation::Metadata::WebHostHidden] public ref class HologramScriptHost sealed {
+   public:
+    HologramScriptHost();
 
-		virtual ~HologramScriptHost();
+    virtual ~HologramScriptHost();
 
-		bool Initialize();
-		void Shutdown();
+    bool Initialize();
+    void Shutdown();
 
-		bool EnableHolographicExperimental(Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ frameOfReference);
+    bool EnableHolographicExperimental(Windows::Perception::Spatial::SpatialStationaryFrameOfReference ^
+                                       frameOfReference);
 
-		Windows::Foundation::IAsyncOperation<bool>^ RunLocalScriptAppAsync(Platform::String^ jsonFilePath);
-		Windows::Foundation::IAsyncOperation<bool>^ RunWebScriptAppAsync(Platform::String^ jsonUri);
+    Windows::Foundation::IAsyncOperation<bool> ^ RunLocalScriptAppAsync(Platform::String ^ jsonFilePath);
+    Windows::Foundation::IAsyncOperation<bool> ^ RunWebScriptAppAsync(Platform::String ^ jsonUri);
 
-		void ResizeWindow(int width, int height) { m_window.Resize(width, height); }
-		void VSync(Windows::Foundation::Numerics::float4x4 viewMatrix) { m_window.VSync(viewMatrix); }
+    void ResizeWindow(int width, int height) { m_window.Resize(width, height); }
+    void VSync(Windows::Foundation::Numerics::float4x4 viewMatrix) { m_window.VSync(viewMatrix); }
 
-	private:
-		JsRuntimeHandle m_jsRuntime = nullptr;
-		JsContextRef m_jsContext = nullptr;
+   private:
+    JsRuntimeHandle m_jsRuntime = nullptr;
+    JsContextRef m_jsContext = nullptr;
 
-		concurrency::task<bool> RunLocalScriptApp(std::wstring jsonFilePath);
-		concurrency::task<bool> RunWebScriptApp(std::wstring jsonFilePath);
+    concurrency::task<bool> RunLocalScriptApp(std::wstring jsonFilePath);
+    concurrency::task<bool> RunWebScriptApp(std::wstring jsonFilePath);
 
-		API::WindowElement m_window;
-		API::System m_system;
-		API::Timers m_timers;
-		Utilities::EventsManager m_scriptEventsManager;
-	};
-}
+    API::WindowElement m_window;
+    API::System m_system;
+    API::Timers m_timers;
+    Utilities::EventsManager m_scriptEventsManager;
+};
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/IBufferOnMemory.h
+++ b/HoloJS/HoloJsHost/IBufferOnMemory.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <windows.storage.streams.h>
+
 namespace HologramJS
 {
 	namespace Utilities

--- a/HoloJS/HoloJsHost/IRelease.h
+++ b/HoloJS/HoloJsHost/IRelease.h
@@ -1,15 +1,12 @@
 #pragma once
 
-namespace HologramJS
-{
-	namespace Utilities
-	{
-		class IRelease
-		{
-		public:
-			virtual void Release() = 0;
+namespace HologramJS {
+namespace Utilities {
+class IRelease {
+   public:
+    virtual void Release() = 0;
 
-			virtual ~IRelease() {}
-		};
-	}
-}
+    virtual ~IRelease() {}
+};
+}  // namespace Utilities
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/ImageElement.cpp
+++ b/HoloJS/HoloJsHost/ImageElement.cpp
@@ -1,6 +1,9 @@
 #include "pch.h"
 #include "ScriptsLoader.h"
 #include "ImageElement.h"
+#include "ExternalObject.h"
+#include "ScriptHostUtilities.h"
+#include "ScriptResourceTracker.h"
 
 using namespace HologramJS::Utilities;
 using namespace HologramJS::API;

--- a/HoloJS/HoloJsHost/ImageElement.cpp
+++ b/HoloJS/HoloJsHost/ImageElement.cpp
@@ -1,9 +1,9 @@
 #include "pch.h"
-#include "ScriptsLoader.h"
 #include "ImageElement.h"
 #include "ExternalObject.h"
 #include "ScriptHostUtilities.h"
 #include "ScriptResourceTracker.h"
+#include "ScriptsLoader.h"
 
 using namespace HologramJS::Utilities;
 using namespace HologramJS::API;
@@ -19,260 +19,191 @@ JsValueRef ImageElement::m_setImageSourceFunction = JS_INVALID_REFERENCE;
 JsValueRef ImageElement::m_setImageSourceFromBlobFunction = JS_INVALID_REFERENCE;
 JsValueRef ImageElement::m_getImageDataFunction = JS_INVALID_REFERENCE;
 
+ImageElement::ImageElement() {}
 
-ImageElement::ImageElement()
+ImageElement::~ImageElement() {}
+
+bool ImageElement::Initialize()
 {
+    RETURN_IF_FALSE(
+        ScriptHostUtilities::ProjectFunction(L"createImage", L"image", createImage, nullptr, &m_createImageFunction));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(
+        L"setImageSource", L"image", setImageSource, nullptr, &m_setImageSourceFunction));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(
+        L"setImageSourceFromBlob", L"image", setImageSourceFromBlob, nullptr, &m_setImageSourceFromBlobFunction));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(
+        L"getImageData", L"image", getImageData, nullptr, &m_getImageDataFunction));
+
+    return true;
 }
 
-
-ImageElement::~ImageElement()
+_Use_decl_annotations_ JsValueRef CHAKRA_CALLBACK ImageElement::createImage(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
+    ExternalObject* externalObject = new ExternalObject();
+    RETURN_INVALID_REF_IF_FALSE(externalObject->Initialize(new ImageElement()));
+    return ScriptResourceTracker::ObjectToDirectExternal(externalObject);
 }
 
-bool
-ImageElement::Initialize()
+_Use_decl_annotations_ JsValueRef CHAKRA_CALLBACK ImageElement::setImageSource(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createImage", L"image", createImage, nullptr, &m_createImageFunction));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"setImageSource", L"image", setImageSource, nullptr, &m_setImageSourceFunction));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"setImageSourceFromBlob", L"image", setImageSourceFromBlob, nullptr, &m_setImageSourceFromBlobFunction));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getImageData", L"image", getImageData, nullptr, &m_getImageDataFunction));
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+    auto image = ScriptResourceTracker::ExternalToObject<ImageElement>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(image);
 
-	return true;
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[2], image->m_source));
+
+    image->LoadAsync();
+
+    return JS_INVALID_REFERENCE;
 }
 
-_Use_decl_annotations_
-JsValueRef
-CHAKRA_CALLBACK
-ImageElement::createImage(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef *arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+_Use_decl_annotations_ JsValueRef CHAKRA_CALLBACK ImageElement::setImageSourceFromBlob(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	ExternalObject* externalObject = new ExternalObject();
-	RETURN_INVALID_REF_IF_FALSE(externalObject->Initialize(new ImageElement()));
-	return ScriptResourceTracker::ObjectToDirectExternal(externalObject);
+    return JS_INVALID_REFERENCE;
 }
 
-_Use_decl_annotations_
-JsValueRef
-CHAKRA_CALLBACK
-ImageElement::setImageSource(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef *arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+_Use_decl_annotations_ JsValueRef CHAKRA_CALLBACK ImageElement::getImageData(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-	auto image = ScriptResourceTracker::ExternalToObject<ImageElement>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(image);
-
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[2], image->m_source));
-
-	image->LoadAsync();
-
-	return JS_INVALID_REFERENCE;
+    return JS_INVALID_REFERENCE;
 }
 
-_Use_decl_annotations_
-JsValueRef
-CHAKRA_CALLBACK
-ImageElement::setImageSourceFromBlob(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef *arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+void ImageElement::LoadAsync()
 {
-	return JS_INVALID_REFERENCE;
+    if ((_wcsnicmp(m_source.c_str(), L"http://", wcslen(L"http://")) == 0) ||
+        (_wcsnicmp(m_source.c_str(), L"https://", wcslen(L"https://")) == 0) || !UseFileSystem) {
+        DownloadAsync();
+    } else {
+        ReadFromPackageAsync();
+    }
 }
 
-_Use_decl_annotations_
-JsValueRef
-CHAKRA_CALLBACK
-ImageElement::getImageData(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef *arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+task<void> ImageElement::ReadFromPackageAsync()
 {
-	return JS_INVALID_REFERENCE;
+    wstring completePath = BasePath + m_source;
+
+    auto imageBuffer = await HologramJS::Loaders::FileSystemLoader::ReadBinaryFromFileAsync(
+        Windows::ApplicationModel::Package::Current->InstalledLocation, completePath);
+
+    LoadImageFromBuffer(imageBuffer);
 }
 
-void
-ImageElement::LoadAsync()
+task<void> ImageElement::DownloadAsync()
 {
-	if ((_wcsnicmp(m_source.c_str(), L"http://", wcslen(L"http://")) == 0)
-		|| (_wcsnicmp(m_source.c_str(), L"https://", wcslen(L"https://")) == 0)
-		|| !UseFileSystem)
-	{
-		DownloadAsync();
-	}
-	else
-	{
-		ReadFromPackageAsync();
-	}
+    Windows::Foundation::Uri ^ uri;
+
+    if ((_wcsnicmp(m_source.c_str(), L"http://", wcslen(L"http://")) == 0) ||
+        (_wcsnicmp(m_source.c_str(), L"https://", wcslen(L"https://")) == 0)) {
+        uri = ref new Windows::Foundation::Uri(Platform::StringReference(m_source.c_str()));
+    } else {
+        wstring completeUrl = BaseUrl + L"/" + m_source;
+        uri = ref new Windows::Foundation::Uri(Platform::StringReference(completeUrl.c_str()));
+    }
+
+    Windows::Web::Http::HttpClient ^ httpClient = ref new Windows::Web::Http::HttpClient();
+
+    auto responseMessage = await httpClient->GetAsync(uri);
+    if (responseMessage->IsSuccessStatusCode) {
+        Windows::Storage::Streams::IBuffer ^ responseBuffer = await responseMessage->Content->ReadAsBufferAsync();
+        LoadImageFromBuffer(responseBuffer);
+    }
+
+    return;
 }
 
-task<void>
-ImageElement::ReadFromPackageAsync()
+void ImageElement::LoadImageFromBuffer(Windows::Storage::Streams::IBuffer ^ imageBuffer)
 {
-	wstring completePath = BasePath + m_source;
-	auto mainPathElements = HologramJS::ScriptsLoader::SplitPath(completePath);
+    Microsoft::WRL::ComPtr<IWICImagingFactory> factory;
+    EXIT_IF_FAILED(
+        CoCreateInstance(CLSID_WICImagingFactory, NULL, CLSCTX_INPROC_SERVER, IID_IWICImagingFactory, &factory));
 
-	if (mainPathElements.size() == 0)
-	{
-		return;
-	}
+    EXIT_IF_FAILED(factory->CreateStream(&m_imageStream));
 
-	auto fileName = mainPathElements.front();
-	mainPathElements.erase(mainPathElements.begin());
+    Microsoft::WRL::ComPtr<Windows::Storage::Streams::IBufferByteAccess> bufferByteAccess;
+    EXIT_IF_FAILED(reinterpret_cast<IInspectable*>(imageBuffer)->QueryInterface(IID_PPV_ARGS(&bufferByteAccess)));
 
-	auto imageBuffer = await HologramJS::ScriptsLoader::ReadBinaryFromFile(
-		Windows::ApplicationModel::Package::Current->InstalledLocation,
-		mainPathElements,
-		fileName);
+    byte* imageNativeBuffer;
+    EXIT_IF_FAILED(bufferByteAccess->Buffer(&imageNativeBuffer));
 
-	LoadImageFromBuffer(imageBuffer);
+    EXIT_IF_FAILED(m_imageStream->InitializeFromMemory(imageNativeBuffer, imageBuffer->Length));
+
+    EXIT_IF_FAILED(
+        factory->CreateDecoderFromStream(m_imageStream.Get(), nullptr, WICDecodeMetadataCacheOnDemand, &m_decoder));
+
+    unsigned int frameCount;
+    EXIT_IF_FAILED(m_decoder->GetFrameCount(&frameCount));
+    EXIT_IF_FALSE(frameCount > 0);
+
+    Microsoft::WRL::ComPtr<IWICBitmapFrameDecode> bitmapFrameDecode;
+
+    EXIT_IF_FAILED(m_decoder->GetFrame(0, &bitmapFrameDecode));
+
+    Microsoft::WRL::ComPtr<IWICBitmapSource> source;
+    EXIT_IF_FAILED(bitmapFrameDecode.As(&source));
+
+    EXIT_IF_FAILED(source->GetSize(&m_width, &m_height));
+
+    WICPixelFormatGUID pixelFormat;
+    EXIT_IF_FAILED(source->GetPixelFormat(&pixelFormat));
+
+    Microsoft::WRL::ComPtr<IWICBitmapSource> converter;
+    if (!IsEqualGUID(pixelFormat, GUID_WICPixelFormat32bppRGBA)) {
+        EXIT_IF_FAILED(WICConvertBitmapSource(GUID_WICPixelFormat32bppRGBA, source.Get(), &converter));
+        EXIT_IF_FAILED(converter.As(&m_bitmapSource));
+    }
+
+    EXIT_IF_FAILED(factory->CreateBitmapFromSource(m_bitmapSource.Get(), WICBitmapNoCache, &m_bitmap));
+
+    FireOnLoadEvent();
 }
 
-task<void>
-ImageElement::DownloadAsync()
+void ImageElement::FireOnLoadEvent()
 {
-	Windows::Foundation::Uri^ uri;
+    if (HasCallback()) {
+        vector<JsValueRef> parameters(3);
 
-	if ((_wcsnicmp(m_source.c_str(), L"http://", wcslen(L"http://")) == 0)
-		|| (_wcsnicmp(m_source.c_str(), L"https://", wcslen(L"https://")) == 0))
-	{
-		uri = ref new Windows::Foundation::Uri(Platform::StringReference(m_source.c_str()));
-	}
-	else
-	{
-		wstring completeUrl = BaseUrl + L"/" + m_source;
-		uri = ref new Windows::Foundation::Uri(Platform::StringReference(completeUrl.c_str()));
-	}
+        JsValueRef* typeParam = &parameters[0];
+        EXIT_IF_JS_ERROR(JsPointerToString(L"load", wcslen(L"load"), typeParam));
 
-	Windows::Web::Http::HttpClient^ httpClient = ref new  Windows::Web::Http::HttpClient();
+        JsValueRef* widthParam = &parameters[1];
+        EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(m_width), widthParam));
 
-	auto responseMessage = await httpClient->GetAsync(uri);
-	if (responseMessage->IsSuccessStatusCode)
-	{
-		Windows::Storage::Streams::IBuffer^ responseBuffer = await responseMessage->Content->ReadAsBufferAsync();
-		LoadImageFromBuffer(responseBuffer);
-	}
+        JsValueRef* heightParam = &parameters[2];
+        EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(m_height), heightParam));
 
-	return;
+        (void)InvokeCallback(parameters);
+    }
 }
 
-void
-ImageElement::LoadImageFromBuffer(
-	Windows::Storage::Streams::IBuffer^ imageBuffer
-)
+bool ImageElement::GetPixelsPointer(WICInProcPointer* pixels, unsigned int* pixelsSize, unsigned int* stride)
 {
-	Microsoft::WRL::ComPtr<IWICImagingFactory> factory;
-	EXIT_IF_FAILED(
-		CoCreateInstance(
-			CLSID_WICImagingFactory,
-			NULL,
-			CLSCTX_INPROC_SERVER,
-			IID_IWICImagingFactory,
-			&factory));
+    if (!m_bitmapLock) {
+        WICRect allBitmapRect;
+        allBitmapRect.X = 0;
+        allBitmapRect.Y = 0;
+        allBitmapRect.Width = m_width;
+        allBitmapRect.Height = m_height;
+        RETURN_IF_FAILED(m_bitmap->Lock(&allBitmapRect, WICBitmapLockRead, &m_bitmapLock));
 
-	EXIT_IF_FAILED(factory->CreateStream(&m_imageStream));
+        WICInProcPointer localPixels;
+        unsigned int localPixelsSize;
+        unsigned int localStride;
 
-	Microsoft::WRL::ComPtr<Windows::Storage::Streams::IBufferByteAccess> bufferByteAccess;
-	EXIT_IF_FAILED(reinterpret_cast<IInspectable*>(imageBuffer)->QueryInterface(IID_PPV_ARGS(&bufferByteAccess)));
+        RETURN_IF_FAILED(m_bitmapLock->GetStride(&localStride));
 
-	byte* imageNativeBuffer;
-	EXIT_IF_FAILED(bufferByteAccess->Buffer(&imageNativeBuffer));
+        RETURN_IF_FAILED(m_bitmapLock->GetDataPointer(&localPixelsSize, &localPixels));
 
-	EXIT_IF_FAILED(m_imageStream->InitializeFromMemory(imageNativeBuffer, imageBuffer->Length));
+        *pixels = localPixels;
+        *pixelsSize = localPixelsSize;
+        *stride = localStride;
+    } else {
+        *pixels = m_pixels;
+        *pixelsSize = m_pixelsSize;
+        *stride = m_stride;
+    }
 
-	EXIT_IF_FAILED(factory->CreateDecoderFromStream(m_imageStream.Get(), nullptr, WICDecodeMetadataCacheOnDemand, &m_decoder));
-
-	unsigned int frameCount;
-	EXIT_IF_FAILED(m_decoder->GetFrameCount(&frameCount));
-	EXIT_IF_FALSE(frameCount > 0);
-
-	Microsoft::WRL::ComPtr<IWICBitmapFrameDecode> bitmapFrameDecode;
-
-	EXIT_IF_FAILED(m_decoder->GetFrame(0, &bitmapFrameDecode));
-
-	Microsoft::WRL::ComPtr<IWICBitmapSource> source;
-	EXIT_IF_FAILED(bitmapFrameDecode.As(&source));
-
-	EXIT_IF_FAILED(source->GetSize(&m_width, &m_height));
-
-	WICPixelFormatGUID pixelFormat;
-	EXIT_IF_FAILED(source->GetPixelFormat(&pixelFormat));
-
-	Microsoft::WRL::ComPtr<IWICBitmapSource> converter;
-	if (!IsEqualGUID(pixelFormat, GUID_WICPixelFormat32bppRGBA))
-	{
-		EXIT_IF_FAILED(WICConvertBitmapSource(GUID_WICPixelFormat32bppRGBA, source.Get(), &converter));
-		EXIT_IF_FAILED(converter.As(&m_bitmapSource));
-	}
-
-	EXIT_IF_FAILED(factory->CreateBitmapFromSource(m_bitmapSource.Get(), WICBitmapNoCache, &m_bitmap));
-
-	FireOnLoadEvent();
-}
-
-void
-ImageElement::FireOnLoadEvent()
-{
-	if (HasCallback())
-	{
-		vector<JsValueRef> parameters(3);
-
-		JsValueRef* typeParam = &parameters[0];
-		EXIT_IF_JS_ERROR(JsPointerToString(L"load", wcslen(L"load"), typeParam));
-		
-		JsValueRef* widthParam= &parameters[1];
-		EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(m_width), widthParam));
-
-		JsValueRef* heightParam = &parameters[2];
-		EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(m_height), heightParam));
-
-		(void)InvokeCallback(parameters);
-	}
-}
-
-bool
-ImageElement::GetPixelsPointer(WICInProcPointer* pixels, unsigned int* pixelsSize, unsigned int* stride)
-{
-	if (!m_bitmapLock)
-	{
-		WICRect allBitmapRect;
-		allBitmapRect.X = 0; allBitmapRect.Y = 0; allBitmapRect.Width = m_width; allBitmapRect.Height = m_height;
-		RETURN_IF_FAILED(m_bitmap->Lock(&allBitmapRect, WICBitmapLockRead, &m_bitmapLock));
-
-		WICInProcPointer localPixels;
-		unsigned int localPixelsSize;
-		unsigned int localStride;
-
-		RETURN_IF_FAILED(m_bitmapLock->GetStride(&localStride));
-
-		RETURN_IF_FAILED(m_bitmapLock->GetDataPointer(&localPixelsSize, &localPixels));
-
-		*pixels = localPixels;
-		*pixelsSize = localPixelsSize;
-		*stride = localStride;
-	}
-	else
-	{
-		*pixels = m_pixels;
-		*pixelsSize = m_pixelsSize;
-		*stride = m_stride;
-	}
-	
-	return true;
-	
+    return true;
 }

--- a/HoloJS/HoloJsHost/ImageElement.h
+++ b/HoloJS/HoloJsHost/ImageElement.h
@@ -1,4 +1,9 @@
 #pragma once
+
+#include "IRelease.h"
+#include "ChakraForHoloJS.h"
+#include "ObjectEvents.h"
+
 namespace HologramJS
 {
 	namespace API

--- a/HoloJS/HoloJsHost/InputInterface.h
+++ b/HoloJS/HoloJsHost/InputInterface.h
@@ -1,38 +1,16 @@
 #pragma once
 
-namespace HologramJS
-{
-	namespace Input
-	{
-		// the mapping of events to values is fixed on the script side;
-		// any changes here must be ported to window.js as well
-		enum class NativeToScriptInputType : int {
-			Resize = 0,
-			Mouse,
-			Keyboard,
-			SpatialInput,
-			SpatialMapping
-		};
+namespace HologramJS {
+namespace Input {
+// the mapping of events to values is fixed on the script side;
+// any changes here must be ported to window.js as well
+enum class NativeToScriptInputType : int { Resize = 0, Mouse, Keyboard, SpatialInput, SpatialMapping };
 
-		enum class KeyboardInputEventType : int {
-			KeyDown = 0,
-			KeyUp
-		};
+enum class KeyboardInputEventType : int { KeyDown = 0, KeyUp };
 
-		enum class MouseInputEventType : int {
-			MouseUp = 0,
-			MouseDown,
-			MouseMove,
-			MouseWheel
-		};
+enum class MouseInputEventType : int { MouseUp = 0, MouseDown, MouseMove, MouseWheel };
 
-		enum class SpatialInputEventType : int {
-			Pressed = 0,
-			Released,
-			Lost,
-			Detected,
-			Update
-		};
+enum class SpatialInputEventType : int { Pressed = 0, Released, Lost, Detected, Update };
 
-	}
-}
+}  // namespace Input
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/KeyboardInput.cpp
+++ b/HoloJS/HoloJsHost/KeyboardInput.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "KeyboardInput.h"
+#include "ScriptErrorHandling.h"
 
 using namespace HologramJS::Input;
 using namespace Windows::UI::Core;

--- a/HoloJS/HoloJsHost/KeyboardInput.h
+++ b/HoloJS/HoloJsHost/KeyboardInput.h
@@ -1,29 +1,24 @@
 #pragma once
+#include "ChakraForHoloJS.h"
 #include "InputInterface.h"
-namespace HologramJS
-{
-	namespace Input
-	{
-		class KeyboardInput
-		{
-		public:
-			KeyboardInput();
-			~KeyboardInput();
 
-			void SetScriptCallback(JsValueRef scriptCallback) { m_scriptCallback = scriptCallback; }
+namespace HologramJS {
+namespace Input {
+class KeyboardInput {
+   public:
+    KeyboardInput();
+    ~KeyboardInput();
 
-		private:
-			JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
+    void SetScriptCallback(JsValueRef scriptCallback) { m_scriptCallback = scriptCallback; }
 
-			void CallbackScriptForKeyboardInput(
-				KeyboardInputEventType type,
-				Windows::UI::Core::KeyEventArgs^ args
-			);
+   private:
+    JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
 
-			Windows::Foundation::EventRegistrationToken m_keyDownToken;
-			Windows::Foundation::EventRegistrationToken m_keyUpToken;
-		};
+    void CallbackScriptForKeyboardInput(KeyboardInputEventType type, Windows::UI::Core::KeyEventArgs ^ args);
 
-	}
-}
+    Windows::Foundation::EventRegistrationToken m_keyDownToken;
+    Windows::Foundation::EventRegistrationToken m_keyUpToken;
+};
 
+}  // namespace Input
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/Log.cpp
+++ b/HoloJS/HoloJsHost/Log.cpp
@@ -1,0 +1,11 @@
+#include "pch.h"
+
+void Log(PCSTR file, int line)
+{
+    std::string completeOutput = "Failure in file ";
+    completeOutput += file;
+    completeOutput += ", line ";
+    completeOutput += std::to_string(line);
+    completeOutput += "\r\n";
+    OutputDebugStringA(completeOutput.c_str());
+}

--- a/HoloJS/HoloJsHost/MouseInput.cpp
+++ b/HoloJS/HoloJsHost/MouseInput.cpp
@@ -1,108 +1,94 @@
 #include "pch.h"
 #include "MouseInput.h"
+#include "ScriptErrorHandling.h"
 
 using namespace HologramJS::Input;
 using namespace Windows::UI::Core;
 using namespace std;
 using namespace Windows::Foundation;
 
-enum class MouseButtons : int
-{
-	NoButton = 0,
-	LeftButton = 1,
-	RightButton = 2,
-	MiddleButton = 4
-};
+enum class MouseButtons : int { NoButton = 0, LeftButton = 1, RightButton = 2, MiddleButton = 4 };
 
-inline MouseButtons &
-operator|=(MouseButtons & __x, MouseButtons __y)
+inline MouseButtons& operator|=(MouseButtons& __x, MouseButtons __y)
 {
-	__x = static_cast<MouseButtons>(static_cast<int>(__x) | static_cast<int>(__y));
-	return __x;
+    __x = static_cast<MouseButtons>(static_cast<int>(__x) | static_cast<int>(__y));
+    return __x;
 }
 
 MouseInput::MouseInput()
 {
-	m_mouseDownToken = CoreWindow::GetForCurrentThread()->PointerPressed += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(
-		[this](CoreWindow ^sender, PointerEventArgs ^args)
-	{
-		this->CallbackScriptForMouseInput(MouseInputEventType::MouseDown, args);
-	});
+    m_mouseDownToken = CoreWindow::GetForCurrentThread()->PointerPressed +=
+        ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(
+            [this](CoreWindow ^ sender, PointerEventArgs ^ args) {
+                this->CallbackScriptForMouseInput(MouseInputEventType::MouseDown, args);
+            });
 
-	m_mouseUpToken = CoreWindow::GetForCurrentThread()->PointerReleased += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(
-		[this](CoreWindow ^sender, PointerEventArgs ^args)
-	{
-		this->CallbackScriptForMouseInput(MouseInputEventType::MouseUp, args);
-	});
+    m_mouseUpToken = CoreWindow::GetForCurrentThread()->PointerReleased +=
+        ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(
+            [this](CoreWindow ^ sender, PointerEventArgs ^ args) {
+                this->CallbackScriptForMouseInput(MouseInputEventType::MouseUp, args);
+            });
 
-	m_mouseWheelToken = CoreWindow::GetForCurrentThread()->PointerWheelChanged += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(
-		[this](CoreWindow ^sender, PointerEventArgs ^args)
-	{
-		this->CallbackScriptForMouseInput(MouseInputEventType::MouseWheel, args);
-	});
+    m_mouseWheelToken = CoreWindow::GetForCurrentThread()->PointerWheelChanged +=
+        ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(
+            [this](CoreWindow ^ sender, PointerEventArgs ^ args) {
+                this->CallbackScriptForMouseInput(MouseInputEventType::MouseWheel, args);
+            });
 
-	m_mouseMoveToken = CoreWindow::GetForCurrentThread()->PointerMoved += ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(
-		[this](CoreWindow ^sender, PointerEventArgs ^args)
-	{
-		this->CallbackScriptForMouseInput(MouseInputEventType::MouseMove, args);
-	});
+    m_mouseMoveToken = CoreWindow::GetForCurrentThread()->PointerMoved +=
+        ref new TypedEventHandler<CoreWindow ^, PointerEventArgs ^>(
+            [this](CoreWindow ^ sender, PointerEventArgs ^ args) {
+                this->CallbackScriptForMouseInput(MouseInputEventType::MouseMove, args);
+            });
 }
-
 
 MouseInput::~MouseInput()
 {
-	CoreWindow::GetForCurrentThread()->PointerPressed -= m_mouseDownToken;
-	CoreWindow::GetForCurrentThread()->PointerReleased -= m_mouseUpToken;
-	CoreWindow::GetForCurrentThread()->PointerWheelChanged -= m_mouseWheelToken;
-	CoreWindow::GetForCurrentThread()->PointerMoved -= m_mouseMoveToken;
+    CoreWindow::GetForCurrentThread()->PointerPressed -= m_mouseDownToken;
+    CoreWindow::GetForCurrentThread()->PointerReleased -= m_mouseUpToken;
+    CoreWindow::GetForCurrentThread()->PointerWheelChanged -= m_mouseWheelToken;
+    CoreWindow::GetForCurrentThread()->PointerMoved -= m_mouseMoveToken;
 }
 
-MouseButtons GetButtonFromArgs(PointerEventArgs^ args)
+MouseButtons GetButtonFromArgs(PointerEventArgs ^ args)
 {
-	auto returnValue = MouseButtons::NoButton;
+    auto returnValue = MouseButtons::NoButton;
 
-	const auto pointProps = args->CurrentPoint->Properties;
+    const auto pointProps = args->CurrentPoint->Properties;
 
-	if (pointProps->IsLeftButtonPressed)
-	{
-		returnValue |= MouseButtons::LeftButton;
-	}
+    if (pointProps->IsLeftButtonPressed) {
+        returnValue |= MouseButtons::LeftButton;
+    }
 
-	if (pointProps->IsMiddleButtonPressed)
-	{
-		returnValue |= MouseButtons::MiddleButton;
-	}
+    if (pointProps->IsMiddleButtonPressed) {
+        returnValue |= MouseButtons::MiddleButton;
+    }
 
-	if (pointProps->IsRightButtonPressed)
-	{
-		returnValue |= MouseButtons::RightButton;
-	}
+    if (pointProps->IsRightButtonPressed) {
+        returnValue |= MouseButtons::RightButton;
+    }
 
-	return returnValue;
+    return returnValue;
 }
 
-void
-MouseInput::CallbackScriptForMouseInput(
-	MouseInputEventType type,
-	Windows::UI::Core::PointerEventArgs^ args
-)
+void MouseInput::CallbackScriptForMouseInput(MouseInputEventType type, Windows::UI::Core::PointerEventArgs ^ args)
 {
-	EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
+    EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
 
-	JsValueRef parameters[6];
-	parameters[0] = m_scriptCallback;
-	JsValueRef* eventTypeParam = &parameters[1];
-	JsValueRef* xParam = &parameters[2];
-	JsValueRef* yParam = &parameters[3];
-	JsValueRef* buttonParam = &parameters[4];
-	JsValueRef* actionParam = &parameters[5];
+    JsValueRef parameters[6];
+    parameters[0] = m_scriptCallback;
+    JsValueRef* eventTypeParam = &parameters[1];
+    JsValueRef* xParam = &parameters[2];
+    JsValueRef* yParam = &parameters[3];
+    JsValueRef* buttonParam = &parameters[4];
+    JsValueRef* actionParam = &parameters[5];
 
-	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::Mouse), eventTypeParam));
-	EXIT_IF_JS_ERROR(JsDoubleToNumber(args->CurrentPoint->Position.X, xParam));
-	EXIT_IF_JS_ERROR(JsDoubleToNumber(args->CurrentPoint->Position.Y, yParam));
-	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(GetButtonFromArgs(args)), buttonParam));
-	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(type), actionParam));
+    EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::Mouse), eventTypeParam));
+    EXIT_IF_JS_ERROR(JsDoubleToNumber(args->CurrentPoint->Position.X, xParam));
+    EXIT_IF_JS_ERROR(JsDoubleToNumber(args->CurrentPoint->Position.Y, yParam));
+    EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(GetButtonFromArgs(args)), buttonParam));
+    EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(type), actionParam));
 
-	JsValueRef result;
-	HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
+    JsValueRef result;
+    HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
 }

--- a/HoloJS/HoloJsHost/MouseInput.h
+++ b/HoloJS/HoloJsHost/MouseInput.h
@@ -1,32 +1,25 @@
 #pragma once
+#include "ChakraForHoloJS.h"
 #include "InputInterface.h"
 
-namespace HologramJS
-{
-	namespace Input
-	{
-		class MouseInput
-		{
-		public:
-			MouseInput();
-			~MouseInput();
+namespace HologramJS {
+namespace Input {
+class MouseInput {
+   public:
+    MouseInput();
+    ~MouseInput();
 
-			void SetScriptCallback(JsValueRef scriptCallback) { m_scriptCallback = scriptCallback; }
+    void SetScriptCallback(JsValueRef scriptCallback) { m_scriptCallback = scriptCallback; }
 
-		private:
-			JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
+   private:
+    JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
 
-			void CallbackScriptForMouseInput(
-				MouseInputEventType type,
-				Windows::UI::Core::PointerEventArgs^ args
-			);
+    void CallbackScriptForMouseInput(MouseInputEventType type, Windows::UI::Core::PointerEventArgs ^ args);
 
-			Windows::Foundation::EventRegistrationToken m_mouseDownToken;
-			Windows::Foundation::EventRegistrationToken m_mouseUpToken;
-			Windows::Foundation::EventRegistrationToken m_mouseWheelToken;
-			Windows::Foundation::EventRegistrationToken m_mouseMoveToken;
-		};
-	}
-}
-
-
+    Windows::Foundation::EventRegistrationToken m_mouseDownToken;
+    Windows::Foundation::EventRegistrationToken m_mouseUpToken;
+    Windows::Foundation::EventRegistrationToken m_mouseWheelToken;
+    Windows::Foundation::EventRegistrationToken m_mouseMoveToken;
+};
+}  // namespace Input
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/ObjectEvents.cpp
+++ b/HoloJS/HoloJsHost/ObjectEvents.cpp
@@ -1,61 +1,52 @@
 #include "pch.h"
 #include "ObjectEvents.h"
+#include "ScriptHostUtilities.h"
+#include "ScriptResourceTracker.h"
 
 using namespace HologramJS::Utilities;
 
-EventsManager::EventsManager()
+EventsManager::EventsManager() {}
+
+EventsManager::~EventsManager() {}
+
+bool EventsManager::Initialize()
 {
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(
+        L"setCallback", L"eventing", setCallback, nullptr, &m_setCallbackFunction));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(
+        L"removeCallback", L"eventing", removeCallback, nullptr, &m_removeCallbackFunction));
+
+    return true;
 }
 
-EventsManager::~EventsManager()
+JsValueRef CHAKRA_CALLBACK EventsManager::setCallback(_In_ JsValueRef callee,
+                                                      _In_ bool isConstructCall,
+                                                      _In_ JsValueRef* arguments,
+                                                      _In_ unsigned short argumentCount,
+                                                      _In_ PVOID callbackData)
 {
+    RETURN_IF_FALSE(argumentCount == 3);
+
+    ElementWithEvents* element = ScriptResourceTracker::ExternalToEventsInterface(arguments[1]);
+    RETURN_IF_NULL(element);
+
+    RETURN_IF_FALSE(element->SetCallback(arguments[2], callee));
+
+    return JS_INVALID_REFERENCE;
 }
 
-bool
-EventsManager::Initialize()
+JsValueRef CHAKRA_CALLBACK EventsManager::removeCallback(_In_ JsValueRef callee,
+                                                         _In_ bool isConstructCall,
+                                                         _In_ JsValueRef* arguments,
+                                                         _In_ unsigned short argumentCount,
+                                                         _In_ PVOID callbackData)
 {
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"setCallback", L"eventing", setCallback, nullptr, &m_setCallbackFunction));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"removeCallback", L"eventing", removeCallback, nullptr, &m_removeCallbackFunction));
+    RETURN_IF_FALSE(argumentCount == 2);
 
-	return true;
-}
+    ElementWithEvents* element = ScriptResourceTracker::ExternalToEventsInterface(arguments[1]);
+    RETURN_IF_NULL(element);
 
-JsValueRef
-CHAKRA_CALLBACK
-EventsManager::setCallback(
-	_In_ JsValueRef callee,
-	_In_ bool isConstructCall,
-	_In_ JsValueRef *arguments,
-	_In_ unsigned short argumentCount,
-	_In_ PVOID callbackData
-)
-{
-	RETURN_IF_FALSE(argumentCount == 3);
+    element->ReleaseCallback();
 
-	ElementWithEvents* element = ScriptResourceTracker::ExternalToEventsInterface(arguments[1]);
-	RETURN_IF_NULL(element);
-
-	RETURN_IF_FALSE(element->SetCallback(arguments[2], callee));
-
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-EventsManager::removeCallback(
-	_In_ JsValueRef callee,
-	_In_ bool isConstructCall,
-	_In_ JsValueRef *arguments,
-	_In_ unsigned short argumentCount,
-	_In_ PVOID callbackData
-)
-{
-	RETURN_IF_FALSE(argumentCount == 2);
-
-	ElementWithEvents* element = ScriptResourceTracker::ExternalToEventsInterface(arguments[1]);
-	RETURN_IF_NULL(element);
-
-	element->ReleaseCallback();
-
-	return nullptr;
+    return nullptr;
 }

--- a/HoloJS/HoloJsHost/ObjectEvents.h
+++ b/HoloJS/HoloJsHost/ObjectEvents.h
@@ -1,91 +1,79 @@
 #pragma once
 
-namespace HologramJS
-{
-	namespace Utilities
-	{
-		class ElementWithEvents
-		{
-		public:
+#include "ScriptErrorHandling.h"
 
-			bool SetCallback(JsValueRef scriptCallback, JsValueRef scriptCallbackContext)
-			{
-				if (m_scriptCallback == JS_INVALID_REFERENCE)
-				{
-					m_scriptCallback = scriptCallback;
-					m_scriptCallbackContext = scriptCallbackContext;
+namespace HologramJS {
+namespace Utilities {
+class ElementWithEvents {
+   public:
+    bool SetCallback(JsValueRef scriptCallback, JsValueRef scriptCallbackContext)
+    {
+        if (m_scriptCallback == JS_INVALID_REFERENCE) {
+            m_scriptCallback = scriptCallback;
+            m_scriptCallbackContext = scriptCallbackContext;
 
-					unsigned int refCount;
-					RETURN_IF_JS_ERROR(JsAddRef(m_scriptCallback, &refCount));
-					RETURN_IF_JS_ERROR(JsAddRef(m_scriptCallbackContext, &refCount));
-				}
+            unsigned int refCount;
+            RETURN_IF_JS_ERROR(JsAddRef(m_scriptCallback, &refCount));
+            RETURN_IF_JS_ERROR(JsAddRef(m_scriptCallbackContext, &refCount));
+        }
 
-				return true;
-			}
+        return true;
+    }
 
-			void ReleaseCallback()
-			{
-				if (m_scriptCallback != JS_INVALID_REFERENCE)
-				{
-					unsigned int refCount;
-					JsRelease(m_scriptCallback, &refCount);
-					m_scriptCallback = JS_INVALID_REFERENCE;
-				}
+    void ReleaseCallback()
+    {
+        if (m_scriptCallback != JS_INVALID_REFERENCE) {
+            unsigned int refCount;
+            JsRelease(m_scriptCallback, &refCount);
+            m_scriptCallback = JS_INVALID_REFERENCE;
+        }
 
-				if (m_scriptCallbackContext != JS_INVALID_REFERENCE)
-				{
-					unsigned int refCount;
-					JsRelease(m_scriptCallbackContext, &refCount);
-					m_scriptCallbackContext = JS_INVALID_REFERENCE;
-				}
-			}
+        if (m_scriptCallbackContext != JS_INVALID_REFERENCE) {
+            unsigned int refCount;
+            JsRelease(m_scriptCallbackContext, &refCount);
+            m_scriptCallbackContext = JS_INVALID_REFERENCE;
+        }
+    }
 
-			bool InvokeCallback(std::vector<JsValueRef>& parameters)
-			{
-				JsValueRef result;
-				parameters.insert(parameters.begin(), m_scriptCallbackContext);
-				HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters.data(), static_cast<unsigned short>(parameters.size()), &result));
+    bool InvokeCallback(std::vector<JsValueRef> &parameters)
+    {
+        JsValueRef result;
+        parameters.insert(parameters.begin(), m_scriptCallbackContext);
+        HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(
+            m_scriptCallback, parameters.data(), static_cast<unsigned short>(parameters.size()), &result));
 
-				return true;
-			}
+        return true;
+    }
 
-			bool HasCallback() { return m_scriptCallback != JS_INVALID_REFERENCE; }
+    bool HasCallback() { return m_scriptCallback != JS_INVALID_REFERENCE; }
 
-		private:
-			JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
-			JsValueRef m_scriptCallbackContext = JS_INVALID_REFERENCE;
-		};
+   private:
+    JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
+    JsValueRef m_scriptCallbackContext = JS_INVALID_REFERENCE;
+};
 
-		class EventsManager
-		{
-		public:
-			EventsManager();
-			~EventsManager();
+class EventsManager {
+   public:
+    EventsManager();
+    ~EventsManager();
 
-			bool Initialize();
+    bool Initialize();
 
-		private:
-			JsValueRef m_setCallbackFunction;
-			static JsValueRef CHAKRA_CALLBACK setCallback(
-				_In_ JsValueRef callee,
-				_In_ bool isConstructCall,
-				_In_ JsValueRef *arguments,
-				_In_ unsigned short argumentCount,
-				_In_ PVOID callbackData
-			);
+   private:
+    JsValueRef m_setCallbackFunction;
+    static JsValueRef CHAKRA_CALLBACK setCallback(_In_ JsValueRef callee,
+                                                  _In_ bool isConstructCall,
+                                                  _In_ JsValueRef *arguments,
+                                                  _In_ unsigned short argumentCount,
+                                                  _In_ PVOID callbackData);
 
-			JsValueRef m_removeCallbackFunction;
-			static JsValueRef CHAKRA_CALLBACK removeCallback(
-				_In_ JsValueRef callee,
-				_In_ bool isConstructCall,
-				_In_ JsValueRef *arguments,
-				_In_ unsigned short argumentCount,
-				_In_ PVOID callbackData
-			);
+    JsValueRef m_removeCallbackFunction;
+    static JsValueRef CHAKRA_CALLBACK removeCallback(_In_ JsValueRef callee,
+                                                     _In_ bool isConstructCall,
+                                                     _In_ JsValueRef *arguments,
+                                                     _In_ unsigned short argumentCount,
+                                                     _In_ PVOID callbackData);
+};
 
-		};
-
-
-	}
-}
-
+}  // namespace Utilities
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/RenderingContext2D.cpp
+++ b/HoloJS/HoloJsHost/RenderingContext2D.cpp
@@ -1,6 +1,8 @@
 #include "pch.h"
-#include "ImageElement.h"
 #include "RenderingContext2D.h"
+#include "ImageElement.h"
+
+#include "IBufferOnMemory.h"
 
 using namespace Microsoft::Graphics::Canvas;
 using namespace Windows::Graphics::DirectX;
@@ -9,134 +11,118 @@ using namespace Windows::Foundation::Numerics;
 using namespace Windows::Storage::Streams;
 using namespace HologramJS::WebGL;
 
-void
-RenderingContext2D::drawImage3(
-	HologramJS::API::ImageElement* imageElement,
-    GLsizei imageWidth,
-    GLsizei imageHeight,
-    unsigned int sx,
-    unsigned int sy,
-    unsigned int sWidth,
-    unsigned int sHeight,
-    unsigned int dx,
-    unsigned int dy,
-    unsigned int dWidth,
-    unsigned int dHeight
-    )
+void RenderingContext2D::drawImage3(HologramJS::API::ImageElement *imageElement,
+                                    GLsizei imageWidth,
+                                    GLsizei imageHeight,
+                                    unsigned int sx,
+                                    unsigned int sy,
+                                    unsigned int sWidth,
+                                    unsigned int sHeight,
+                                    unsigned int dx,
+                                    unsigned int dy,
+                                    unsigned int dWidth,
+                                    unsigned int dHeight)
 {
-	m_isOptimizedBitmap = false;
+    m_isOptimizedBitmap = false;
 
-	m_canvasRenderTarget = ref new CanvasRenderTarget(
-		CanvasDevice::GetSharedDevice(),
-		static_cast<float>(m_width),
-		static_cast<float>(m_height),
-		96,
-		DirectXPixelFormat::R8G8B8A8UIntNormalized,
-		CanvasAlphaMode::Ignore);
+    m_canvasRenderTarget = ref new CanvasRenderTarget(CanvasDevice::GetSharedDevice(),
+                                                      static_cast<float>(m_width),
+                                                      static_cast<float>(m_height),
+                                                      96,
+                                                      DirectXPixelFormat::R8G8B8A8UIntNormalized,
+                                                      CanvasAlphaMode::Ignore);
 
-	unsigned int imageBufferSize = 0;
-	WICInProcPointer imageMemory = nullptr;
-	unsigned int stride;
-	EXIT_IF_FALSE(imageElement->GetPixelsPointer(&imageMemory, &imageBufferSize, &stride));
+    unsigned int imageBufferSize = 0;
+    WICInProcPointer imageMemory = nullptr;
+    unsigned int stride;
+    EXIT_IF_FALSE(imageElement->GetPixelsPointer(&imageMemory, &imageBufferSize, &stride));
 
+    Microsoft::WRL::ComPtr<HologramJS::Utilities::BufferOnMemory> imageBuffer;
+    Microsoft::WRL::Details::MakeAndInitialize<HologramJS::Utilities::BufferOnMemory>(
+        &imageBuffer, imageMemory, imageBufferSize);
+    auto iinspectable = (IInspectable *)reinterpret_cast<IInspectable *>(imageBuffer.Get());
+    IBuffer ^ imageIBuffer = reinterpret_cast<IBuffer ^>(iinspectable);
 
-	Microsoft::WRL::ComPtr<HologramJS::Utilities::BufferOnMemory> imageBuffer;
-	Microsoft::WRL::Details::MakeAndInitialize<HologramJS::Utilities::BufferOnMemory>(&imageBuffer, imageMemory, imageBufferSize);
-	auto iinspectable = (IInspectable *)reinterpret_cast<IInspectable *>(imageBuffer.Get());
-	IBuffer^ imageIBuffer = reinterpret_cast<IBuffer^>(iinspectable);
-	
-	auto canvasBitmap = CanvasBitmap::CreateFromBytes(
-		CanvasDevice::GetSharedDevice(),
-		imageIBuffer,
-		imageElement->Width(),
-		imageElement->Height(),
-		DirectXPixelFormat::R8G8B8A8UIntNormalized);
+    auto canvasBitmap = CanvasBitmap::CreateFromBytes(CanvasDevice::GetSharedDevice(),
+                                                      imageIBuffer,
+                                                      imageElement->Width(),
+                                                      imageElement->Height(),
+                                                      DirectXPixelFormat::R8G8B8A8UIntNormalized);
 
-    CanvasDrawingSession^ session = m_canvasRenderTarget->CreateDrawingSession();
+    CanvasDrawingSession ^ session = m_canvasRenderTarget->CreateDrawingSession();
 
-    Rect source(static_cast<float>(sx), static_cast<float>(sy), static_cast<float>(sWidth), static_cast<float>(sHeight));
+    Rect source(
+        static_cast<float>(sx), static_cast<float>(sy), static_cast<float>(sWidth), static_cast<float>(sHeight));
     Rect dest(static_cast<float>(dx), static_cast<float>(dy), static_cast<float>(dWidth), static_cast<float>(dHeight));
     session->DrawImage(canvasBitmap, dest, source);
     session = nullptr;
 }
 
-void
-RenderingContext2D::drawImage1(
-	HologramJS::API::ImageElement* imageElement,
-    GLsizei imageWidth,
-    GLsizei imageHeight,
-    unsigned int dx,
-    unsigned int dy
-)
+void RenderingContext2D::drawImage1(HologramJS::API::ImageElement *imageElement,
+                                    GLsizei imageWidth,
+                                    GLsizei imageHeight,
+                                    unsigned int dx,
+                                    unsigned int dy)
 {
-	EXIT_IF_FALSE((imageWidth + dx <= m_width) && (imageHeight + dy <= m_height));
+    EXIT_IF_FALSE((imageWidth + dx <= m_width) && (imageHeight + dy <= m_height));
 
-	unsigned int imageBufferSize = 0;
-	WICInProcPointer imageMemory = nullptr;
-	unsigned int stride;
-	EXIT_IF_FALSE(imageElement->GetPixelsPointer(&imageMemory, &imageBufferSize, &stride));
+    unsigned int imageBufferSize = 0;
+    WICInProcPointer imageMemory = nullptr;
+    unsigned int stride;
+    EXIT_IF_FALSE(imageElement->GetPixelsPointer(&imageMemory, &imageBufferSize, &stride));
 
-	m_optimizedBitmap.resize(m_width * m_height* 4);
-	m_isOptimizedBitmap = true;
+    m_optimizedBitmap.resize(m_width * m_height * 4);
+    m_isOptimizedBitmap = true;
 
-	if (dx == 0 && dy == 0 && imageWidth == m_width && imageHeight == m_height && stride == (m_width * 4))
-	{
-		CopyMemory(m_optimizedBitmap.data(), imageMemory, imageBufferSize);
-	}
-	else
-	{
-		unsigned int sourceLine = 0;
-		unsigned int destinationLine = dy;
-		const unsigned int destinationStride = m_width * 4;
-		for (int i = 0; i < imageHeight; i++)
-		{
-			CopyMemory(
-				m_optimizedBitmap.data() + destinationLine * destinationStride + dx,
-				imageMemory + sourceLine * stride,
-				stride);
-			sourceLine ++;
-			destinationLine++;
-		}
-	}
+    if (dx == 0 && dy == 0 && imageWidth == m_width && imageHeight == m_height && stride == (m_width * 4)) {
+        CopyMemory(m_optimizedBitmap.data(), imageMemory, imageBufferSize);
+    } else {
+        unsigned int sourceLine = 0;
+        unsigned int destinationLine = dy;
+        const unsigned int destinationStride = m_width * 4;
+        for (int i = 0; i < imageHeight; i++) {
+            CopyMemory(m_optimizedBitmap.data() + destinationLine * destinationStride + dx,
+                       imageMemory + sourceLine * stride,
+                       stride);
+            sourceLine++;
+            destinationLine++;
+        }
+    }
 }
 
-void
-RenderingContext2D::drawImage2(
-	HologramJS::API::ImageElement* imageElement,
-    GLsizei imageWidth,
-    GLsizei imageHeight,
-    unsigned int dx,
-    unsigned int dy,
-    unsigned int dWidth,
-    unsigned int dHeight
-)
+void RenderingContext2D::drawImage2(HologramJS::API::ImageElement *imageElement,
+                                    GLsizei imageWidth,
+                                    GLsizei imageHeight,
+                                    unsigned int dx,
+                                    unsigned int dy,
+                                    unsigned int dWidth,
+                                    unsigned int dHeight)
 {
-	m_isOptimizedBitmap = false;
+    m_isOptimizedBitmap = false;
 
-	m_canvasRenderTarget = ref new CanvasRenderTarget(
-		CanvasDevice::GetSharedDevice(),
-		static_cast<float>(m_width),
-		static_cast<float>(m_height),
-		96,
-		DirectXPixelFormat::R8G8B8A8UIntNormalized,
-		CanvasAlphaMode::Ignore);
+    m_canvasRenderTarget = ref new CanvasRenderTarget(CanvasDevice::GetSharedDevice(),
+                                                      static_cast<float>(m_width),
+                                                      static_cast<float>(m_height),
+                                                      96,
+                                                      DirectXPixelFormat::R8G8B8A8UIntNormalized,
+                                                      CanvasAlphaMode::Ignore);
 
-	unsigned int imageBufferSize = 0;
-	WICInProcPointer imageMemory = nullptr;
-	unsigned int stride;
-	EXIT_IF_FALSE(imageElement->GetPixelsPointer(&imageMemory, &imageBufferSize, &stride));
+    unsigned int imageBufferSize = 0;
+    WICInProcPointer imageMemory = nullptr;
+    unsigned int stride;
+    EXIT_IF_FALSE(imageElement->GetPixelsPointer(&imageMemory, &imageBufferSize, &stride));
 
-	Microsoft::WRL::ComPtr<HologramJS::Utilities::BufferOnMemory> imageBuffer;
-	Microsoft::WRL::Details::MakeAndInitialize<HologramJS::Utilities::BufferOnMemory>(&imageBuffer, imageMemory, imageBufferSize);
-	auto iinspectable = (IInspectable *)reinterpret_cast<IInspectable *>(imageBuffer.Get());
-	IBuffer^ imageIBuffer = reinterpret_cast<IBuffer^>(iinspectable);
+    Microsoft::WRL::ComPtr<HologramJS::Utilities::BufferOnMemory> imageBuffer;
+    Microsoft::WRL::Details::MakeAndInitialize<HologramJS::Utilities::BufferOnMemory>(
+        &imageBuffer, imageMemory, imageBufferSize);
+    auto iinspectable = (IInspectable *)reinterpret_cast<IInspectable *>(imageBuffer.Get());
+    IBuffer ^ imageIBuffer = reinterpret_cast<IBuffer ^>(iinspectable);
 
-	auto canvasBitmap = CanvasBitmap::CreateFromBytes(
-		CanvasDevice::GetSharedDevice(),
-		imageIBuffer,
-		imageElement->Width(),
-		imageElement->Height(),
-		DirectXPixelFormat::R8G8B8A8UIntNormalized);
+    auto canvasBitmap = CanvasBitmap::CreateFromBytes(CanvasDevice::GetSharedDevice(),
+                                                      imageIBuffer,
+                                                      imageElement->Width(),
+                                                      imageElement->Height(),
+                                                      DirectXPixelFormat::R8G8B8A8UIntNormalized);
 
     auto session = m_canvasRenderTarget->CreateDrawingSession();
 
@@ -145,15 +131,11 @@ RenderingContext2D::drawImage2(
     session = nullptr;
 }
 
-Platform::Array<unsigned char>^
-RenderingContext2D::getImageData(int sx, int sy, int sw, int sh)
+Platform::Array<unsigned char> ^ RenderingContext2D::getImageData(int sx, int sy, int sw, int sh)
 {
-	if (!m_isOptimizedBitmap)
-	{
-		return m_canvasRenderTarget->GetPixelBytes(sx, sy, sw, sh);
-	}
-	else
-	{
-		return nullptr;
-	}
+    if (!m_isOptimizedBitmap) {
+        return m_canvasRenderTarget->GetPixelBytes(sx, sy, sw, sh);
+    } else {
+        return nullptr;
+    }
 }

--- a/HoloJS/HoloJsHost/RenderingContext2D.h
+++ b/HoloJS/HoloJsHost/RenderingContext2D.h
@@ -1,71 +1,65 @@
 #pragma once
 
-namespace HologramJS
-{
-	namespace WebGL
-	{
-		class RenderingContext2D : public HologramJS::Utilities::IRelease
-		{
-		public:
-			RenderingContext2D() {}
+#include "IRelease.h"
+#include "ImageElement.h"
 
-			virtual ~RenderingContext2D() {}
+namespace HologramJS {
+namespace WebGL {
+class RenderingContext2D : public HologramJS::Utilities::IRelease {
+   public:
+    RenderingContext2D() {}
 
-			void Release() {}
+    virtual ~RenderingContext2D() {}
 
-			bool OptimizedBufferAvailable() { return m_isOptimizedBitmap; }
-			size_t GetOptimizedBufferSize() { return m_optimizedBitmap.size(); }
-			void CopyOptimizedBitmapToBuffer(byte* buffer) { CopyMemory(buffer, m_optimizedBitmap.data(), m_optimizedBitmap.size()); }
+    void Release() {}
 
-			void drawImage3(
-				HologramJS::API::ImageElement* imageElement,
-				GLsizei width,
-				GLsizei heigh,
-				unsigned int sx,
-				unsigned int sy,
-				unsigned int sWidth,
-				unsigned int sHeight,
-				unsigned int dx,
-				unsigned int dy,
-				unsigned int dWidth,
-				unsigned int dHeight
-			);
+    bool OptimizedBufferAvailable() { return m_isOptimizedBitmap; }
+    size_t GetOptimizedBufferSize() { return m_optimizedBitmap.size(); }
+    void CopyOptimizedBitmapToBuffer(byte* buffer)
+    {
+        CopyMemory(buffer, m_optimizedBitmap.data(), m_optimizedBitmap.size());
+    }
 
-			void drawImage1(
-				HologramJS::API::ImageElement* imageElement,
-				GLsizei width,
-				GLsizei heigh,
-				unsigned int dx,
-				unsigned int dy
-			);
+    void drawImage3(HologramJS::API::ImageElement* imageElement,
+                    GLsizei width,
+                    GLsizei heigh,
+                    unsigned int sx,
+                    unsigned int sy,
+                    unsigned int sWidth,
+                    unsigned int sHeight,
+                    unsigned int dx,
+                    unsigned int dy,
+                    unsigned int dWidth,
+                    unsigned int dHeight);
 
-			void drawImage2(
-				HologramJS::API::ImageElement* imageElement,
-				GLsizei width,
-				GLsizei heigh,
-				unsigned int dx,
-				unsigned int dy,
-				unsigned int dWidth,
-				unsigned int dHeight
-			);
+    void drawImage1(
+        HologramJS::API::ImageElement* imageElement, GLsizei width, GLsizei heigh, unsigned int dx, unsigned int dy);
 
-			Platform::Array<unsigned char>^ getImageData(int sx, int sy, int sw, int sh);
+    void drawImage2(HologramJS::API::ImageElement* imageElement,
+                    GLsizei width,
+                    GLsizei heigh,
+                    unsigned int dx,
+                    unsigned int dy,
+                    unsigned int dWidth,
+                    unsigned int dHeight);
 
-			void SetSize(unsigned int width, unsigned int height)
-			{
-				m_height = height;
-				m_width = width;
-			}
+    Platform::Array<unsigned char> ^ getImageData(int sx, int sy, int sw, int sh);
 
-		private:
+    void SetSize(unsigned int width, unsigned int height)
+    {
+        m_height = height;
+        m_width = width;
+    }
 
-			unsigned int m_height;
-			unsigned int m_width;
+   private:
+    unsigned int m_height;
+    unsigned int m_width;
 
-			std::vector<byte> m_optimizedBitmap;
-			bool m_isOptimizedBitmap = false;;
+    std::vector<byte> m_optimizedBitmap;
+    bool m_isOptimizedBitmap = false;
+    ;
 
-			Microsoft::Graphics::Canvas::CanvasRenderTarget^ m_canvasRenderTarget = nullptr;
-		};
-	}
-}
+    Microsoft::Graphics::Canvas::CanvasRenderTarget ^ m_canvasRenderTarget = nullptr;
+};
+}  // namespace WebGL
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/ScriptErrorHandling.h
+++ b/HoloJS/HoloJsHost/ScriptErrorHandling.h
@@ -1,28 +1,30 @@
 #pragma once
 
-namespace HologramJS
-{
-	class ScriptErrorHandling {
-	public:
-		static void PrintException() {
-			// Get error message
-			JsValueRef exception;
-			JsGetAndClearException(&exception);
+#include "ChakraForHoloJS.h"
 
-			JsPropertyIdRef messageName;
-			JsGetPropertyIdFromName(L"stack", &messageName);
+namespace HologramJS {
+class ScriptErrorHandling {
+   public:
+    static void PrintException()
+    {
+        // Get error message
+        JsValueRef exception;
+        JsGetAndClearException(&exception);
 
-			JsValueRef messageValue;
-			JsGetProperty(exception, messageName, &messageValue);
+        JsPropertyIdRef messageName;
+        JsGetPropertyIdFromName(L"stack", &messageName);
 
-			const wchar_t *message;
-			size_t length;
-			JsStringToPointer(messageValue, &message, &length);
+        JsValueRef messageValue;
+        JsGetProperty(exception, messageName, &messageValue);
 
-			std::wstring output = L"";
-			output += message;
-			output += L"\r\n";
-			OutputDebugString(output.c_str());
-		}
-	};
-}
+        const wchar_t *message;
+        size_t length;
+        JsStringToPointer(messageValue, &message, &length);
+
+        std::wstring output = L"";
+        output += message;
+        output += L"\r\n";
+        OutputDebugString(output.c_str());
+    }
+};
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/ScriptHostUtilities.cpp
+++ b/HoloJS/HoloJsHost/ScriptHostUtilities.cpp
@@ -4,181 +4,142 @@
 using namespace HologramJS::Utilities;
 using namespace std;
 
-bool
-ScriptHostUtilities::SetJsProperty(
-	JsValueRef& parentObject,
-	const std::wstring& propertyName,
-	JsValueRef& propertyValue
-)
+bool ScriptHostUtilities::SetJsProperty(JsValueRef& parentObject,
+                                        const std::wstring& propertyName,
+                                        JsValueRef& propertyValue)
 {
-	JsPropertyIdRef propertyId;
-	RETURN_IF_JS_ERROR(JsGetPropertyIdFromName(propertyName.c_str(), &propertyId));
-	RETURN_IF_JS_ERROR(JsSetProperty(parentObject, propertyId, propertyValue, true));
+    JsPropertyIdRef propertyId;
+    RETURN_IF_JS_ERROR(JsGetPropertyIdFromName(propertyName.c_str(), &propertyId));
+    RETURN_IF_JS_ERROR(JsSetProperty(parentObject, propertyId, propertyValue, true));
 
-	return true;
+    return true;
 }
 
-bool
-ScriptHostUtilities::GetJsProperty(
-	JsValueRef& parentObject,
-	const std::wstring& name,
-	JsValueRef* outProperty
-)
+bool ScriptHostUtilities::GetJsProperty(JsValueRef& parentObject, const std::wstring& name, JsValueRef* outProperty)
 {
-	JsPropertyIdRef propertyId;
-	RETURN_IF_JS_ERROR(JsGetPropertyIdFromName(name.c_str(), &propertyId));
+    JsPropertyIdRef propertyId;
+    RETURN_IF_JS_ERROR(JsGetPropertyIdFromName(name.c_str(), &propertyId));
 
-	// Create or get parent.name
-	bool hasProperty;
-	JsValueRef property;
-	RETURN_IF_JS_ERROR(JsHasProperty(parentObject, propertyId, &hasProperty));
-	if (!hasProperty)
-	{
-		RETURN_IF_JS_ERROR(JsCreateObject(&property));
-		RETURN_IF_JS_ERROR(JsSetProperty(parentObject, propertyId, property, true));
-	}
-	else
-	{
-		RETURN_IF_JS_ERROR(JsGetProperty(parentObject, propertyId, &property));
-	}
+    // Create or get parent.name
+    bool hasProperty;
+    JsValueRef property;
+    RETURN_IF_JS_ERROR(JsHasProperty(parentObject, propertyId, &hasProperty));
+    if (!hasProperty) {
+        RETURN_IF_JS_ERROR(JsCreateObject(&property));
+        RETURN_IF_JS_ERROR(JsSetProperty(parentObject, propertyId, property, true));
+    } else {
+        RETURN_IF_JS_ERROR(JsGetProperty(parentObject, propertyId, &property));
+    }
 
-	*outProperty = property;
+    *outProperty = property;
 
-	return true;
+    return true;
 }
 
-bool
-ScriptHostUtilities::ProjectFunction(
-	const std::wstring& name,
-	const std::wstring& namespaceName,
-	JsNativeFunction nativeFunction,
-	void* callbackState,
-	JsValueRef* scriptFunction
-)
+bool ScriptHostUtilities::ProjectFunction(const std::wstring& name,
+                                          const std::wstring& namespaceName,
+                                          JsNativeFunction nativeFunction,
+                                          void* callbackState,
+                                          JsValueRef* scriptFunction)
 {
-	// Get the global object
-	JsValueRef globalObject;
+    // Get the global object
+    JsValueRef globalObject;
 
-	RETURN_IF_JS_ERROR(JsGetGlobalObject(&globalObject));
+    RETURN_IF_JS_ERROR(JsGetGlobalObject(&globalObject));
 
-	// Create or get global.nativeInterface
-	JsValueRef nativeInterface;
-	RETURN_IF_FALSE(GetJsProperty(globalObject, L"nativeInterface", &nativeInterface));
+    // Create or get global.nativeInterface
+    JsValueRef nativeInterface;
+    RETURN_IF_FALSE(GetJsProperty(globalObject, L"nativeInterface", &nativeInterface));
 
-	// Create or get global.nativeInterface.[namespace]
+    // Create or get global.nativeInterface.[namespace]
 
-	JsValueRef namespaceProperty;
-	RETURN_IF_FALSE(GetJsProperty(nativeInterface, namespaceName, &namespaceProperty));
+    JsValueRef namespaceProperty;
+    RETURN_IF_FALSE(GetJsProperty(nativeInterface, namespaceName, &namespaceProperty));
 
-	JsPropertyIdRef functionPropertyId;
-	RETURN_IF_JS_ERROR(JsGetPropertyIdFromName(name.c_str(), &functionPropertyId));
-	RETURN_IF_JS_ERROR(JsCreateFunction(nativeFunction, callbackState, scriptFunction));
-	RETURN_IF_JS_ERROR(JsSetProperty(namespaceProperty, functionPropertyId, *scriptFunction, true));
+    JsPropertyIdRef functionPropertyId;
+    RETURN_IF_JS_ERROR(JsGetPropertyIdFromName(name.c_str(), &functionPropertyId));
+    RETURN_IF_JS_ERROR(JsCreateFunction(nativeFunction, callbackState, scriptFunction));
+    RETURN_IF_JS_ERROR(JsSetProperty(namespaceProperty, functionPropertyId, *scriptFunction, true));
 
-	return true;
+    return true;
 }
 
-bool
-ScriptHostUtilities::GetString(
-	JsValueRef value,
-	wstring& outString
-)
+bool ScriptHostUtilities::GetString(JsValueRef value, wstring& outString)
 {
-	PCWSTR rawString;
-	size_t rawStringLength;
-	RETURN_IF_JS_ERROR(JsStringToPointer(value, &rawString, &rawStringLength));
+    PCWSTR rawString;
+    size_t rawStringLength;
+    RETURN_IF_JS_ERROR(JsStringToPointer(value, &rawString, &rawStringLength));
 
-	outString.assign(rawString);
+    outString.assign(rawString);
 
-	return true;
+    return true;
 }
 
-GLclampf
-ScriptHostUtilities::GLclampfFromJsRef(JsValueRef value)
+GLclampf ScriptHostUtilities::GLclampfFromJsRef(JsValueRef value)
 {
-	double doubleValue;
-	if (JsNumberToDouble(value, &doubleValue) != JsNoError)
-	{
-		return 0;
-	}
+    double doubleValue;
+    if (JsNumberToDouble(value, &doubleValue) != JsNoError) {
+        return 0;
+    }
 
-	return (GLclampf)doubleValue;
+    return (GLclampf)doubleValue;
 }
 
-GLenum
-ScriptHostUtilities::GLenumFromJsRef(JsValueRef value)
+GLenum ScriptHostUtilities::GLenumFromJsRef(JsValueRef value)
 {
-	int intValue;
-	if (JsNumberToInt(value, &intValue) != JsNoError)
-	{
-		return 0;
-	}
+    int intValue;
+    if (JsNumberToInt(value, &intValue) != JsNoError) {
+        return 0;
+    }
 
-	return static_cast<unsigned int>(intValue);
+    return static_cast<unsigned int>(intValue);
 }
 
-GLint
-ScriptHostUtilities::GLintFromJsRef(JsValueRef value)
+GLint ScriptHostUtilities::GLintFromJsRef(JsValueRef value)
 {
-	int intValue;
-	if (JsNumberToInt(value, &intValue) != JsNoError)
-	{
-		return 0;
-	}
+    int intValue;
+    if (JsNumberToInt(value, &intValue) != JsNoError) {
+        return 0;
+    }
 
-	return intValue;
+    return intValue;
 }
 
-GLboolean
-ScriptHostUtilities::GLbooleanFromJsRef(JsValueRef value)
+GLboolean ScriptHostUtilities::GLbooleanFromJsRef(JsValueRef value)
 {
-	bool boolValue;
-	if (JsBooleanToBool(value, &boolValue) != JsNoError)
-	{
-		return false;
-	}
+    bool boolValue;
+    if (JsBooleanToBool(value, &boolValue) != JsNoError) {
+        return false;
+    }
 
-	return boolValue;
+    return boolValue;
 }
 
-GLbitfield
-ScriptHostUtilities::GLbitfieldFromJsRef(JsValueRef value)
+GLbitfield ScriptHostUtilities::GLbitfieldFromJsRef(JsValueRef value)
 {
-	return static_cast<GLbitfield>(GLintFromJsRef(value));
+    return static_cast<GLbitfield>(GLintFromJsRef(value));
 }
 
-GLsizeiptr
-ScriptHostUtilities::GLsizeiptrFromJsRef(JsValueRef value)
+GLsizeiptr ScriptHostUtilities::GLsizeiptrFromJsRef(JsValueRef value)
 {
-	double doubleValue;
-	if (JsNumberToDouble(value, &doubleValue) != JsNoError)
-	{
-		return 0;
-	}
+    double doubleValue;
+    if (JsNumberToDouble(value, &doubleValue) != JsNoError) {
+        return 0;
+    }
 
-	return static_cast<GLsizeiptr>(doubleValue);
+    return static_cast<GLsizeiptr>(doubleValue);
 }
 
-GLuint
-ScriptHostUtilities::GLuintFromJsRef(JsValueRef value)
-{
-	return static_cast<GLuint>(GLintFromJsRef(value));
-}
+GLuint ScriptHostUtilities::GLuintFromJsRef(JsValueRef value) { return static_cast<GLuint>(GLintFromJsRef(value)); }
 
-GLsizei
-ScriptHostUtilities::GLsizeiFromJsRef(JsValueRef value)
-{
-	return GLintFromJsRef(value);
-}
+GLsizei ScriptHostUtilities::GLsizeiFromJsRef(JsValueRef value) { return GLintFromJsRef(value); }
 
-GLfloat
-ScriptHostUtilities::GLfloatFromJsRef(JsValueRef value)
+GLfloat ScriptHostUtilities::GLfloatFromJsRef(JsValueRef value)
 {
-	double doubleValue;
-	if (JsNumberToDouble(value, &doubleValue) != JsNoError)
-	{
-		return 0;
-	}
+    double doubleValue;
+    if (JsNumberToDouble(value, &doubleValue) != JsNoError) {
+        return 0;
+    }
 
-	return static_cast<GLfloat>(doubleValue);
+    return static_cast<GLfloat>(doubleValue);
 }

--- a/HoloJS/HoloJsHost/ScriptHostUtilities.h
+++ b/HoloJS/HoloJsHost/ScriptHostUtilities.h
@@ -1,4 +1,7 @@
 #pragma once
+
+#include "ChakraForHoloJS.h"
+
 namespace HologramJS
 {
 	namespace Utilities

--- a/HoloJS/HoloJsHost/ScriptResourceTracker.cpp
+++ b/HoloJS/HoloJsHost/ScriptResourceTracker.cpp
@@ -6,43 +6,33 @@ using namespace HologramJS::Utilities;
 std::list<HologramJS::API::ExternalObject*> ScriptResourceTracker::ProjectedResources;
 std::mutex ScriptResourceTracker::ResourcesListLock;
 
-
-_Use_decl_annotations_
-void
-CHAKRA_CALLBACK
-ScriptResourceTracker::JsFinalize(void *data)
+_Use_decl_annotations_ void CHAKRA_CALLBACK ScriptResourceTracker::JsFinalize(void* data)
 {
-	HologramJS::API::ExternalObject* iRelease = reinterpret_cast<HologramJS::API::ExternalObject*>(data);
-	if (iRelease == nullptr)
-	{
-		return;
-	}
+    HologramJS::API::ExternalObject* iRelease = reinterpret_cast<HologramJS::API::ExternalObject*>(data);
+    if (iRelease == nullptr) {
+        return;
+    }
 
-	std::lock_guard<std::mutex> guard(ResourcesListLock);
+    std::lock_guard<std::mutex> guard(ResourcesListLock);
 
-	for (auto& object : ProjectedResources)
-	{
-		if (object == iRelease)
-		{
-			delete iRelease;
-			ProjectedResources.remove(object);
-			break;
-		}
-	}
+    for (auto& object : ProjectedResources) {
+        if (object == iRelease) {
+            delete iRelease;
+            ProjectedResources.remove(object);
+            break;
+        }
+    }
 }
 
-void
-ScriptResourceTracker::ReleaseAll()
+void ScriptResourceTracker::ReleaseAll()
 {
-	std::lock_guard<std::mutex> guard(ResourcesListLock);
+    std::lock_guard<std::mutex> guard(ResourcesListLock);
 
-	for (auto& object : ProjectedResources)
-	{
-		if (object != nullptr)
-		{
-			delete object;
-		}
-	}
+    for (auto& object : ProjectedResources) {
+        if (object != nullptr) {
+            delete object;
+        }
+    }
 
-	ProjectedResources.clear();
+    ProjectedResources.clear();
 }

--- a/HoloJS/HoloJsHost/ScriptResourceTracker.h
+++ b/HoloJS/HoloJsHost/ScriptResourceTracker.h
@@ -1,136 +1,124 @@
 #pragma once
 
-namespace HologramJS
-{
-	namespace Utilities
-	{
-		class ScriptResourceTracker
-		{
-		public:
+#include "ChakraForHoloJS.h"
+#include "ExternalObject.h"
 
-			static void ReleaseAll();
+namespace HologramJS {
+namespace Utilities {
+class ScriptResourceTracker {
+   public:
+    static void ReleaseAll();
 
-			~ScriptResourceTracker()
-			{
-				ReleaseAll();
-			}
+    ~ScriptResourceTracker() { ReleaseAll(); }
 
-			static JsErrorCode CreateAndTrackExternalBuffer(size_t bufferLength, void** allocatedBuffer, JsValueRef* scriptBuffer)
-			{
-				*allocatedBuffer = new unsigned char[bufferLength];
-				return JsCreateExternalArrayBuffer(*allocatedBuffer, bufferLength, JsFinalizeArray, nullptr, scriptBuffer);
-			}
+    static JsErrorCode CreateAndTrackExternalBuffer(size_t bufferLength,
+                                                    void** allocatedBuffer,
+                                                    JsValueRef* scriptBuffer)
+    {
+        *allocatedBuffer = new unsigned char[bufferLength];
+        return JsCreateExternalArrayBuffer(*allocatedBuffer, bufferLength, JsFinalizeArray, nullptr, scriptBuffer);
+    }
 
-			static void TrackObject(HologramJS::API::ExternalObject* object)
-			{
-				std::lock_guard<std::mutex> guard(ResourcesListLock);
-				ProjectedResources.push_back(object);
-			}
+    static void TrackObject(HologramJS::API::ExternalObject* object)
+    {
+        std::lock_guard<std::mutex> guard(ResourcesListLock);
+        ProjectedResources.push_back(object);
+    }
 
-			static JsValueRef ObjectToDirectExternal(HologramJS::API::ExternalObject* object)
-			{
-				JsValueRef externalObjectRef;
-				RETURN_INVALID_REF_IF_JS_ERROR(JsCreateExternalObject(object, JsFinalize, &externalObjectRef));
-				TrackObject(object);
+    static JsValueRef ObjectToDirectExternal(HologramJS::API::ExternalObject* object)
+    {
+        JsValueRef externalObjectRef;
+        RETURN_INVALID_REF_IF_JS_ERROR(JsCreateExternalObject(object, JsFinalize, &externalObjectRef));
+        TrackObject(object);
 
-				return externalObjectRef;
-			}
+        return externalObjectRef;
+    }
 
-			template<typename T> static JsValueRef ObjectToDirectExternal(T* object)
-			{
-				if (object != nullptr)
-				{
-					HologramJS::API::ExternalObject* externalObject = new HologramJS::API::ExternalObject();
-					RETURN_INVALID_REF_IF_FALSE(externalObject->Initialize(object));
-					return ScriptResourceTracker::ObjectToDirectExternal(externalObject);
-				}
-				else
-				{
-					return JS_INVALID_REFERENCE;
-				}
-			}
+    template <typename T>
+    static JsValueRef ObjectToDirectExternal(T* object)
+    {
+        if (object != nullptr) {
+            HologramJS::API::ExternalObject* externalObject = new HologramJS::API::ExternalObject();
+            RETURN_INVALID_REF_IF_FALSE(externalObject->Initialize(object));
+            return ScriptResourceTracker::ObjectToDirectExternal(externalObject);
+        } else {
+            return JS_INVALID_REFERENCE;
+        }
+    }
 
-			static JsValueRef ObjectToExternal(HologramJS::API::ExternalObject* object)
-			{
-				JsValueRef externalObject;
-				RETURN_INVALID_REF_IF_JS_ERROR(JsCreateExternalObject(object, JsFinalize, &externalObject));
+    static JsValueRef ObjectToExternal(HologramJS::API::ExternalObject* object)
+    {
+        JsValueRef externalObject;
+        RETURN_INVALID_REF_IF_JS_ERROR(JsCreateExternalObject(object, JsFinalize, &externalObject));
 
-				JsValueRef wrapperObject;
-				RETURN_INVALID_REF_IF_JS_ERROR(JsCreateObject(&wrapperObject));
+        JsValueRef wrapperObject;
+        RETURN_INVALID_REF_IF_JS_ERROR(JsCreateObject(&wrapperObject));
 
-				JsPropertyIdRef externalPropertyId;
-				RETURN_INVALID_REF_IF_JS_ERROR(JsGetPropertyIdFromName(L"external", &externalPropertyId));
+        JsPropertyIdRef externalPropertyId;
+        RETURN_INVALID_REF_IF_JS_ERROR(JsGetPropertyIdFromName(L"external", &externalPropertyId));
 
-				RETURN_INVALID_REF_IF_JS_ERROR(JsSetProperty(wrapperObject, externalPropertyId, externalObject, true));
+        RETURN_INVALID_REF_IF_JS_ERROR(JsSetProperty(wrapperObject, externalPropertyId, externalObject, true));
 
-				TrackObject(object);
+        TrackObject(object);
 
-				return wrapperObject;
-			}
+        return wrapperObject;
+    }
 
-			template<typename T> static JsValueRef ObjectToExternal(T* object)
-			{
-				if (object == nullptr)
-				{
-					return JS_INVALID_REFERENCE;
-				}
-				else
-				{
-					HologramJS::API::ExternalObject* externalObject = new HologramJS::API::ExternalObject();
-					RETURN_INVALID_REF_IF_FALSE(externalObject->Initialize(object));
-					return ScriptResourceTracker::ObjectToExternal(externalObject);
-				}
-			}
+    template <typename T>
+    static JsValueRef ObjectToExternal(T* object)
+    {
+        if (object == nullptr) {
+            return JS_INVALID_REFERENCE;
+        } else {
+            HologramJS::API::ExternalObject* externalObject = new HologramJS::API::ExternalObject();
+            RETURN_INVALID_REF_IF_FALSE(externalObject->Initialize(object));
+            return ScriptResourceTracker::ObjectToExternal(externalObject);
+        }
+    }
 
-			static ElementWithEvents* ExternalToEventsInterface(JsValueRef value)
-			{
-				bool hasExternal;
-				RETURN_NULL_IF_JS_ERROR(JsHasExternalData(value, &hasExternal));
+    static ElementWithEvents* ExternalToEventsInterface(JsValueRef value)
+    {
+        bool hasExternal;
+        RETURN_NULL_IF_JS_ERROR(JsHasExternalData(value, &hasExternal));
 
-				if (hasExternal)
-				{
-					HologramJS::API::ExternalObject* externalObject;
-					RETURN_NULL_IF_JS_ERROR(JsGetExternalData(value, (void**)&externalObject));
+        if (hasExternal) {
+            HologramJS::API::ExternalObject* externalObject;
+            RETURN_NULL_IF_JS_ERROR(JsGetExternalData(value, (void**)&externalObject));
 
-					return externalObject->EventsInterface();
-				}
-				else
-				{
-					return nullptr;
-				}
-			}
+            return externalObject->EventsInterface();
+        } else {
+            return nullptr;
+        }
+    }
 
-			template<typename T> static T* ExternalToObject(JsValueRef value)
-			{
-				bool hasExternal;
-				RETURN_NULL_IF_JS_ERROR(JsHasExternalData(value, &hasExternal));
+    template <typename T>
+    static T* ExternalToObject(JsValueRef value)
+    {
+        bool hasExternal;
+        RETURN_NULL_IF_JS_ERROR(JsHasExternalData(value, &hasExternal));
 
-				if (hasExternal)
-				{
-					HologramJS::API::ExternalObject* externalObject;
-					RETURN_NULL_IF_JS_ERROR(JsGetExternalData(value, (void**)&externalObject));
+        if (hasExternal) {
+            HologramJS::API::ExternalObject* externalObject;
+            RETURN_NULL_IF_JS_ERROR(JsGetExternalData(value, (void**)&externalObject));
 
-					return reinterpret_cast<T*>(externalObject->Data());
-				}
-				else
-				{
-					return nullptr;
-				}
-			}
+            return reinterpret_cast<T*>(externalObject->Data());
+        } else {
+            return nullptr;
+        }
+    }
 
-		private:
-			static std::list<HologramJS::API::ExternalObject*> ProjectedResources;
-			static std::mutex ResourcesListLock;
+   private:
+    static std::list<HologramJS::API::ExternalObject*> ProjectedResources;
+    static std::mutex ResourcesListLock;
 
-			static VOID CHAKRA_CALLBACK JsFinalize(_In_opt_ void *data);
-			static VOID CHAKRA_CALLBACK JsFinalizeArray(_In_opt_ void *data)
-			{
-				if (data != nullptr)
-				{
-					delete[] data;
-				}
-			}
-		};
+    static VOID CHAKRA_CALLBACK JsFinalize(_In_opt_ void* data);
+    static VOID CHAKRA_CALLBACK JsFinalizeArray(_In_opt_ void* data)
+    {
+        if (data != nullptr) {
+            delete[] data;
+        }
+    }
+};
 
-	}
-}
+}  // namespace Utilities
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/ScriptingFramework/Canvas2D.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/Canvas2D.js
@@ -1,74 +1,73 @@
-﻿(function () {
-    function ImageData(buffer, width, height) {
-        this.data = buffer;
-        this.height = height;
-        this.width = width;
-    }
+﻿(function() {
+function ImageData(buffer, width, height)
+{
+    this.data = buffer;
+    this.height = height;
+    this.width = width;
+}
 
-    function Context2D(canvas) {
-        this.canvas = canvas;
-        this.context2d = nativeInterface.canvas2d.createContext2D();
+function Context2D(canvas)
+{
+    this.canvas = canvas;
+    this.context2d = nativeInterface.canvas2d.createContext2D();
 
-        this.drawImage = function (image) {
-            if (arguments.length == 9) {
-                nativeInterface.canvas2d.drawImage3(
-                    this.context2d,
-                    this.canvas.width,
-                    this.canvas.height,
-                    image.native,
-                    image.width,
-                    image.height,
-                    arguments[1], //sx,
-                    arguments[2], //sy,
-                    arguments[3], //sWidth,
-                    arguments[4], //sHeight,
-                    arguments[5], //dx,
-                    arguments[6], //dy,
-                    arguments[7], //dWidth,
-                    arguments[8]); //dHeight);
-            } else if (arguments.length == 3) {
-                nativeInterface.canvas2d.drawImage1(
-                    this.context2d,
-                    this.canvas.width,
-                    this.canvas.height,
-                    image.native,
-                    image.width,
-                    image.height,
-                    arguments[1],  //dx,
-                    arguments[2]); //dy
-            } else if (arguments.length == 5) {
-                nativeInterface.canvas2d.drawImage2(
-                    this.context2d,
-                    this.canvas.width,
-                    this.canvas.height,
-                    image.native,
-                    image.width,
-                    image.height,
-                    arguments[1],  //dx,
-                    arguments[2],  //dy
-                    arguments[3],  //dWidth,
-                    arguments[4]); //dHeight
+    this.drawImage = function(image) {
+        if (arguments.length == 9) {
+            nativeInterface.canvas2d.drawImage3(this.context2d,
+                                                this.canvas.width,
+                                                this.canvas.height,
+                                                image.native,
+                                                image.width,
+                                                image.height,
+                                                arguments[1],   // sx,
+                                                arguments[2],   // sy,
+                                                arguments[3],   // sWidth,
+                                                arguments[4],   // sHeight,
+                                                arguments[5],   // dx,
+                                                arguments[6],   // dy,
+                                                arguments[7],   // dWidth,
+                                                arguments[8]);  // dHeight);
+        } else if (arguments.length == 3) {
+            nativeInterface.canvas2d.drawImage1(this.context2d,
+                                                this.canvas.width,
+                                                this.canvas.height,
+                                                image.native,
+                                                image.width,
+                                                image.height,
+                                                arguments[1],   // dx,
+                                                arguments[2]);  // dy
+        } else if (arguments.length == 5) {
+            nativeInterface.canvas2d.drawImage2(this.context2d,
+                                                this.canvas.width,
+                                                this.canvas.height,
+                                                image.native,
+                                                image.width,
+                                                image.height,
+                                                arguments[1],   // dx,
+                                                arguments[2],   // dy
+                                                arguments[3],   // dWidth,
+                                                arguments[4]);  // dHeight
+        }
+    }.bind(this);
+
+    this.getImageData = function(sx, sy, sw, sh) {
+        var buffer = nativeInterface.canvas2d.getImageData(this.context2d, sx, sy, sw, sh);
+        var imageData = new ImageData(buffer, sw, sh);
+        return imageData;
+    }.bind(this);
+}
+
+nativeInterface.Canvas2D = function() {
+    this.isCanvas2D = true;
+    this.getContext = function(type) {
+        if (type === '2d') {
+            if (!this.context) {
+                this.context = new Context2D(this);
+                this.context.canvas = this;
             }
-        }.bind(this);
 
-        this.getImageData = function (sx, sy, sw, sh) {
-            var buffer = nativeInterface.canvas2d.getImageData(this.context2d, sx, sy, sw, sh);
-            var imageData = new ImageData(buffer, sw, sh);
-            return imageData;
-        }.bind(this);
-    }
-
-    nativeInterface.Canvas2D = function () {
-        this.isCanvas2D = true;
-        this.getContext = function (type) {
-            if (type === "2d") {
-                if (!this.context) {
-                    this.context = new Context2D(this);
-                    this.context.canvas = this;
-                }
-
-                return this.context;
-            }
-        }.bind(this);
-    }
+            return this.context;
+        }
+    }.bind(this);
+}
 })();

--- a/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
@@ -7,16 +7,17 @@ var clearTimeout = nativeInterface.timers.clearTimer;
 var setInterval = nativeInterface.timers.setInterval;
 var clearInterval = nativeInterface.timers.clearTimer;
 
-function Source() {
-
+function Source()
+{
 }
 
-function URL() {
+function URL()
+{
     URL.index = 0;
-    URL.createObjectURL = function (blob) {
-        URL.objects.push({ data: blob, key: URL.index });
+    URL.createObjectURL = function(blob) {
+        URL.objects.push({data: blob, key: URL.index});
         return URL.index++;
-    }
+    };
 
     URL.revokeObjectURL = function(url) {
         for (var index = 0; index < URL.objects.length; index++) {
@@ -25,129 +26,130 @@ function URL() {
                 break;
             }
         }
-    }
+    };
 
     URL.objects = [];
 }
 
 URL();
 
-function HTMLElement() {
-
+function HTMLElement()
+{
 }
 
-function Anchor() {
-
+function Anchor()
+{
 }
 
-(function () {
+(function() {
 
-    function makeConsole() {
-        this.logEntries = [];
-        this.warningEntries = [];
-        this.errorEntries = [];
-        this.log = function (entry) {
-            this.logEntries.push(entry);
-            nativeInterface.system.log("log: " + entry + "\r\n");
-        }.bind(this);
+function makeConsole()
+{
+    this.logEntries = [];
+    this.warningEntries = [];
+    this.errorEntries = [];
+    this.log = function(entry) {
+        this.logEntries.push(entry);
+        nativeInterface.system.log('log: ' + entry + '\r\n');
+    }.bind(this);
 
-        this.warn = function (entry) {
-            this.warningEntries.push(entry);
-            nativeInterface.system.log("warn: " + entry + "\r\n");
-        }
+    this.warn = function(entry) {
+        this.warningEntries.push(entry);
+        nativeInterface.system.log('warn: ' + entry + '\r\n');
+    };
 
-        this.error = function (entry) {
-            this.errorEntries.push(entry);
-            nativeInterface.system.log("error: " + entry + "\r\n");
-        }
-    }
+    this.error = function(entry) {
+        this.errorEntries.push(entry);
+        nativeInterface.system.log('error: ' + entry + '\r\n');
+    };
+}
 
-    function makeDocument() {
-        this.createElement = function (type) {
-            if (type === "canvas3D") {
-                if (!this.canvas) {
-                    this.canvas = new makeCanvas3D();
-                }
-                return this.canvas;
-            } else if (type === "canvas") {
-                return new nativeInterface.Canvas2D();
-            } else if (type === 'a') {
-                return new Anchor();
-            } else if (type === "img") {
-                return new Image();
-            } else if (type === "video") {
-                return new HTMLVideoElement();
-            } else if (type === "source") {
-                return new Source();
-            } else {
-                return null;
+function makeDocument()
+{
+    this.createElement = function(type) {
+        if (type === 'canvas3D') {
+            if (!this.canvas) {
+                this.canvas = new makeCanvas3D();
             }
-        }.bind(this);
-
-        nativeInterface.extendWithEventHandling(this);
-
-        this.getElementById = function (id) {
+            return this.canvas;
+        } else if (type === 'canvas') {
+            return new nativeInterface.Canvas2D();
+        } else if (type === 'a') {
+            return new Anchor();
+        } else if (type === 'img') {
+            return new Image();
+        } else if (type === 'video') {
+            return new HTMLVideoElement();
+        } else if (type === 'source') {
+            return new Source();
+        } else {
             return null;
-        };
+        }
+    }.bind(this);
 
-        this.createElementNS = function (ns, type) {
-            return this.createElement(type);
-        }.bind(this);
-    }
+    nativeInterface.extendWithEventHandling(this);
 
-    function makeCanvas3D() {
-        this.getContext = function (type) {
-            if (type === "experimental-webgl" || type === "webgl") {
-                if (this.context) {
-                    return this.context;
-                } else {
-                    this.context = new nativeInterface.makeWebGLRenderingContext();
-                    return this.context;
-                }
+    this.getElementById = function(id) {
+        return null;
+    };
+
+    this.createElementNS = function(ns, type) {
+        return this.createElement(type);
+    }.bind(this);
+}
+
+function makeCanvas3D()
+{
+    this.getContext = function(type) {
+        if (type === 'experimental-webgl' || type === 'webgl') {
+            if (this.context) {
+                return this.context;
+            } else {
+                this.context = new nativeInterface.makeWebGLRenderingContext();
+                return this.context;
             }
-        }.bind(this);
+        }
+    }.bind(this);
 
-        // Lock the size of the canvas3D to the size of the window
-        nativeInterface.mapNativePropertiesToScripted(
-            this,
-            window,
-            [{ scriptedName: "width", nativeName: "innerWidth" },
-            { scriptedName: "height", nativeName: "innerHeight" },
-            { scriptedName: "clientWidth", nativeName: "innerWidth" },
-            { scriptedName: "clientHeight", nativeName: "innerHeight" }
-            ]);
+    // Lock the size of the canvas3D to the size of the window
+    nativeInterface.mapNativePropertiesToScripted(this, window, [
+        {scriptedName: 'width', nativeName: 'innerWidth'},
+        {scriptedName: 'height', nativeName: 'innerHeight'},
+        {scriptedName: 'clientWidth', nativeName: 'innerWidth'},
+        {scriptedName: 'clientHeight', nativeName: 'innerHeight'}
+    ]);
 
-        nativeInterface.extendWithEventHandling(this);
+    nativeInterface.extendWithEventHandling(this);
 
-        this.getBoundingClientRect = function () {
-            var rect = {};
-            rect.top = 0;
-            rect.bottom = window.innerHeight;
+    this.getBoundingClientRect = function() {
+        var rect = {};
+        rect.top = 0;
+        rect.bottom = window.innerHeight;
 
-            rect.width = window.innerWidth;
-            rect.height = window.innerHeight;
+        rect.width = window.innerWidth;
+        rect.height = window.innerHeight;
 
-            rect.left = 0;
-            rect.right = window.innerWidth;
+        rect.left = 0;
+        rect.right = window.innerWidth;
 
-            rect.x = 0;
-            rect.y = 0;
+        rect.x = 0;
+        rect.y = 0;
 
-            return rect;
-        };
+        return rect;
+    };
 
-        // Stub CSS style
-        this.style = {};
+    // Stub CSS style
+    this.style = {};
 
-        this.releasePointerCapture = function () { };
-        this.setPointerCapture = function () { };
-    }
+    this.releasePointerCapture = function() {};
+    this.setPointerCapture = function() {};
+}
 
-    function makeNavigator() {
+function makeNavigator()
+{
+}
 
-    }
-
-    document = new makeDocument();
-    console = new makeConsole();
-    navigator = new makeNavigator();
+document = new makeDocument();
+console = new makeConsole();
+navigator = new makeNavigator();
 })();

--- a/HoloJS/HoloJsHost/ScriptingFramework/FrameworkHelpers.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/FrameworkHelpers.js
@@ -1,64 +1,64 @@
 ﻿var nativeInterface = (nativeInterface ? nativeInterface : {});
 
-(function () {
-    nativeInterface.extendWithEventHandling = function (base) {
-        base.eventListeners = [];
-        base.addEventListener = function (eventType, eventHandler) {
-            if ((base.eventListeners.length === 0) && base.native && base.nativeCallback) {
-                nativeInterface.eventing.setCallback(base.native, base.nativeCallback.bind(base));
-            }
-            base.eventListeners.push({ type: eventType, handler: eventHandler });
-        };
-
-        base.removeEventListener = function (eventType, eventHandler) {
-            var index;
-            var eventListener;
-            for (index = 0; index < base.eventListeners.length; index++) {
-                eventListener = base.eventListeners[index];
-                if (eventListener.type === eventType && eventListener.handler === eventHandler) {
-                    base.eventListeners.splice(index, 1);
-                    break;
-                }
-            }
-
-            if (base.eventListeners.length === 0 && base.native && base.nativeCallback) {
-                nativeInterface.eventing.removeCallback(base.native);
-            }
-        };
-
-        base.fireHandlersByType = function (type, args) {
-            var index;
-            var eventListener;
-            for (index = 0; index < base.eventListeners.length; index++) {
-                eventListener = base.eventListeners[index];
-                if (eventListener.type === type) {
-                    eventListener.handler.call(this, args);
-                }
-            }
-        };
+(function() {
+nativeInterface.extendWithEventHandling = function(base) {
+    base.eventListeners = [];
+    base.addEventListener = function(eventType, eventHandler) {
+        if ((base.eventListeners.length === 0) && base.native && base.nativeCallback) {
+            nativeInterface.eventing.setCallback(base.native, base.nativeCallback.bind(base));
+        }
+        base.eventListeners.push({type: eventType, handler: eventHandler});
     };
 
-    nativeInterface.mapNativePropertiesToScripted = function (scriptedObject, nativeObject, properties) {
+    base.removeEventListener = function(eventType, eventHandler) {
         var index;
-        for (index = 0; index < properties.length; index++) {
-            Object.defineProperty(scriptedObject, properties[index].scriptedName, {
-                get: function () {
-                    return nativeObject[this];
-                }.bind(properties[index].nativeName),
+        var eventListener;
+        for (index = 0; index < base.eventListeners.length; index++) {
+            eventListener = base.eventListeners[index];
+            if (eventListener.type === eventType && eventListener.handler === eventHandler) {
+                base.eventListeners.splice(index, 1);
+                break;
+            }
+        }
 
-                set: function (value) {
-                    nativeObject[this] = value;
-                }.bind(properties[index].nativeName)
-            });
+        if (base.eventListeners.length === 0 && base.native && base.nativeCallback) {
+            nativeInterface.eventing.removeCallback(base.native);
         }
     };
 
-    nativeInterface.mapNativeFunctionsToScripted = function (scriptedObject, nativeObject, functions) {
+    base.fireHandlersByType = function(type, args) {
         var index;
-        for (index = 0; index < functions.length; index++) {
-            scriptedObject[functions[index].scriptedName] = function (args) {
-                return this.thisObject[this.methodName].apply(this.thisObject, arguments);
-            }.bind({ thisObject: nativeObject, methodName: functions[index].nativeName });
+        var eventListener;
+        for (index = 0; index < base.eventListeners.length; index++) {
+            eventListener = base.eventListeners[index];
+            if (eventListener.type === type) {
+                eventListener.handler.call(this, args);
+            }
         }
     };
+};
+
+nativeInterface.mapNativePropertiesToScripted = function(scriptedObject, nativeObject, properties) {
+    var index;
+    for (index = 0; index < properties.length; index++) {
+        Object.defineProperty(scriptedObject, properties[index].scriptedName, {
+            get: function() {
+                return nativeObject[this];
+            }.bind(properties[index].nativeName),
+
+            set: function(value) {
+                nativeObject[this] = value;
+            }.bind(properties[index].nativeName)
+        });
+    }
+};
+
+nativeInterface.mapNativeFunctionsToScripted = function(scriptedObject, nativeObject, functions) {
+    var index;
+    for (index = 0; index < functions.length; index++) {
+        scriptedObject[functions[index].scriptedName] = function(args) {
+            return this.thisObject[this.methodName].apply(this.thisObject, arguments);
+        }.bind({thisObject: nativeObject, methodName: functions[index].nativeName});
+    }
+};
 })();

--- a/HoloJS/HoloJsHost/ScriptingFramework/Image.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/Image.js
@@ -1,48 +1,50 @@
-﻿function HTMLImageElement() { }
+﻿function HTMLImageElement()
+{
+}
 
-function Image() {
-
+function Image()
+{
     this.native = new nativeInterface.image.createImage();
 
-    this.nativeCallback = function (type) {
-        if (type === "load" && arguments.length > 2) {
+    this.nativeCallback = function(type) {
+        if (type === 'load' && arguments.length > 2) {
             this.width = arguments[1];
             this.height = arguments[2];
         }
-        
+
         this.fireHandlersByType(type);
     };
 
     nativeInterface.extendWithEventHandling(this);
 
-    this.stubOnLoad = function () {
+    this.stubOnLoad = function() {
         if (this.loadEvent) {
             this.loadEvent();
         }
-    }
+    };
 
-    Object.defineProperty(this, "onload", {
-        get: function () {
+    Object.defineProperty(this, 'onload', {
+        get: function() {
             return this.loadEvent;
         },
-        set: function (value) {
+        set: function(value) {
             if (!value && this.loadEvent) {
                 this.loadEvent = value;
-                this.removeEventListener("load", this.stubOnLoad);
+                this.removeEventListener('load', this.stubOnLoad);
             } else if (value && !this.loadEvent) {
                 this.loadEvent = value;
-                this.addEventListener("load", this.stubOnLoad);
+                this.addEventListener('load', this.stubOnLoad);
             } else {
                 this.loadEvent = value;
             }
         }
     });
 
-    Object.defineProperty(this, "src", {
-        get: function () {
+    Object.defineProperty(this, 'src', {
+        get: function() {
             return this.source;
         },
-        set: function (value) {
+        set: function(value) {
             this.source = value;
             var isBlob = false;
             for (var index = 0; index < URL.objects.length; index++) {

--- a/HoloJS/HoloJsHost/ScriptingFramework/Video.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/Video.js
@@ -1,9 +1,9 @@
-function HTMLVideoElement() {
-
+function HTMLVideoElement()
+{
     this.native = new nativeInterface.video.createVideo();
 
-    this.nativeCallback = function (type) {
-        if (type === "load" && arguments.length > 2) {
+    this.nativeCallback = function(type) {
+        if (type === 'load' && arguments.length > 2) {
             this.width = arguments[1];
             this.height = arguments[2];
             this.fireHandlersByType('canplaythrough');
@@ -14,45 +14,45 @@ function HTMLVideoElement() {
 
     nativeInterface.extendWithEventHandling(this);
 
-    this.stubOnLoad = function () {
+    this.stubOnLoad = function() {
         if (this.loadEvent) {
             this.loadEvent();
         }
-    }
+    };
 
-    this.play = function () {
+    this.play = function() {
 
-    }
+    };
 
-    Object.defineProperty(this, "onload", {
-        get: function () {
+    Object.defineProperty(this, 'onload', {
+        get: function() {
             return this.loadEvent;
         },
-        set: function (value) {
+        set: function(value) {
             if (!value && this.loadEvent) {
                 this.loadEvent = value;
-                this.removeEventListener("load", this.stubOnLoad);
+                this.removeEventListener('load', this.stubOnLoad);
             } else if (value && !this.loadEvent) {
                 this.loadEvent = value;
-                this.addEventListener("load", this.stubOnLoad);
+                this.addEventListener('load', this.stubOnLoad);
             } else {
                 this.loadEvent = value;
             }
         }
     });
 
-    this.appendChild = function (source) {
+    this.appendChild = function(source) {
         if (source instanceof Source) {
             this.source = source.src;
             nativeInterface.video.setVideoSource(this.native, source.src);
         }
-    }
+    };
 
-    Object.defineProperty(this, "src", {
-        get: function () {
+    Object.defineProperty(this, 'src', {
+        get: function() {
             return this.source;
         },
-        set: function (value) {
+        set: function(value) {
             this.source = value;
             nativeInterface.video.setVideoSource(this.native, value);
         }

--- a/HoloJS/HoloJsHost/ScriptingFramework/WebGL.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/WebGL.js
@@ -1,715 +1,834 @@
-﻿(function () {
-    
-    nativeInterface.makeWebGLRenderingContext = function() {
+﻿(function() {
 
-        this.glContext = nativeInterface.webgl.createContext();
+nativeInterface.makeWebGLRenderingContext = function() {
 
-        this.getError = function () {
-            return 0;
-        };
+    this.glContext = nativeInterface.webgl.createContext();
 
-        this.getShaderPrecisionFormat = function (shadertype, precisiontype) {
-            return nativeInterface.webgl.getShaderPrecisionFormat(this.glContext, shadertype, precisiontype);
-        };
-        this.getExtension = function (name) {
-            return nativeInterface.webgl.getExtension(this.glContext, name);
-        };
-        this.getParameter = function (pname) {
-            return nativeInterface.webgl.getParameter(this.glContext, pname);
-        };
-        this.createRenderbuffer = function () {
-            return nativeInterface.webgl.createRenderbuffer(this.glContext);
-        };
-        this.bindRenderbuffer = function (target, renderbuffer) {
-            if (renderbuffer) {
-                return nativeInterface.webgl.bindRenderbuffer(this.glContext, target, renderbuffer.external);
-            } else {
-                return nativeInterface.webgl.bindRenderbuffer(this.glContext, target, null);
-            }
-        };
-        this.renderbufferStorage = function (target, internalformat, width, height) {
-            return nativeInterface.webgl.renderbufferStorage(this.glContext, target, internalformat, width, height);
-        };
-        this.createFramebuffer = function () {
-            return nativeInterface.webgl.createFramebuffer(this.glContext);
-        };
-        this.bindFramebuffer = function (target, framebuffer) {
-            if (framebuffer) {
-                return nativeInterface.webgl.bindFramebuffer(this.glContext, target, framebuffer.external);
-            } else {
-                return nativeInterface.webgl.bindFramebuffer(this.glContext, target, null);
-            }
-        };
-        this.framebufferRenderbuffer = function (target, attachment, renderbuffertarget, renderbuffer) {
-            return nativeInterface.webgl.framebufferRenderbuffer(this.glContext, target, attachment, renderbuffertarget, renderbuffer.external);
-        };
-        this.framebufferTexture2D = function (target, attachment, textarget, texture, level) {
-            return nativeInterface.webgl.framebufferTexture2D(this.glContext, target, attachment, textarget, texture.external, level);
-        };
-        this.createTexture = function () {
-            return nativeInterface.webgl.createTexture(this.glContext);
-        };
-        this.bindTexture = function (target, texture) {
-            if (texture) {
-                return nativeInterface.webgl.bindTexture(this.glContext, target, texture.external);
-            } else {
-                return nativeInterface.webgl.bindTexture(this.glContext, target, null);
-            }
-        };
-        this.texParameteri = function (target, pname, param) {
-            return nativeInterface.webgl.texParameteri(this.glContext, target, pname, param);
-        };
+    this.getError = function() {
+        return 0;
+    };
 
-        this.texImage2D = function (target, level, internalformat, width, height, border, format, type, pixels) {
-            return nativeInterface.webgl.texImage2D(this.glContext, target, level, internalformat, width, height, border, format, type, pixels.external);
-        };
+    this.getShaderPrecisionFormat = function(shadertype, precisiontype) {
+        return nativeInterface.webgl.getShaderPrecisionFormat(this.glContext, shadertype, precisiontype);
+    };
 
-        this.texImage2D = function () {
-            if (arguments.length === 9) {
-                //GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, ArrayBufferView? pixels
-                nativeInterface.webgl.texImage2D1(this.glContext, arguments[0], arguments[1], arguments[2], arguments[3], arguments[4], arguments[5], arguments[6], arguments[7], arguments[8]);
-            } else if (arguments.length === 6 && (arguments[5] instanceof Image)) {
-                var image = arguments[5];
-                //GLenum target, GLint level, GLenum internalformat, GLenum format, GLenum type, HTMLImageElement image
-                nativeInterface.webgl.texImage2D2(this.glContext, arguments[0], arguments[1], arguments[2], image.width, image.height, arguments[3], arguments[4], image.native);
-            } else if ((arguments.length === 6) && (arguments[5].isCanvas2D === true) && arguments[5].context && arguments[5].context.context2d) {
-                //GLenum target, GLint level, GLenum internalformat, GLenum format, GLenum type, canvas
-                var canvas = arguments[5];
-                nativeInterface.webgl.texImage2D3(this.glContext, arguments[0], arguments[1], arguments[2], canvas.width, canvas.height, arguments[3], arguments[4], canvas.context.context2d);
-            } else if (arguments.length === 6 && (arguments[5] instanceof HTMLVideoElement)) {
-                var video = arguments[5];
-                nativeInterface.webgl.texImage2D4(this.glContext, arguments[0], arguments[1], arguments[2], video.width, video.height, arguments[3], arguments[4], video.native);
-            } else {
-                throw DOMException();
-            }
-        };
+    this.getExtension = function(name) {
+        return nativeInterface.webgl.getExtension(this.glContext, name);
+    };
 
+    this.getParameter = function(pname) {
+        return nativeInterface.webgl.getParameter(this.glContext, pname);
+    };
 
-        this.activeTexture = function (texture) {
-            return nativeInterface.webgl.activeTexture(this.glContext, texture);
-        };
-        this.generateMipmap = function (target) {
-            return nativeInterface.webgl.generateMipmap(this.glContext, target);
-        };
-        this.pixelStorei = function (pname, param) {
-            return nativeInterface.webgl.pixelStorei(this.glContext, pname, param);
-        };
-        this.clearDepth = function (depth) {
-            return nativeInterface.webgl.clearDepth(this.glContext, depth);
-        };
-        this.clearStencil = function (s) {
-            return nativeInterface.webgl.clearStencil(this.glContext, s);
-        };
-        this.enable = function (cap) {
-            return nativeInterface.webgl.enable(this.glContext, cap);
-        };
-        this.disable = function (cap) {
-            return nativeInterface.webgl.disable(this.glContext, cap);
-        };
-        this.depthFunc = function (func) {
-            return nativeInterface.webgl.depthFunc(this.glContext, func);
-        };
-        this.depthMask = function (flag) {
-            return nativeInterface.webgl.depthMask(this.glContext, flag);
-        };
-        this.depthRange = function (zNear, zFar) {
-            return nativeInterface.webgl.depthRange(this.glContext, zNear, zFar);
-        };
-        this.frontFace = function (mode) {
-            return nativeInterface.webgl.frontFace(this.glContext, mode);
-        };
-        this.cullFace = function (mode) {
-            return nativeInterface.webgl.cullFace(this.glContext, mode);
-        };
-        this.blendColor = function (red, green, blue, alpha) {
-            return nativeInterface.webgl.blendColor(this.glContext, red, green, blue, alpha);
-        };
-        this.blendEquation = function (mode) {
-            return nativeInterface.webgl.blendEquation(this.glContext, mode);
-        };
-        this.blendEquationSeparate = function (modeRGB, modeAlpha) {
-            return nativeInterface.webgl.blendEquationSeparate(this.glContext, modeRGB, modeAlpha);
-        };
-        this.blendFunc = function (sfactor, dfactor) {
-            return nativeInterface.webgl.blendFunc(this.glContext, sfactor, dfactor);
-        };
-        this.blendFuncSeparate = function (srcRGB, dstRGB, srcAlpha, dstAlpha) {
-            return nativeInterface.webgl.blendFuncSeparate(this.glContext, srcRGB, dstRGB, srcAlpha, dstAlpha);
-        };
-        this.scissor = function (x, y, width, height) {
-            return nativeInterface.webgl.scissor(this.glContext, x, y, width, height);
-        };
-        this.viewport = function (x, y, width, height) {
-            return nativeInterface.webgl.viewport(this.glContext, x, y, width, height);
-        };
-        this.clearColor = function (red, green, blue, alpha) {
-            return nativeInterface.webgl.clearColor(this.glContext, red, green, blue, alpha);
-        };
-        this.clear = function (mask) {
-            return nativeInterface.webgl.clear(this.glContext, mask);
-        };
-        this.createBuffer = function () {
-            return nativeInterface.webgl.createBuffer(this.glContext);
-        };
-        this.bindBuffer = function (target, buffer) {
-            if (buffer) {
-                return nativeInterface.webgl.bindBuffer(this.glContext, target, buffer.external);
-            } else {
-                return nativeInterface.webgl.bindBuffer(this.glContext, target, null);
-            }
-        };
+    this.createRenderbuffer = function() {
+        return nativeInterface.webgl.createRenderbuffer(this.glContext);
+    };
 
-        this.bufferData = function (target, size, usage) {
-            if (typeof size === "number") {
-                return nativeInterface.webgl.bufferData1(this.glContext, target, size, usage);
-            } else {
-                // size is data
-                return nativeInterface.webgl.bufferData2(this.glContext, target, size, usage);
-            }
-        };
+    this.bindRenderbuffer = function(target, renderbuffer) {
+        if (renderbuffer) {
+            return nativeInterface.webgl.bindRenderbuffer(this.glContext, target, renderbuffer.external);
+        } else {
+            return nativeInterface.webgl.bindRenderbuffer(this.glContext, target, null);
+        }
+    };
 
-        this.deleteBuffer = function (buffer) {
-            return nativeInterface.webgl.deleteBuffer(this.glContext, buffer.external);
-        };
+    this.renderbufferStorage = function(target, internalformat, width, height) {
+        return nativeInterface.webgl.renderbufferStorage(this.glContext, target, internalformat, width, height);
+    };
 
-        this.colorMask = function (red, green, blue, alpha) {
-            return nativeInterface.webgl.colorMask(this.glContext, red, green, blue, alpha);
-        };
-        this.drawArrays = function (mode, first, count) {
-            return nativeInterface.webgl.drawArrays(this.glContext, mode, first, count);
-        };
-        this.drawElements = function (mode, count, type, offset) {
-            return nativeInterface.webgl.drawElements(this.glContext, mode, count, type, offset);
-        };
-        this.enableVertexAttribArray = function (index) {
-            return nativeInterface.webgl.enableVertexAttribArray(this.glContext, index);
-        };
-        this.disableVertexAttribArray = function (index) {
-            return nativeInterface.webgl.disableVertexAttribArray(this.glContext, index);
-        };
-        this.vertexAttribPointer = function (indx, size, type, normalized, stride, offset) {
-            return nativeInterface.webgl.vertexAttribPointer(this.glContext, indx, size, type, normalized, stride, offset);
-        };
-        this.createProgram = function () {
-            return nativeInterface.webgl.createProgram(this.glContext);
-        };
-        this.useProgram = function (program) {
-            return nativeInterface.webgl.useProgram(this.glContext, program.external);
-        };
-        this.validateProgram = function (program) {
-            return nativeInterface.webgl.validateProgram(this.glContext, program.external);
-        };
-        this.linkProgram = function (program) {
-            return nativeInterface.webgl.linkProgram(this.glContext, program.external);
-        };
-        this.getProgramParameter = function (program, pname) {
-            return nativeInterface.webgl.getProgramParameter(this.glContext, program.external, pname);
-        };
-        this.getProgramInfoLog = function (program) {
-            return nativeInterface.webgl.getProgramInfoLog(this.glContext, program.external);
-        };
-        this.deleteProgram = function (program) {
-            return nativeInterface.webgl.deleteProgram(this.glContext, program.external);
-        };
-        this.bindAttribLocation = function (program, index, name) {
-            return nativeInterface.webgl.bindAttribLocation(this.glContext, program.external, index, name);
-        };
-        this.getActiveUniform = function (program, index) {
-            return nativeInterface.webgl.getActiveUniform(this.glContext, program.external, index);
-        };
-        this.getActiveAttrib = function (program, index) {
-            return nativeInterface.webgl.getActiveAttrib(this.glContext, program.external, index);
-        };
-        this.getAttribLocation = function (program, name) {
-            return nativeInterface.webgl.getAttribLocation(this.glContext, program.external, name);
-        };
-        this.createShader = function (type) {
-            return nativeInterface.webgl.createShader(this.glContext, type);
-        };
-        this.shaderSource = function (shader, source) {
-            return nativeInterface.webgl.shaderSource(this.glContext, shader.external, source);
-        };
-        this.compileShader = function (shader) {
-            return nativeInterface.webgl.compileShader(this.glContext, shader.external);
-        };
-        this.getShaderParameter = function (shader, pname) {
-            return nativeInterface.webgl.getShaderParameter(this.glContext, shader.external, pname);
-        };
-        this.getShaderInfoLog = function (shader) {
-            return nativeInterface.webgl.getShaderInfoLog(this.glContext, shader.external);
-        };
-        this.attachShader = function (program, shader) {
-            return nativeInterface.webgl.attachShader(this.glContext, program.external, shader.external);
-        };
-        this.deleteShader = function (shader) {
-            return nativeInterface.webgl.deleteShader(this.glContext, shader.external);
-        };
-        this.getUniformLocation = function (program, name) {
-            return nativeInterface.webgl.getUniformLocation(this.glContext, program.external, name);
-        };
-        this.uniform1f = function (location, x) {
-            return nativeInterface.webgl.uniform1f(this.glContext, location.external, x);
-        };
-        this.uniform1fv = function (location, v) {
-            return nativeInterface.webgl.uniform1fv(this.glContext, location.external, v);
-        };
-        this.uniform1i = function (location, x) {
-            return nativeInterface.webgl.uniform1i(this.glContext, location.external, x);
-        };
-        this.uniform1iv = function (location, v) {
-            return nativeInterface.webgl.uniform1iv(this.glContext, location.external, v);
-        };
-        this.uniform2f = function (location, x, y) {
-            return nativeInterface.webgl.uniform2f(this.glContext, location.external, x, y);
-        };
-        this.uniform2fv = function (location, v) {
-            return nativeInterface.webgl.uniform2fv(this.glContext, location.external, Float32Array.from(v));
-        };
-        this.uniform2i = function (location, x, y) {
-            return nativeInterface.webgl.uniform2i(this.glContext, location.external, x, y);
-        };
-        this.uniform2iv = function (location, v) {
-            return nativeInterface.webgl.uniform2iv(this.glContext, location.external, Int32Array.from(v));
-        };
-        this.uniform3f = function (location, x, y, z) {
-            return nativeInterface.webgl.uniform3f(this.glContext, location.external, x, y, z);
-        };
-        this.uniform3fv = function (location, v) {
-            return nativeInterface.webgl.uniform3fv(this.glContext, location.external, Float32Array.from(v));
-        };
-        this.uniform3i = function (location, x, y, z) {
-            return nativeInterface.webgl.uniform3i(this.glContext, location.external, x, y, z);
-        };
-        this.uniform3iv = function (location, v) {
-            return nativeInterface.webgl.uniform3iv(this.glContext, location.external, Int32Array.from(v));
-        };
-        this.uniform4f = function (location, x, y, z, w) {
-            return nativeInterface.webgl.uniform4f(this.glContext, location.external, x, y, z, w);
-        };
-        this.uniform4fv = function (location, v) {
-            return nativeInterface.webgl.uniform4fv(this.glContext, location.external, Float32Array.from(v));
-        };
-        this.uniform4i = function (location, x, y, z, w) {
-            return nativeInterface.webgl.uniform4i(this.glContext, location.external, x, y, z, w);
-        };
-        this.uniform4iv = function (location, v) {
-            return nativeInterface.webgl.uniform4iv(this.glContext, location.external, Int32Array.from(v));
-        };
-        this.uniformMatrix2fv = function (location, transpose, value) {
-            return nativeInterface.webgl.uniformMatrix2fv(this.glContext, location.external, transpose, Float32Array.from(value));
-        };
-        this.uniformMatrix3fv = function (location, transpose, value) {
-            return nativeInterface.webgl.uniformMatrix3fv(this.glContext, location.external, transpose, Float32Array.from(value));
-        };
-        this.uniformMatrix4fv = function (location, transpose, value) {
-            return nativeInterface.webgl.uniformMatrix4fv(this.glContext, location.external, transpose, Float32Array.from(value));
-        };
-        this.stencilFunc = function (func, ref, mask) {
-            return nativeInterface.webgl.stencilFunc(this.glContext, func, ref, mask);
-        };
-        this.stencilMask = function (mask) {
-            return nativeInterface.webgl.stencilMask(this.glContext, mask);
-        };
-        this.stencilOp = function (fail, zfail, zpass) {
-            return nativeInterface.webgl.stencilOp(this.glContext, fail, zfail, zpass);
-        };
+    this.createFramebuffer = function() {
+        return nativeInterface.webgl.createFramebuffer(this.glContext);
+    };
 
-        this.lineWidth = function (width) {
-            return nativeInterface.webgl.lineWidth(this.glContext, width);
-        };
+    this.bindFramebuffer = function(target, framebuffer) {
+        if (framebuffer) {
+            return nativeInterface.webgl.bindFramebuffer(this.glContext, target, framebuffer.external);
+        } else {
+            return nativeInterface.webgl.bindFramebuffer(this.glContext, target, null);
+        }
+    };
 
-        this.DEPTH_BUFFER_BIT = 0x00000100;
-        this.STENCIL_BUFFER_BIT = 0x00000400;
-        this.COLOR_BUFFER_BIT = 0x00004000;
+    this.framebufferRenderbuffer = function(target, attachment, renderbuffertarget, renderbuffer) {
+        return nativeInterface.webgl.framebufferRenderbuffer(
+            this.glContext, target, attachment, renderbuffertarget, renderbuffer.external);
+    };
 
-        /* BeginMode */
-        this.POINTS = 0x0000;
-        this.LINES = 0x0001;
-        this.LINE_LOOP = 0x0002;
-        this.LINE_STRIP = 0x0003;
-        this.TRIANGLES = 0x0004;
-        this.TRIANGLE_STRIP = 0x0005;
-        this.TRIANGLE_FAN = 0x0006;
+    this.framebufferTexture2D = function(target, attachment, textarget, texture, level) {
+        return nativeInterface.webgl.framebufferTexture2D(
+            this.glContext, target, attachment, textarget, texture.external, level);
+    };
 
-        /* BlendingFactorDest */
-        this.ZERO = 0;
-        this.ONE = 1;
-        this.SRC_COLOR = 0x0300;
-        this.ONE_MINUS_SRC_COLOR = 0x0301;
-        this.SRC_ALPHA = 0x0302;
-        this.ONE_MINUS_SRC_ALPHA = 0x0303;
-        this.DST_ALPHA = 0x0304;
-        this.ONE_MINUS_DST_ALPHA = 0x0305;
+    this.createTexture = function() {
+        return nativeInterface.webgl.createTexture(this.glContext);
+    };
 
-        /* BlendingFactorSrc */
-        this.DST_COLOR = 0x0306;
-        this.ONE_MINUS_DST_COLOR = 0x0307;
-        this.SRC_ALPHA_SATURATE = 0x0308;
+    this.bindTexture = function(target, texture) {
+        if (texture) {
+            return nativeInterface.webgl.bindTexture(this.glContext, target, texture.external);
+        } else {
+            return nativeInterface.webgl.bindTexture(this.glContext, target, null);
+        }
+    };
 
-        /* BlendEquationSeparate */
-        this.FUNC_ADD = 0x8006;
-        this.BLEND_EQUATION = 0x8009;
-        this.BLEND_EQUATION_RGB = 0x8009;   /* same as BLEND_EQUATION */
-        this.BLEND_EQUATION_ALPHA = 0x883D;
+    this.texParameteri = function(target, pname, param) {
+        return nativeInterface.webgl.texParameteri(this.glContext, target, pname, param);
+    };
 
-        /* BlendSubtract */
-        this.FUNC_SUBTRACT = 0x800A;
-        this.FUNC_REVERSE_SUBTRACT = 0x800B;
+    this.texImage2D = function(target, level, internalformat, width, height, border, format, type, pixels) {
+        return nativeInterface.webgl.texImage2D(
+            this.glContext, target, level, internalformat, width, height, border, format, type, pixels.external);
+    };
 
-        /* Separate Blend Functions */
-        this.BLEND_DST_RGB = 0x80C8;
-        this.BLEND_SRC_RGB = 0x80C9;
-        this.BLEND_DST_ALPHA = 0x80CA;
-        this.BLEND_SRC_ALPHA = 0x80CB;
-        this.CONSTANT_COLOR = 0x8001;
-        this.ONE_MINUS_CONSTANT_COLOR = 0x8002;
-        this.CONSTANT_ALPHA = 0x8003;
-        this.ONE_MINUS_CONSTANT_ALPHA = 0x8004;
-        this.BLEND_COLOR = 0x8005;
+    this.texImage2D = function() {
+        if (arguments.length === 9) {
+            // GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLenum
+            // format, GLenum type, ArrayBufferView? pixels
+            nativeInterface.webgl.texImage2D1(this.glContext,
+                                              arguments[0],
+                                              arguments[1],
+                                              arguments[2],
+                                              arguments[3],
+                                              arguments[4],
+                                              arguments[5],
+                                              arguments[6],
+                                              arguments[7],
+                                              arguments[8]);
+        } else if (arguments.length === 6 && (arguments[5] instanceof Image)) {
+            var image = arguments[5];
+            // GLenum target, GLint level, GLenum internalformat, GLenum format, GLenum type, HTMLImageElement image
+            nativeInterface.webgl.texImage2D2(this.glContext,
+                                              arguments[0],
+                                              arguments[1],
+                                              arguments[2],
+                                              image.width,
+                                              image.height,
+                                              arguments[3],
+                                              arguments[4],
+                                              image.native);
+        } else if ((arguments.length === 6) && (arguments[5].isCanvas2D === true) && arguments[5].context &&
+                   arguments[5].context.context2d) {
+            // GLenum target, GLint level, GLenum internalformat, GLenum format, GLenum type, canvas
+            var canvas = arguments[5];
+            nativeInterface.webgl.texImage2D3(this.glContext,
+                                              arguments[0],
+                                              arguments[1],
+                                              arguments[2],
+                                              canvas.width,
+                                              canvas.height,
+                                              arguments[3],
+                                              arguments[4],
+                                              canvas.context.context2d);
+        } else if (arguments.length === 6 && (arguments[5] instanceof HTMLVideoElement)) {
+            var video = arguments[5];
+            nativeInterface.webgl.texImage2D4(this.glContext,
+                                              arguments[0],
+                                              arguments[1],
+                                              arguments[2],
+                                              video.width,
+                                              video.height,
+                                              arguments[3],
+                                              arguments[4],
+                                              video.native);
+        } else {
+            throw DOMException();
+        }
+    };
 
-        /* Buffer Objects */
-        this.ARRAY_BUFFER = 0x8892;
-        this.ELEMENT_ARRAY_BUFFER = 0x8893;
-        this.ARRAY_BUFFER_BINDING = 0x8894;
-        this.ELEMENT_ARRAY_BUFFER_BINDING = 0x8895;
+    this.activeTexture = function(texture) {
+        return nativeInterface.webgl.activeTexture(this.glContext, texture);
+    };
 
-        this.STREAM_DRAW = 0x88E0;
-        this.STATIC_DRAW = 0x88E4;
-        this.DYNAMIC_DRAW = 0x88E8;
+    this.generateMipmap = function(target) {
+        return nativeInterface.webgl.generateMipmap(this.glContext, target);
+    };
 
-        this.BUFFER_SIZE = 0x8764;
-        this.BUFFER_USAGE = 0x8765;
+    this.pixelStorei = function(pname, param) {
+        return nativeInterface.webgl.pixelStorei(this.glContext, pname, param);
+    };
 
-        this.CURRENT_VERTEX_ATTRIB = 0x8626;
+    this.clearDepth = function(depth) {
+        return nativeInterface.webgl.clearDepth(this.glContext, depth);
+    };
 
-        /* CullFaceMode */
-        this.FRONT = 0x0404;
-        this.BACK = 0x0405;
-        this.FRONT_AND_BACK = 0x0408;
+    this.clearStencil = function(s) {
+        return nativeInterface.webgl.clearStencil(this.glContext, s);
+    };
 
-        /* EnableCap */
-        /* TEXTURE_2D */
-        this.CULL_FACE = 0x0B44;
-        this.BLEND = 0x0BE2;
-        this.DITHER = 0x0BD0;
-        this.STENCIL_TEST = 0x0B90;
-        this.DEPTH_TEST = 0x0B71;
-        this.SCISSOR_TEST = 0x0C11;
-        this.POLYGON_OFFSET_FILL = 0x8037;
-        this.SAMPLE_ALPHA_TO_COVERAGE = 0x809E;
-        this.SAMPLE_COVERAGE = 0x80A0;
+    this.enable = function(cap) {
+        return nativeInterface.webgl.enable(this.glContext, cap);
+    };
 
-        /* ErrorCode */
+    this.disable = function(cap) {
+        return nativeInterface.webgl.disable(this.glContext, cap);
+    };
 
-        this.NO_ERROR = 0;
-        this.INVALID_ENUM = 0x0500;
-        this.INVALID_VALUE = 0x0501;
-        this.INVALID_OPERATION = 0x0502;
-        this.OUT_OF_MEMORY = 0x0505;
+    this.depthFunc = function(func) {
+        return nativeInterface.webgl.depthFunc(this.glContext, func);
+    };
 
-        /* FrontFaceDirection */
-        this.CW = 0x0900;
-        this.CCW = 0x0901;
+    this.depthMask = function(flag) {
+        return nativeInterface.webgl.depthMask(this.glContext, flag);
+    };
 
-        /* GetPName */
-        this.LINE_WIDTH = 0x0B21;
-        this.ALIASED_POINT_SIZE_RANGE = 0x846D;
-        this.ALIASED_LINE_WIDTH_RANGE = 0x846E;
-        this.CULL_FACE_MODE = 0x0B45;
-        this.FRONT_FACE = 0x0B46;
-        this.DEPTH_RANGE = 0x0B70;
-        this.DEPTH_WRITEMASK = 0x0B72;
-        this.DEPTH_CLEAR_VALUE = 0x0B73;
-        this.DEPTH_FUNC = 0x0B74;
-        this.STENCIL_CLEAR_VALUE = 0x0B91;
-        this.STENCIL_FUNC = 0x0B92;
-        this.STENCIL_FAIL = 0x0B94;
-        this.STENCIL_PASS_DEPTH_FAIL = 0x0B95;
-        this.STENCIL_PASS_DEPTH_PASS = 0x0B96;
-        this.STENCIL_REF = 0x0B97;
-        this.STENCIL_VALUE_MASK = 0x0B93;
-        this.STENCIL_WRITEMASK = 0x0B98;
-        this.STENCIL_BACK_FUNC = 0x8800;
-        this.STENCIL_BACK_FAIL = 0x8801;
-        this.STENCIL_BACK_PASS_DEPTH_FAIL = 0x8802;
-        this.STENCIL_BACK_PASS_DEPTH_PASS = 0x8803;
-        this.STENCIL_BACK_REF = 0x8CA3;
-        this.STENCIL_BACK_VALUE_MASK = 0x8CA4;
-        this.STENCIL_BACK_WRITEMASK = 0x8CA5;
-        this.VIEWPORT = 0x0BA2;
-        this.SCISSOR_BOX = 0x0C10;
-        /*      SCISSOR_TEST */
-        this.COLOR_CLEAR_VALUE = 0x0C22;
-        this.COLOR_WRITEMASK = 0x0C23;
-        this.UNPACK_ALIGNMENT = 0x0CF5;
-        this.PACK_ALIGNMENT = 0x0D05;
-        this.MAX_TEXTURE_SIZE = 0x0D33;
-        this.MAX_VIEWPORT_DIMS = 0x0D3A;
-        this.SUBPIXEL_BITS = 0x0D50;
-        this.RED_BITS = 0x0D52;
-        this.GREEN_BITS = 0x0D53;
-        this.BLUE_BITS = 0x0D54;
-        this.ALPHA_BITS = 0x0D55;
-        this.DEPTH_BITS = 0x0D56;
-        this.STENCIL_BITS = 0x0D57;
-        this.POLYGON_OFFSET_UNITS = 0x2A00;
-        /*      POLYGON_OFFSET_FILL */
-        this.POLYGON_OFFSET_FACTOR = 0x8038;
-        this.TEXTURE_BINDING_2D = 0x8069;
-        this.SAMPLE_BUFFERS = 0x80A8;
-        this.SAMPLES = 0x80A9;
-        this.SAMPLE_COVERAGE_VALUE = 0x80AA;
-        SAMPLE_COVERAGE_INVERT = 0x80AB;
+    this.depthRange = function(zNear, zFar) {
+        return nativeInterface.webgl.depthRange(this.glContext, zNear, zFar);
+    };
 
-        /* GetTextureParameter */
-        /*      TEXTURE_MAG_FILTER */
-        /*      TEXTURE_MIN_FILTER */
-        /*      TEXTURE_WRAP_S */
-        /*      TEXTURE_WRAP_T */
+    this.frontFace = function(mode) {
+        return nativeInterface.webgl.frontFace(this.glContext, mode);
+    };
 
-        this.COMPRESSED_TEXTURE_FORMATS = 0x86A3;
+    this.cullFace = function(mode) {
+        return nativeInterface.webgl.cullFace(this.glContext, mode);
+    };
 
-        /* HintMode */
-        this.DONT_CARE = 0x1100;
-        this.FASTEST = 0x1101;
-        this.NICEST = 0x1102;
+    this.blendColor = function(red, green, blue, alpha) {
+        return nativeInterface.webgl.blendColor(this.glContext, red, green, blue, alpha);
+    };
 
-        /* HintTarget */
-        this.GENERATE_MIPMAP_HINT = 0x8192;
+    this.blendEquation = function(mode) {
+        return nativeInterface.webgl.blendEquation(this.glContext, mode);
+    };
 
-        /* DataType */
-        this.BYTE = 0x1400;
-        this.UNSIGNED_BYTE = 0x1401;
-        this.SHORT = 0x1402;
-        this.UNSIGNED_SHORT = 0x1403;
-        this.INT = 0x1404;
-        this.UNSIGNED_INT = 0x1405;
-        this.FLOAT = 0x1406;
+    this.blendEquationSeparate = function(modeRGB, modeAlpha) {
+        return nativeInterface.webgl.blendEquationSeparate(this.glContext, modeRGB, modeAlpha);
+    };
 
-        /* PixelFormat */
-        this.DEPTH_COMPONENT = 0x1902;
-        this.ALPHA = 0x1906;
-        this.RGB = 0x1907;
-        this.RGBA = 0x1908;
-        this.LUMINANCE = 0x1909;
-        this.LUMINANCE_ALPHA = 0x190A;
+    this.blendFunc = function(sfactor, dfactor) {
+        return nativeInterface.webgl.blendFunc(this.glContext, sfactor, dfactor);
+    };
 
-        /* PixelType */
-        /*      UNSIGNED_BYTE */
-        this.UNSIGNED_SHORT_4_4_4_4 = 0x8033;
-        this.UNSIGNED_SHORT_5_5_5_1 = 0x8034;
-        this.UNSIGNED_SHORT_5_6_5 = 0x8363;
+    this.blendFuncSeparate = function(srcRGB, dstRGB, srcAlpha, dstAlpha) {
+        return nativeInterface.webgl.blendFuncSeparate(this.glContext, srcRGB, dstRGB, srcAlpha, dstAlpha);
+    };
 
-        /* Shaders */
-        this.FRAGMENT_SHADER = 0x8B30;
-        this.VERTEX_SHADER = 0x8B31;
-        this.MAX_VERTEX_ATTRIBS = 0x8869;
-        this.MAX_VERTEX_UNIFORM_VECTORS = 0x8DFB;
-        this.MAX_VARYING_VECTORS = 0x8DFC;
-        this.MAX_COMBINED_TEXTURE_IMAGE_UNITS = 0x8B4D;
-        this.MAX_VERTEX_TEXTURE_IMAGE_UNITS = 0x8B4C;
-        this.MAX_TEXTURE_IMAGE_UNITS = 0x8872;
-        this.MAX_FRAGMENT_UNIFORM_VECTORS = 0x8DFD;
-        this.SHADER_TYPE = 0x8B4F;
-        this.DELETE_STATUS = 0x8B80;
-        this.LINK_STATUS = 0x8B82;
-        this.VALIDATE_STATUS = 0x8B83;
-        this.ATTACHED_SHADERS = 0x8B85;
-        this.ACTIVE_UNIFORMS = 0x8B86;
-        this.ACTIVE_ATTRIBUTES = 0x8B89;
-        this.SHADING_LANGUAGE_VERSION = 0x8B8C;
-        this.CURRENT_PROGRAM = 0x8B8D;
+    this.scissor = function(x, y, width, height) {
+        return nativeInterface.webgl.scissor(this.glContext, x, y, width, height);
+    };
 
-        /* StencilFunction */
-        this.NEVER = 0x0200;
-        this.LESS = 0x0201;
-        this.EQUAL = 0x0202;
-        this.LEQUAL = 0x0203;
-        this.GREATER = 0x0204;
-        this.NOTEQUAL = 0x0205;
-        this.GEQUAL = 0x0206;
-        this.ALWAYS = 0x0207;
+    this.viewport = function(x, y, width, height) {
+        return nativeInterface.webgl.viewport(this.glContext, x, y, width, height);
+    };
 
-        /* StencilOp */
-        /*      ZERO */
-        this.KEEP = 0x1E00;
-        this.REPLACE = 0x1E01;
-        this.INCR = 0x1E02;
-        this.DECR = 0x1E03;
-        this.INVERT = 0x150A;
-        this.INCR_WRAP = 0x8507;
-        this.DECR_WRAP = 0x8508;
+    this.clearColor = function(red, green, blue, alpha) {
+        return nativeInterface.webgl.clearColor(this.glContext, red, green, blue, alpha);
+    };
 
-        /* StringName */
-        this.VENDOR = 0x1F00;
-        this.RENDERER = 0x1F01;
-        this.VERSION = 0x1F02;
+    this.clear = function(mask) {
+        return nativeInterface.webgl.clear(this.glContext, mask);
+    };
 
-        /* TextureMagFilter */
-        this.NEAREST = 0x2600;
-        this.LINEAR = 0x2601;
+    this.createBuffer = function() {
+        return nativeInterface.webgl.createBuffer(this.glContext);
+    };
 
-        /* TextureMinFilter */
-        /*      NEAREST */
-        /*      LINEAR */
-        this.NEAREST_MIPMAP_NEAREST = 0x2700;
-        this.LINEAR_MIPMAP_NEAREST = 0x2701;
-        this.NEAREST_MIPMAP_LINEAR = 0x2702;
-        this.LINEAR_MIPMAP_LINEAR = 0x2703;
+    this.bindBuffer = function(target, buffer) {
+        if (buffer) {
+            return nativeInterface.webgl.bindBuffer(this.glContext, target, buffer.external);
+        } else {
+            return nativeInterface.webgl.bindBuffer(this.glContext, target, null);
+        }
+    };
 
-        /* TextureParameterName */
-        this.TEXTURE_MAG_FILTER = 0x2800;
-        this.TEXTURE_MIN_FILTER = 0x2801;
-        this.TEXTURE_WRAP_S = 0x2802;
-        this.TEXTURE_WRAP_T = 0x2803;
+    this.bufferData = function(target, size, usage) {
+        if (typeof size === 'number') {
+            return nativeInterface.webgl.bufferData1(this.glContext, target, size, usage);
+        } else {
+            // size is data
+            return nativeInterface.webgl.bufferData2(this.glContext, target, size, usage);
+        }
+    };
 
-        /* TextureTarget */
-        this.TEXTURE_2D = 0x0DE1;
-        this.TEXTURE = 0x1702;
+    this.deleteBuffer = function(buffer) {
+        return nativeInterface.webgl.deleteBuffer(this.glContext, buffer.external);
+    };
 
-        this.TEXTURE_CUBE_MAP = 0x8513;
-        this.TEXTURE_BINDING_CUBE_MAP = 0x8514;
-        this.TEXTURE_CUBE_MAP_POSITIVE_X = 0x8515;
-        this.TEXTURE_CUBE_MAP_NEGATIVE_X = 0x8516;
-        this.TEXTURE_CUBE_MAP_POSITIVE_Y = 0x8517;
-        this.TEXTURE_CUBE_MAP_NEGATIVE_Y = 0x8518;
-        this.TEXTURE_CUBE_MAP_POSITIVE_Z = 0x8519;
-        this.TEXTURE_CUBE_MAP_NEGATIVE_Z = 0x851A;
-        this.MAX_CUBE_MAP_TEXTURE_SIZE = 0x851C;
+    this.colorMask = function(red, green, blue, alpha) {
+        return nativeInterface.webgl.colorMask(this.glContext, red, green, blue, alpha);
+    };
 
-        /* TextureUnit */
-        this.TEXTURE0 = 0x84C0;
-        this.TEXTURE1 = 0x84C1;
-        this.TEXTURE2 = 0x84C2;
-        this.TEXTURE3 = 0x84C3;
-        this.TEXTURE4 = 0x84C4;
-        this.TEXTURE5 = 0x84C5;
-        this.TEXTURE6 = 0x84C6;
-        this.TEXTURE7 = 0x84C7;
-        this.TEXTURE8 = 0x84C8;
-        this.TEXTURE9 = 0x84C9;
-        this.TEXTURE10 = 0x84CA;
-        this.TEXTURE11 = 0x84CB;
-        this.TEXTURE12 = 0x84CC;
-        this.TEXTURE13 = 0x84CD;
-        this.TEXTURE14 = 0x84CE;
-        this.TEXTURE15 = 0x84CF;
-        this.TEXTURE16 = 0x84D0;
-        this.TEXTURE17 = 0x84D1;
-        this.TEXTURE18 = 0x84D2;
-        this.TEXTURE19 = 0x84D3;
-        this.TEXTURE20 = 0x84D4;
-        this.TEXTURE21 = 0x84D5;
-        this.TEXTURE22 = 0x84D6;
-        this.TEXTURE23 = 0x84D7;
-        this.TEXTURE24 = 0x84D8;
-        this.TEXTURE25 = 0x84D9;
-        this.TEXTURE26 = 0x84DA;
-        this.TEXTURE27 = 0x84DB;
-        this.TEXTURE28 = 0x84DC;
-        this.TEXTURE29 = 0x84DD;
-        this.TEXTURE30 = 0x84DE;
-        this.TEXTURE31 = 0x84DF;
-        this.ACTIVE_TEXTURE = 0x84E0;
+    this.drawArrays = function(mode, first, count) {
+        return nativeInterface.webgl.drawArrays(this.glContext, mode, first, count);
+    };
 
-        /* TextureWrapMode */
-        this.REPEAT = 0x2901;
-        this.CLAMP_TO_EDGE = 0x812F;
-        this.MIRRORED_REPEAT = 0x8370;
+    this.drawElements = function(mode, count, type, offset) {
+        return nativeInterface.webgl.drawElements(this.glContext, mode, count, type, offset);
+    };
 
-        /* Uniform Types */
-        this.FLOAT_VEC2 = 0x8B50;
-        this.FLOAT_VEC3 = 0x8B51;
-        this.FLOAT_VEC4 = 0x8B52;
-        this.INT_VEC2 = 0x8B53;
-        this.INT_VEC3 = 0x8B54;
-        this.INT_VEC4 = 0x8B55;
-        this.BOOL = 0x8B56;
-        this.BOOL_VEC2 = 0x8B57;
-        this.BOOL_VEC3 = 0x8B58;
-        this.BOOL_VEC4 = 0x8B59;
-        this.FLOAT_MAT2 = 0x8B5A;
-        this.FLOAT_MAT3 = 0x8B5B;
-        this.FLOAT_MAT4 = 0x8B5C;
-        this.SAMPLER_2D = 0x8B5E;
-        this.SAMPLER_CUBE = 0x8B60;
+    this.enableVertexAttribArray = function(index) {
+        return nativeInterface.webgl.enableVertexAttribArray(this.glContext, index);
+    };
 
-        /* Vertex Arrays */
-        this.VERTEX_ATTRIB_ARRAY_ENABLED = 0x8622;
-        this.VERTEX_ATTRIB_ARRAY_SIZE = 0x8623;
-        this.VERTEX_ATTRIB_ARRAY_STRIDE = 0x8624;
-        this.VERTEX_ATTRIB_ARRAY_TYPE = 0x8625;
-        this.VERTEX_ATTRIB_ARRAY_NORMALIZED = 0x886A;
-        this.VERTEX_ATTRIB_ARRAY_POINTER = 0x8645;
-        this.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING = 0x889F;
+    this.disableVertexAttribArray = function(index) {
+        return nativeInterface.webgl.disableVertexAttribArray(this.glContext, index);
+    };
 
-        /* Read Format */
-        this.IMPLEMENTATION_COLOR_READ_TYPE = 0x8B9A;
-        this.IMPLEMENTATION_COLOR_READ_FORMAT = 0x8B9B;
+    this.vertexAttribPointer = function(indx, size, type, normalized, stride, offset) {
+        return nativeInterface.webgl.vertexAttribPointer(this.glContext, indx, size, type, normalized, stride, offset);
+    };
 
-        /* Shader Source */
-        this.COMPILE_STATUS = 0x8B81;
+    this.createProgram = function() {
+        return nativeInterface.webgl.createProgram(this.glContext);
+    };
 
-        /* Shader Precision-Specified Types */
-        this.LOW_FLOAT = 0x8DF0;
-        this.MEDIUM_FLOAT = 0x8DF1;
-        this.HIGH_FLOAT = 0x8DF2;
-        this.LOW_INT = 0x8DF3;
-        this.MEDIUM_INT = 0x8DF4;
-        this.HIGH_INT = 0x8DF5;
+    this.useProgram = function(program) {
+        return nativeInterface.webgl.useProgram(this.glContext, program.external);
+    };
 
-        /* Framebuffer Object. */
-        this.FRAMEBUFFER = 0x8D40;
-        this.RENDERBUFFER = 0x8D41;
+    this.validateProgram = function(program) {
+        return nativeInterface.webgl.validateProgram(this.glContext, program.external);
+    };
 
-        this.RGBA4 = 0x8056;
-        this.RGB5_A1 = 0x8057;
-        this.RGB565 = 0x8D62;
-        this.DEPTH_COMPONENT16 = 0x81A5;
-        this.STENCIL_INDEX = 0x1901;
-        this.STENCIL_INDEX8 = 0x8D48;
-        this.DEPTH_STENCIL = 0x84F9;
+    this.linkProgram = function(program) {
+        return nativeInterface.webgl.linkProgram(this.glContext, program.external);
+    };
 
-        this.RENDERBUFFER_WIDTH = 0x8D42;
-        this.RENDERBUFFER_HEIGHT = 0x8D43;
-        this.RENDERBUFFER_INTERNAL_FORMAT = 0x8D44;
-        this.RENDERBUFFER_RED_SIZE = 0x8D50;
-        this.RENDERBUFFER_GREEN_SIZE = 0x8D51;
-        this.RENDERBUFFER_BLUE_SIZE = 0x8D52;
-        this.RENDERBUFFER_ALPHA_SIZE = 0x8D53;
-        this.RENDERBUFFER_DEPTH_SIZE = 0x8D54;
-        this.RENDERBUFFER_STENCIL_SIZE = 0x8D55;
+    this.getProgramParameter = function(program, pname) {
+        return nativeInterface.webgl.getProgramParameter(this.glContext, program.external, pname);
+    };
 
-        this.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE = 0x8CD0;
-        this.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME = 0x8CD1;
-        this.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL = 0x8CD2;
-        this.FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE = 0x8CD3;
+    this.getProgramInfoLog = function(program) {
+        return nativeInterface.webgl.getProgramInfoLog(this.glContext, program.external);
+    };
 
-        this.COLOR_ATTACHMENT0 = 0x8CE0;
-        this.DEPTH_ATTACHMENT = 0x8D00;
-        this.STENCIL_ATTACHMENT = 0x8D20;
-        this.DEPTH_STENCIL_ATTACHMENT = 0x821A;
+    this.deleteProgram = function(program) {
+        return nativeInterface.webgl.deleteProgram(this.glContext, program.external);
+    };
 
-        this.NONE = 0;
+    this.bindAttribLocation = function(program, index, name) {
+        return nativeInterface.webgl.bindAttribLocation(this.glContext, program.external, index, name);
+    };
 
-        this.FRAMEBUFFER_COMPLETE = 0x8CD5;
-        this.FRAMEBUFFER_INCOMPLETE_ATTACHMENT = 0x8CD6;
-        this.FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT = 0x8CD7;
-        this.FRAMEBUFFER_INCOMPLETE_DIMENSIONS = 0x8CD9;
-        this.FRAMEBUFFER_UNSUPPORTED = 0x8CDD;
+    this.getActiveUniform = function(program, index) {
+        return nativeInterface.webgl.getActiveUniform(this.glContext, program.external, index);
+    };
 
-        this.FRAMEBUFFER_BINDING = 0x8CA6;
-        this.RENDERBUFFER_BINDING = 0x8CA7;
-        this.MAX_RENDERBUFFER_SIZE = 0x84E8;
+    this.getActiveAttrib = function(program, index) {
+        return nativeInterface.webgl.getActiveAttrib(this.glContext, program.external, index);
+    };
 
-        this.INVALID_FRAMEBUFFER_OPERATION = 0x0506;
+    this.getAttribLocation = function(program, name) {
+        return nativeInterface.webgl.getAttribLocation(this.glContext, program.external, name);
+    };
 
-        /* WebGL-specific enums */
-        this.UNPACK_FLIP_Y_WEBGL = 0x9240;
-        this.UNPACK_PREMULTIPLY_ALPHA_WEBGL = 0x9241;
-        this.CONTEXT_LOST_WEBGL = 0x9242;
-        this.UNPACK_COLORSPACE_CONVERSION_WEBGL = 0x9243;
-        this.BROWSER_DEFAULT_WEBGL = 0x9244;
-    }
+    this.createShader = function(type) {
+        return nativeInterface.webgl.createShader(this.glContext, type);
+    };
+
+    this.shaderSource = function(shader, source) {
+        return nativeInterface.webgl.shaderSource(this.glContext, shader.external, source);
+    };
+
+    this.compileShader = function(shader) {
+        return nativeInterface.webgl.compileShader(this.glContext, shader.external);
+    };
+
+    this.getShaderParameter = function(shader, pname) {
+        return nativeInterface.webgl.getShaderParameter(this.glContext, shader.external, pname);
+    };
+
+    this.getShaderInfoLog = function(shader) {
+        return nativeInterface.webgl.getShaderInfoLog(this.glContext, shader.external);
+    };
+
+    this.attachShader = function(program, shader) {
+        return nativeInterface.webgl.attachShader(this.glContext, program.external, shader.external);
+    };
+
+    this.deleteShader = function(shader) {
+        return nativeInterface.webgl.deleteShader(this.glContext, shader.external);
+    };
+
+    this.getUniformLocation = function(program, name) {
+        return nativeInterface.webgl.getUniformLocation(this.glContext, program.external, name);
+    };
+
+    this.uniform1f = function(location, x) {
+        return nativeInterface.webgl.uniform1f(this.glContext, location.external, x);
+    };
+
+    this.uniform1fv = function(location, v) {
+        return nativeInterface.webgl.uniform1fv(this.glContext, location.external, v);
+    };
+
+    this.uniform1i = function(location, x) {
+        return nativeInterface.webgl.uniform1i(this.glContext, location.external, x);
+    };
+
+    this.uniform1iv = function(location, v) {
+        return nativeInterface.webgl.uniform1iv(this.glContext, location.external, v);
+    };
+
+    this.uniform2f = function(location, x, y) {
+        return nativeInterface.webgl.uniform2f(this.glContext, location.external, x, y);
+    };
+
+    this.uniform2fv = function(location, v) {
+        return nativeInterface.webgl.uniform2fv(this.glContext, location.external, Float32Array.from(v));
+    };
+
+    this.uniform2i = function(location, x, y) {
+        return nativeInterface.webgl.uniform2i(this.glContext, location.external, x, y);
+    };
+
+    this.uniform2iv = function(location, v) {
+        return nativeInterface.webgl.uniform2iv(this.glContext, location.external, Int32Array.from(v));
+    };
+
+    this.uniform3f = function(location, x, y, z) {
+        return nativeInterface.webgl.uniform3f(this.glContext, location.external, x, y, z);
+    };
+
+    this.uniform3fv = function(location, v) {
+        return nativeInterface.webgl.uniform3fv(this.glContext, location.external, Float32Array.from(v));
+    };
+
+    this.uniform3i = function(location, x, y, z) {
+        return nativeInterface.webgl.uniform3i(this.glContext, location.external, x, y, z);
+    };
+
+    this.uniform3iv = function(location, v) {
+        return nativeInterface.webgl.uniform3iv(this.glContext, location.external, Int32Array.from(v));
+    };
+
+    this.uniform4f = function(location, x, y, z, w) {
+        return nativeInterface.webgl.uniform4f(this.glContext, location.external, x, y, z, w);
+    };
+
+    this.uniform4fv = function(location, v) {
+        return nativeInterface.webgl.uniform4fv(this.glContext, location.external, Float32Array.from(v));
+    };
+
+    this.uniform4i = function(location, x, y, z, w) {
+        return nativeInterface.webgl.uniform4i(this.glContext, location.external, x, y, z, w);
+    };
+
+    this.uniform4iv = function(location, v) {
+        return nativeInterface.webgl.uniform4iv(this.glContext, location.external, Int32Array.from(v));
+    };
+
+    this.uniformMatrix2fv = function(location, transpose, value) {
+        return nativeInterface.webgl.uniformMatrix2fv(
+            this.glContext, location.external, transpose, Float32Array.from(value));
+    };
+
+    this.uniformMatrix3fv = function(location, transpose, value) {
+        return nativeInterface.webgl.uniformMatrix3fv(
+            this.glContext, location.external, transpose, Float32Array.from(value));
+    };
+
+    this.uniformMatrix4fv = function(location, transpose, value) {
+        return nativeInterface.webgl.uniformMatrix4fv(
+            this.glContext, location.external, transpose, Float32Array.from(value));
+    };
+
+    this.stencilFunc = function(func, ref, mask) {
+        return nativeInterface.webgl.stencilFunc(this.glContext, func, ref, mask);
+    };
+
+    this.stencilMask = function(mask) {
+        return nativeInterface.webgl.stencilMask(this.glContext, mask);
+    };
+
+    this.stencilOp = function(fail, zfail, zpass) {
+        return nativeInterface.webgl.stencilOp(this.glContext, fail, zfail, zpass);
+    };
+
+    this.lineWidth = function(width) {
+        return nativeInterface.webgl.lineWidth(this.glContext, width);
+    };
+
+    this.DEPTH_BUFFER_BIT = 0x00000100;
+    this.STENCIL_BUFFER_BIT = 0x00000400;
+    this.COLOR_BUFFER_BIT = 0x00004000;
+
+    /* BeginMode */
+    this.POINTS = 0x0000;
+    this.LINES = 0x0001;
+    this.LINE_LOOP = 0x0002;
+    this.LINE_STRIP = 0x0003;
+    this.TRIANGLES = 0x0004;
+    this.TRIANGLE_STRIP = 0x0005;
+    this.TRIANGLE_FAN = 0x0006;
+
+    /* BlendingFactorDest */
+    this.ZERO = 0;
+    this.ONE = 1;
+    this.SRC_COLOR = 0x0300;
+    this.ONE_MINUS_SRC_COLOR = 0x0301;
+    this.SRC_ALPHA = 0x0302;
+    this.ONE_MINUS_SRC_ALPHA = 0x0303;
+    this.DST_ALPHA = 0x0304;
+    this.ONE_MINUS_DST_ALPHA = 0x0305;
+
+    /* BlendingFactorSrc */
+    this.DST_COLOR = 0x0306;
+    this.ONE_MINUS_DST_COLOR = 0x0307;
+    this.SRC_ALPHA_SATURATE = 0x0308;
+
+    /* BlendEquationSeparate */
+    this.FUNC_ADD = 0x8006;
+    this.BLEND_EQUATION = 0x8009;
+    this.BLEND_EQUATION_RGB = 0x8009; /* same as BLEND_EQUATION */
+    this.BLEND_EQUATION_ALPHA = 0x883D;
+
+    /* BlendSubtract */
+    this.FUNC_SUBTRACT = 0x800A;
+    this.FUNC_REVERSE_SUBTRACT = 0x800B;
+
+    /* Separate Blend Functions */
+    this.BLEND_DST_RGB = 0x80C8;
+    this.BLEND_SRC_RGB = 0x80C9;
+    this.BLEND_DST_ALPHA = 0x80CA;
+    this.BLEND_SRC_ALPHA = 0x80CB;
+    this.CONSTANT_COLOR = 0x8001;
+    this.ONE_MINUS_CONSTANT_COLOR = 0x8002;
+    this.CONSTANT_ALPHA = 0x8003;
+    this.ONE_MINUS_CONSTANT_ALPHA = 0x8004;
+    this.BLEND_COLOR = 0x8005;
+
+    /* Buffer Objects */
+    this.ARRAY_BUFFER = 0x8892;
+    this.ELEMENT_ARRAY_BUFFER = 0x8893;
+    this.ARRAY_BUFFER_BINDING = 0x8894;
+    this.ELEMENT_ARRAY_BUFFER_BINDING = 0x8895;
+
+    this.STREAM_DRAW = 0x88E0;
+    this.STATIC_DRAW = 0x88E4;
+    this.DYNAMIC_DRAW = 0x88E8;
+
+    this.BUFFER_SIZE = 0x8764;
+    this.BUFFER_USAGE = 0x8765;
+
+    this.CURRENT_VERTEX_ATTRIB = 0x8626;
+
+    /* CullFaceMode */
+    this.FRONT = 0x0404;
+    this.BACK = 0x0405;
+    this.FRONT_AND_BACK = 0x0408;
+
+    /* EnableCap */
+    /* TEXTURE_2D */
+    this.CULL_FACE = 0x0B44;
+    this.BLEND = 0x0BE2;
+    this.DITHER = 0x0BD0;
+    this.STENCIL_TEST = 0x0B90;
+    this.DEPTH_TEST = 0x0B71;
+    this.SCISSOR_TEST = 0x0C11;
+    this.POLYGON_OFFSET_FILL = 0x8037;
+    this.SAMPLE_ALPHA_TO_COVERAGE = 0x809E;
+    this.SAMPLE_COVERAGE = 0x80A0;
+
+    /* ErrorCode */
+
+    this.NO_ERROR = 0;
+    this.INVALID_ENUM = 0x0500;
+    this.INVALID_VALUE = 0x0501;
+    this.INVALID_OPERATION = 0x0502;
+    this.OUT_OF_MEMORY = 0x0505;
+
+    /* FrontFaceDirection */
+    this.CW = 0x0900;
+    this.CCW = 0x0901;
+
+    /* GetPName */
+    this.LINE_WIDTH = 0x0B21;
+    this.ALIASED_POINT_SIZE_RANGE = 0x846D;
+    this.ALIASED_LINE_WIDTH_RANGE = 0x846E;
+    this.CULL_FACE_MODE = 0x0B45;
+    this.FRONT_FACE = 0x0B46;
+    this.DEPTH_RANGE = 0x0B70;
+    this.DEPTH_WRITEMASK = 0x0B72;
+    this.DEPTH_CLEAR_VALUE = 0x0B73;
+    this.DEPTH_FUNC = 0x0B74;
+    this.STENCIL_CLEAR_VALUE = 0x0B91;
+    this.STENCIL_FUNC = 0x0B92;
+    this.STENCIL_FAIL = 0x0B94;
+    this.STENCIL_PASS_DEPTH_FAIL = 0x0B95;
+    this.STENCIL_PASS_DEPTH_PASS = 0x0B96;
+    this.STENCIL_REF = 0x0B97;
+    this.STENCIL_VALUE_MASK = 0x0B93;
+    this.STENCIL_WRITEMASK = 0x0B98;
+    this.STENCIL_BACK_FUNC = 0x8800;
+    this.STENCIL_BACK_FAIL = 0x8801;
+    this.STENCIL_BACK_PASS_DEPTH_FAIL = 0x8802;
+    this.STENCIL_BACK_PASS_DEPTH_PASS = 0x8803;
+    this.STENCIL_BACK_REF = 0x8CA3;
+    this.STENCIL_BACK_VALUE_MASK = 0x8CA4;
+    this.STENCIL_BACK_WRITEMASK = 0x8CA5;
+    this.VIEWPORT = 0x0BA2;
+    this.SCISSOR_BOX = 0x0C10;
+    /*      SCISSOR_TEST */
+    this.COLOR_CLEAR_VALUE = 0x0C22;
+    this.COLOR_WRITEMASK = 0x0C23;
+    this.UNPACK_ALIGNMENT = 0x0CF5;
+    this.PACK_ALIGNMENT = 0x0D05;
+    this.MAX_TEXTURE_SIZE = 0x0D33;
+    this.MAX_VIEWPORT_DIMS = 0x0D3A;
+    this.SUBPIXEL_BITS = 0x0D50;
+    this.RED_BITS = 0x0D52;
+    this.GREEN_BITS = 0x0D53;
+    this.BLUE_BITS = 0x0D54;
+    this.ALPHA_BITS = 0x0D55;
+    this.DEPTH_BITS = 0x0D56;
+    this.STENCIL_BITS = 0x0D57;
+    this.POLYGON_OFFSET_UNITS = 0x2A00;
+    /*      POLYGON_OFFSET_FILL */
+    this.POLYGON_OFFSET_FACTOR = 0x8038;
+    this.TEXTURE_BINDING_2D = 0x8069;
+    this.SAMPLE_BUFFERS = 0x80A8;
+    this.SAMPLES = 0x80A9;
+    this.SAMPLE_COVERAGE_VALUE = 0x80AA;
+    SAMPLE_COVERAGE_INVERT = 0x80AB;
+
+    /* GetTextureParameter */
+    /*      TEXTURE_MAG_FILTER */
+    /*      TEXTURE_MIN_FILTER */
+    /*      TEXTURE_WRAP_S */
+    /*      TEXTURE_WRAP_T */
+
+    this.COMPRESSED_TEXTURE_FORMATS = 0x86A3;
+
+    /* HintMode */
+    this.DONT_CARE = 0x1100;
+    this.FASTEST = 0x1101;
+    this.NICEST = 0x1102;
+
+    /* HintTarget */
+    this.GENERATE_MIPMAP_HINT = 0x8192;
+
+    /* DataType */
+    this.BYTE = 0x1400;
+    this.UNSIGNED_BYTE = 0x1401;
+    this.SHORT = 0x1402;
+    this.UNSIGNED_SHORT = 0x1403;
+    this.INT = 0x1404;
+    this.UNSIGNED_INT = 0x1405;
+    this.FLOAT = 0x1406;
+
+    /* PixelFormat */
+    this.DEPTH_COMPONENT = 0x1902;
+    this.ALPHA = 0x1906;
+    this.RGB = 0x1907;
+    this.RGBA = 0x1908;
+    this.LUMINANCE = 0x1909;
+    this.LUMINANCE_ALPHA = 0x190A;
+
+    /* PixelType */
+    /*      UNSIGNED_BYTE */
+    this.UNSIGNED_SHORT_4_4_4_4 = 0x8033;
+    this.UNSIGNED_SHORT_5_5_5_1 = 0x8034;
+    this.UNSIGNED_SHORT_5_6_5 = 0x8363;
+
+    /* Shaders */
+    this.FRAGMENT_SHADER = 0x8B30;
+    this.VERTEX_SHADER = 0x8B31;
+    this.MAX_VERTEX_ATTRIBS = 0x8869;
+    this.MAX_VERTEX_UNIFORM_VECTORS = 0x8DFB;
+    this.MAX_VARYING_VECTORS = 0x8DFC;
+    this.MAX_COMBINED_TEXTURE_IMAGE_UNITS = 0x8B4D;
+    this.MAX_VERTEX_TEXTURE_IMAGE_UNITS = 0x8B4C;
+    this.MAX_TEXTURE_IMAGE_UNITS = 0x8872;
+    this.MAX_FRAGMENT_UNIFORM_VECTORS = 0x8DFD;
+    this.SHADER_TYPE = 0x8B4F;
+    this.DELETE_STATUS = 0x8B80;
+    this.LINK_STATUS = 0x8B82;
+    this.VALIDATE_STATUS = 0x8B83;
+    this.ATTACHED_SHADERS = 0x8B85;
+    this.ACTIVE_UNIFORMS = 0x8B86;
+    this.ACTIVE_ATTRIBUTES = 0x8B89;
+    this.SHADING_LANGUAGE_VERSION = 0x8B8C;
+    this.CURRENT_PROGRAM = 0x8B8D;
+
+    /* StencilFunction */
+    this.NEVER = 0x0200;
+    this.LESS = 0x0201;
+    this.EQUAL = 0x0202;
+    this.LEQUAL = 0x0203;
+    this.GREATER = 0x0204;
+    this.NOTEQUAL = 0x0205;
+    this.GEQUAL = 0x0206;
+    this.ALWAYS = 0x0207;
+
+    /* StencilOp */
+    /*      ZERO */
+    this.KEEP = 0x1E00;
+    this.REPLACE = 0x1E01;
+    this.INCR = 0x1E02;
+    this.DECR = 0x1E03;
+    this.INVERT = 0x150A;
+    this.INCR_WRAP = 0x8507;
+    this.DECR_WRAP = 0x8508;
+
+    /* StringName */
+    this.VENDOR = 0x1F00;
+    this.RENDERER = 0x1F01;
+    this.VERSION = 0x1F02;
+
+    /* TextureMagFilter */
+    this.NEAREST = 0x2600;
+    this.LINEAR = 0x2601;
+
+    /* TextureMinFilter */
+    /*      NEAREST */
+    /*      LINEAR */
+    this.NEAREST_MIPMAP_NEAREST = 0x2700;
+    this.LINEAR_MIPMAP_NEAREST = 0x2701;
+    this.NEAREST_MIPMAP_LINEAR = 0x2702;
+    this.LINEAR_MIPMAP_LINEAR = 0x2703;
+
+    /* TextureParameterName */
+    this.TEXTURE_MAG_FILTER = 0x2800;
+    this.TEXTURE_MIN_FILTER = 0x2801;
+    this.TEXTURE_WRAP_S = 0x2802;
+    this.TEXTURE_WRAP_T = 0x2803;
+
+    /* TextureTarget */
+    this.TEXTURE_2D = 0x0DE1;
+    this.TEXTURE = 0x1702;
+
+    this.TEXTURE_CUBE_MAP = 0x8513;
+    this.TEXTURE_BINDING_CUBE_MAP = 0x8514;
+    this.TEXTURE_CUBE_MAP_POSITIVE_X = 0x8515;
+    this.TEXTURE_CUBE_MAP_NEGATIVE_X = 0x8516;
+    this.TEXTURE_CUBE_MAP_POSITIVE_Y = 0x8517;
+    this.TEXTURE_CUBE_MAP_NEGATIVE_Y = 0x8518;
+    this.TEXTURE_CUBE_MAP_POSITIVE_Z = 0x8519;
+    this.TEXTURE_CUBE_MAP_NEGATIVE_Z = 0x851A;
+    this.MAX_CUBE_MAP_TEXTURE_SIZE = 0x851C;
+
+    /* TextureUnit */
+    this.TEXTURE0 = 0x84C0;
+    this.TEXTURE1 = 0x84C1;
+    this.TEXTURE2 = 0x84C2;
+    this.TEXTURE3 = 0x84C3;
+    this.TEXTURE4 = 0x84C4;
+    this.TEXTURE5 = 0x84C5;
+    this.TEXTURE6 = 0x84C6;
+    this.TEXTURE7 = 0x84C7;
+    this.TEXTURE8 = 0x84C8;
+    this.TEXTURE9 = 0x84C9;
+    this.TEXTURE10 = 0x84CA;
+    this.TEXTURE11 = 0x84CB;
+    this.TEXTURE12 = 0x84CC;
+    this.TEXTURE13 = 0x84CD;
+    this.TEXTURE14 = 0x84CE;
+    this.TEXTURE15 = 0x84CF;
+    this.TEXTURE16 = 0x84D0;
+    this.TEXTURE17 = 0x84D1;
+    this.TEXTURE18 = 0x84D2;
+    this.TEXTURE19 = 0x84D3;
+    this.TEXTURE20 = 0x84D4;
+    this.TEXTURE21 = 0x84D5;
+    this.TEXTURE22 = 0x84D6;
+    this.TEXTURE23 = 0x84D7;
+    this.TEXTURE24 = 0x84D8;
+    this.TEXTURE25 = 0x84D9;
+    this.TEXTURE26 = 0x84DA;
+    this.TEXTURE27 = 0x84DB;
+    this.TEXTURE28 = 0x84DC;
+    this.TEXTURE29 = 0x84DD;
+    this.TEXTURE30 = 0x84DE;
+    this.TEXTURE31 = 0x84DF;
+    this.ACTIVE_TEXTURE = 0x84E0;
+
+    /* TextureWrapMode */
+    this.REPEAT = 0x2901;
+    this.CLAMP_TO_EDGE = 0x812F;
+    this.MIRRORED_REPEAT = 0x8370;
+
+    /* Uniform Types */
+    this.FLOAT_VEC2 = 0x8B50;
+    this.FLOAT_VEC3 = 0x8B51;
+    this.FLOAT_VEC4 = 0x8B52;
+    this.INT_VEC2 = 0x8B53;
+    this.INT_VEC3 = 0x8B54;
+    this.INT_VEC4 = 0x8B55;
+    this.BOOL = 0x8B56;
+    this.BOOL_VEC2 = 0x8B57;
+    this.BOOL_VEC3 = 0x8B58;
+    this.BOOL_VEC4 = 0x8B59;
+    this.FLOAT_MAT2 = 0x8B5A;
+    this.FLOAT_MAT3 = 0x8B5B;
+    this.FLOAT_MAT4 = 0x8B5C;
+    this.SAMPLER_2D = 0x8B5E;
+    this.SAMPLER_CUBE = 0x8B60;
+
+    /* Vertex Arrays */
+    this.VERTEX_ATTRIB_ARRAY_ENABLED = 0x8622;
+    this.VERTEX_ATTRIB_ARRAY_SIZE = 0x8623;
+    this.VERTEX_ATTRIB_ARRAY_STRIDE = 0x8624;
+    this.VERTEX_ATTRIB_ARRAY_TYPE = 0x8625;
+    this.VERTEX_ATTRIB_ARRAY_NORMALIZED = 0x886A;
+    this.VERTEX_ATTRIB_ARRAY_POINTER = 0x8645;
+    this.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING = 0x889F;
+
+    /* Read Format */
+    this.IMPLEMENTATION_COLOR_READ_TYPE = 0x8B9A;
+    this.IMPLEMENTATION_COLOR_READ_FORMAT = 0x8B9B;
+
+    /* Shader Source */
+    this.COMPILE_STATUS = 0x8B81;
+
+    /* Shader Precision-Specified Types */
+    this.LOW_FLOAT = 0x8DF0;
+    this.MEDIUM_FLOAT = 0x8DF1;
+    this.HIGH_FLOAT = 0x8DF2;
+    this.LOW_INT = 0x8DF3;
+    this.MEDIUM_INT = 0x8DF4;
+    this.HIGH_INT = 0x8DF5;
+
+    /* Framebuffer Object. */
+    this.FRAMEBUFFER = 0x8D40;
+    this.RENDERBUFFER = 0x8D41;
+
+    this.RGBA4 = 0x8056;
+    this.RGB5_A1 = 0x8057;
+    this.RGB565 = 0x8D62;
+    this.DEPTH_COMPONENT16 = 0x81A5;
+    this.STENCIL_INDEX = 0x1901;
+    this.STENCIL_INDEX8 = 0x8D48;
+    this.DEPTH_STENCIL = 0x84F9;
+
+    this.RENDERBUFFER_WIDTH = 0x8D42;
+    this.RENDERBUFFER_HEIGHT = 0x8D43;
+    this.RENDERBUFFER_INTERNAL_FORMAT = 0x8D44;
+    this.RENDERBUFFER_RED_SIZE = 0x8D50;
+    this.RENDERBUFFER_GREEN_SIZE = 0x8D51;
+    this.RENDERBUFFER_BLUE_SIZE = 0x8D52;
+    this.RENDERBUFFER_ALPHA_SIZE = 0x8D53;
+    this.RENDERBUFFER_DEPTH_SIZE = 0x8D54;
+    this.RENDERBUFFER_STENCIL_SIZE = 0x8D55;
+
+    this.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE = 0x8CD0;
+    this.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME = 0x8CD1;
+    this.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL = 0x8CD2;
+    this.FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE = 0x8CD3;
+
+    this.COLOR_ATTACHMENT0 = 0x8CE0;
+    this.DEPTH_ATTACHMENT = 0x8D00;
+    this.STENCIL_ATTACHMENT = 0x8D20;
+    this.DEPTH_STENCIL_ATTACHMENT = 0x821A;
+
+    this.NONE = 0;
+
+    this.FRAMEBUFFER_COMPLETE = 0x8CD5;
+    this.FRAMEBUFFER_INCOMPLETE_ATTACHMENT = 0x8CD6;
+    this.FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT = 0x8CD7;
+    this.FRAMEBUFFER_INCOMPLETE_DIMENSIONS = 0x8CD9;
+    this.FRAMEBUFFER_UNSUPPORTED = 0x8CDD;
+
+    this.FRAMEBUFFER_BINDING = 0x8CA6;
+    this.RENDERBUFFER_BINDING = 0x8CA7;
+    this.MAX_RENDERBUFFER_SIZE = 0x84E8;
+
+    this.INVALID_FRAMEBUFFER_OPERATION = 0x0506;
+
+    /* WebGL-specific enums */
+    this.UNPACK_FLIP_Y_WEBGL = 0x9240;
+    this.UNPACK_PREMULTIPLY_ALPHA_WEBGL = 0x9241;
+    this.CONTEXT_LOST_WEBGL = 0x9242;
+    this.UNPACK_COLORSPACE_CONVERSION_WEBGL = 0x9243;
+    this.BROWSER_DEFAULT_WEBGL = 0x9244;
+}
 })();
-

--- a/HoloJS/HoloJsHost/ScriptingFramework/Window.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/Window.js
@@ -1,157 +1,163 @@
 ﻿var window = (window ? window : {});
 
-(function () {
+(function() {
 
-    function makeLocation(href) {
-        this.href = href;
-    }
-    
-    window.drawCallback = null;
-    window.spatialMappingCallback = null;
-    window.location = new makeLocation(nativeInterface.window.getBaseUrl());
+function makeLocation(href)
+{
+    this.href = href;
+}
 
-    window.requestAnimationFrame = function (callback) {
-        window.drawCallback = callback;
-    };
+window.drawCallback = null;
+window.spatialMappingCallback = null;
+window.location = new makeLocation(nativeInterface.window.getBaseUrl());
 
-    window.requestSpatialMappingData = function (callback, options) {
-        window.addEventListener("spatialmapping", callback);
-        
-        var extentX, extentY, extentZ;
-        if (options && options.scanExtentMeters) {
-            extentX = options.scanExtentMeters.x;
-            extentY = options.scanExtentMeters.y;
-            extentZ = options.scanExtentMeters.z;
-        } else {
-            extentX = 10;
-            extentY = 5;
-            extentZ = 10;
-        }
+window.requestAnimationFrame = function(callback) {
+    window.drawCallback = callback;
+};
 
-        var trianglesPerCubicMeter = (options && options.trianglesPerCubicMeter ? options.trianglesPerCubicMeter : 1000);
-        return nativeInterface.window.requestSpatialMappingData(extentX, extentY, extentZ, trianglesPerCubicMeter);
-    };
+window.requestSpatialMappingData = function(callback, options) {
+    window.addEventListener('spatialmapping', callback);
 
-    // Mapping of type ids to strings;
-    // JavaScript side registers events by string but the native side sends events with a numeric type for performance reasons
-    window.nativeEvents = {};
-    window.nativeEvents.spatialInputEvents = ["sourcepress", "sourcerelease", "sourcelost", "sourcedetected", "sourceupdate"];
-    window.nativeEvents.keyboardEvents = ["keydown", "keyup"];
-    window.nativeEvents.mouseEvents = ["mouseup", "mousedown", "mousemove", "mousewheel"];
-
-    window.nativeEvents.events = ["resize", "mouse", "keyboard", "spatialinput", "spatialmapping"];
-    window.nativeEvents.resize = 0;
-    window.nativeEvents.mouse = 1;
-    window.nativeEvents.keyboard = 2;
-    window.nativeEvents.spatialinput = 3;
-    window.nativeEvents.spatialmapping = 4;
-
-    function onMouseEvent(x, y, button, action) {
-        if (!document.canvas) {
-            return;
-        }
-
-        var mouseEvent = {};
-        
-        mouseEvent.buttons = button;
-
-        // Native button parameter is actually MouseEvent.buttons. Convert it to MouseEvent.button now
-        if (button & 1) {
-            mouseEvent.button = 0;
-        } else if (button & 2) {
-            mouseEvent.button = 2;
-        } else if (button & 4) {
-            mouseEvent.button = 1;
-        }
-
-        mouseEvent.clientX = x;
-        mouseEvent.clientY = y;
-
-        mouseEvent.preventDefault = function () { };
-        mouseEvent.srcElement = document.canvas;
-
-        document.canvas.fireHandlersByType(window.nativeEvents.mouseEvents[action], mouseEvent);
-        document.fireHandlersByType(window.nativeEvents.mouseEvents[action], mouseEvent);
+    var extentX, extentY, extentZ;
+    if (options && options.scanExtentMeters) {
+        extentX = options.scanExtentMeters.x;
+        extentY = options.scanExtentMeters.y;
+        extentZ = options.scanExtentMeters.z;
+    } else {
+        extentX = 10;
+        extentY = 5;
+        extentZ = 10;
     }
 
-    function onSpatialInputEvent(x, y, z, isPressed, sourceKind, eventType) {
-        var spatialInputEvent = {};
+    var trianglesPerCubicMeter = (options && options.trianglesPerCubicMeter ? options.trianglesPerCubicMeter : 1000);
+    return nativeInterface.window.requestSpatialMappingData(extentX, extentY, extentZ, trianglesPerCubicMeter);
+};
 
-        spatialInputEvent.isPressed = isPressed;
-        spatialInputEvent.location = { x: x, y: y, z: z };
+// Mapping of type ids to strings;
+// JavaScript side registers events by string but the native side sends events with a numeric type for performance
+// reasons
+window.nativeEvents = {};
+window.nativeEvents.spatialInputEvents =
+    ['sourcepress', 'sourcerelease', 'sourcelost', 'sourcedetected', 'sourceupdate'];
+window.nativeEvents.keyboardEvents = ['keydown', 'keyup'];
+window.nativeEvents.mouseEvents = ['mouseup', 'mousedown', 'mousemove', 'mousewheel'];
 
-        spatialInputEvent.preventDefault = function () { };
-        spatialInputEvent.srcElement = document.canvas;
-        spatialInputEvent.sourceKind = sourceKind;
+window.nativeEvents.events = ['resize', 'mouse', 'keyboard', 'spatialinput', 'spatialmapping'];
+window.nativeEvents.resize = 0;
+window.nativeEvents.mouse = 1;
+window.nativeEvents.keyboard = 2;
+window.nativeEvents.spatialinput = 3;
+window.nativeEvents.spatialmapping = 4;
 
-        document.canvas.fireHandlersByType(window.nativeEvents.spatialInputEvents[eventType], spatialInputEvent);
+function onMouseEvent(x, y, button, action)
+{
+    if (!document.canvas) {
+        return;
     }
 
-    function onSpatialMappingEvent(surfaceData) {
-        window.fireHandlersByType(window.nativeEvents.events[window.nativeEvents.spatialmapping], surfaceData);
+    var mouseEvent = {};
+
+    mouseEvent.buttons = button;
+
+    // Native button parameter is actually MouseEvent.buttons. Convert it to MouseEvent.button now
+    if (button & 1) {
+        mouseEvent.button = 0;
+    } else if (button & 2) {
+        mouseEvent.button = 2;
+    } else if (button & 4) {
+        mouseEvent.button = 1;
     }
 
-    function onKeyboardEvent(event) {
+    mouseEvent.clientX = x;
+    mouseEvent.clientY = y;
+
+    mouseEvent.preventDefault = function() {};
+    mouseEvent.srcElement = document.canvas;
+
+    document.canvas.fireHandlersByType(window.nativeEvents.mouseEvents[action], mouseEvent);
+    document.fireHandlersByType(window.nativeEvents.mouseEvents[action], mouseEvent);
+}
+
+function onSpatialInputEvent(x, y, z, isPressed, sourceKind, eventType)
+{
+    var spatialInputEvent = {};
+
+    spatialInputEvent.isPressed = isPressed;
+    spatialInputEvent.location = {x: x, y: y, z: z};
+
+    spatialInputEvent.preventDefault = function() {};
+    spatialInputEvent.srcElement = document.canvas;
+    spatialInputEvent.sourceKind = sourceKind;
+
+    document.canvas.fireHandlersByType(window.nativeEvents.spatialInputEvents[eventType], spatialInputEvent);
+}
+
+function onSpatialMappingEvent(surfaceData)
+{
+    window.fireHandlersByType(window.nativeEvents.events[window.nativeEvents.spatialmapping], surfaceData);
+}
+
+function onKeyboardEvent(event)
+{
+}
+
+window.devicePixelRatio = 1;
+
+Object.defineProperty(window, 'innerWidth', {
+    get: function() {
+        return nativeInterface.window.getWidth();
     }
+});
 
-    window.devicePixelRatio = 1;
+Object.defineProperty(window, 'innerHeight', {
+    get: function() {
+        return nativeInterface.window.getHeight()
+    }
+});
 
-    Object.defineProperty(window, "innerWidth", {
-        get: function () {
-            return nativeInterface.window.getWidth();
+Object.defineProperty(window, 'width', {
+    get: function() {
+        return nativeInterface.window.getWidth();
+    }
+});
+
+Object.defineProperty(window, 'height', {
+    get: function() {
+        return nativeInterface.window.getHeight()
+    }
+});
+
+window.nativeCallback = function(type) {
+    if (!type) {
+        var capturedCallback = window.drawCallback;
+        window.drawCallback = null;
+        if (capturedCallback !== null) {
+            capturedCallback();
         }
-    });
+    } else if (type === window.nativeEvents.resize) {
+        window.fireHandlersByType(window.nativeEvents.events[type]);
+    } else if (type === window.nativeEvents.mouse) {
+        onMouseEvent(arguments[1], arguments[2], arguments[3], arguments[4]);
+    } else if (type === window.nativeEvents.keyboard) {
+        onKeyboardEvent(arguments[1], arguments[2]);
+    } else if (type === window.nativeEvents.spatialinput) {
+        onSpatialInputEvent(arguments[1], arguments[2], arguments[3], arguments[4], arguments[5], arguments[6])
+    } else if (type === window.nativeEvents.spatialmapping) {
+        onSpatialMappingEvent(arguments[1])
+    } else {
+        window.fireHandlersByType(type);
+    }
+};
 
-    Object.defineProperty(window, "innerHeight", {
-        get: function () {
-            return nativeInterface.window.getHeight()
-        }
-    });
+nativeInterface.extendWithEventHandling(window);
 
-    Object.defineProperty(window, "width", {
-        get: function () {
-            return nativeInterface.window.getWidth();
-        }
-    });
+nativeInterface.window.setCallback(window.nativeCallback);
 
-    Object.defineProperty(window, "height", {
-        get: function () {
-            return nativeInterface.window.getHeight()
-        }
-    });
+window.getViewMatrix = function() {
+    return nativeInterface.window.holographicViewMatrix;
+};
 
-    window.nativeCallback = function (type) {
-        if (!type) {
-            var capturedCallback = window.drawCallback;
-            window.drawCallback = null;
-            if (capturedCallback !== null) {
-                capturedCallback();
-            }
-        } else if (type === window.nativeEvents.resize) {
-            window.fireHandlersByType(window.nativeEvents.events[type]);
-        } else if (type === window.nativeEvents.mouse) {
-            onMouseEvent(arguments[1], arguments[2], arguments[3], arguments[4]);
-        } else if (type === window.nativeEvents.keyboard) {
-            onKeyboardEvent(arguments[1], arguments[2]);
-        } else if (type === window.nativeEvents.spatialinput) {
-            onSpatialInputEvent(arguments[1], arguments[2], arguments[3], arguments[4], arguments[5], arguments[6])
-        } else if (type === window.nativeEvents.spatialmapping) {
-            onSpatialMappingEvent(arguments[1])
-        }
-        else {
-            window.fireHandlersByType(type);
-        }
-    };
-
-    nativeInterface.extendWithEventHandling(window);
-
-    nativeInterface.window.setCallback(window.nativeCallback);
-
-    window.getViewMatrix = function () {
-        return nativeInterface.window.holographicViewMatrix;
-    };
-
-    window.getCameraPositionVector = function () {
-        return nativeInterface.window.holographicCameraPosition;
-    };
+window.getCameraPositionVector = function() {
+    return nativeInterface.window.holographicCameraPosition;
+};
 })();

--- a/HoloJS/HoloJsHost/ScriptingFramework/XmlHttpRequest.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/XmlHttpRequest.js
@@ -1,9 +1,9 @@
-﻿function XMLHttpRequest() {
-    
+﻿function XMLHttpRequest()
+{
     this.native = new nativeInterface.xhr.create();
 
-    this.nativeCallback = function (type) {
-        if (type === "change") {
+    this.nativeCallback = function(type) {
+        if (type === 'change') {
             this.readyState = arguments[1];
             this.status = arguments[2];
             this.statusText = arguments[3];
@@ -11,9 +11,9 @@
 
             if (this.readyState === XMLHttpRequest.DONE) {
                 if (this.status >= 200 && this.status <= 205) {
-                    this.fireHandlersByType("load", { target: this });
+                    this.fireHandlersByType('load', {target: this});
                 } else {
-                    this.fireHandlersByType("error", { target: this });
+                    this.fireHandlersByType('error', {target: this});
                 }
             }
         }
@@ -21,61 +21,61 @@
 
     nativeInterface.extendWithEventHandling(this);
 
-    this.stubonreadystatechange = function () {
+    this.stubonreadystatechange = function() {
         if (this.onreadystatechangeEvent) {
             this.onreadystatechangeEvent();
         }
-    }
+    };
 
-    Object.defineProperty(this, "onreadystatechange", {
-        get: function () {
+    Object.defineProperty(this, 'onreadystatechange', {
+        get: function() {
             return this.onreadystatechangeEvent;
         },
-        set: function (value) {
+        set: function(value) {
             if (!value && this.onreadystatechangeEvent) {
                 this.onreadystatechangeEvent = value;
-                this.removeEventListener("load", this.stubonreadystatechange);
+                this.removeEventListener('load', this.stubonreadystatechange);
             } else if (value && !this.onreadystatechangeEvent) {
                 this.onreadystatechangeEvent = value;
-                this.addEventListener("load", this.stubonreadystatechange);
+                this.addEventListener('load', this.stubonreadystatechange);
             } else {
                 this.onreadystatechangeEvent = value;
             }
         }
     });
 
-    this.open = function (method, url) {
+    this.open = function(method, url) {
         this.method = method;
         this.url = url;
     };
 
-    this.setRequestHeader = function (header, value) {
+    this.setRequestHeader = function(header, value) {
         nativeInterface.xhr.setHeader(this.native, header, value);
-    }
-
-    this.getResponseHeader = function (header) {
-        return nativeInterface.xhr.getHeader(this.native, header);
-    }
-
-    this.send = function () {
-        nativeInterface.xhr.send(this.native, this.method, this.url, (this.responseType ? this.responseType : "text"));
     };
 
-    Object.defineProperty(this, "responseText", {
-        get: function () {
+    this.getResponseHeader = function(header) {
+        return nativeInterface.xhr.getHeader(this.native, header);
+    };
+
+    this.send = function() {
+        nativeInterface.xhr.send(this.native, this.method, this.url, (this.responseType ? this.responseType : 'text'));
+    };
+
+    Object.defineProperty(this, 'responseText', {
+        get: function() {
             return nativeInterface.xhr.getResponseText(this.native);
         }
     });
 
-    Object.defineProperty(this, "response", {
-        get: function () {
+    Object.defineProperty(this, 'response', {
+        get: function() {
             return nativeInterface.xhr.getResponse(this.native);
         }
     });
 }
 
-(function () {
-    XMLHttpRequest.DONE = 4;
-    XMLHttpRequest.OPENED = 1;
-    XMLHttpRequest.HEADERS_RECEIVED = 2;
+(function() {
+XMLHttpRequest.DONE = 4;
+XMLHttpRequest.OPENED = 1;
+XMLHttpRequest.HEADERS_RECEIVED = 2;
 })();

--- a/HoloJS/HoloJsHost/ScriptsLoader.h
+++ b/HoloJS/HoloJsHost/ScriptsLoader.h
@@ -1,49 +1,43 @@
 #pragma once
 
-namespace HologramJS
-{
-	struct Script {
-		std::wstring path;
-		std::wstring code;
-	};
+#include "ChakraForHoloJS.h"
 
-	class ScriptsLoader
-	{
-	public:
-		ScriptsLoader();
-		~ScriptsLoader();
+namespace HologramJS {
+struct Script {
+    std::wstring path;
+    std::wstring code;
+};
 
-		concurrency::task<bool> LoadScripts(Windows::Storage::StorageFolder^ root, const std::wstring& jsonPath);
-		concurrency::task<bool> DownloadScripts(const std::wstring& uri);
+class ScriptsLoader {
+   public:
+    ScriptsLoader();
+    ~ScriptsLoader();
 
-		static std::list<std::wstring> SplitPath(const std::wstring& path);
+    concurrency::task<bool> LoadScripts(Windows::Storage::StorageFolder ^ root, const std::wstring& jsonPath);
+    concurrency::task<bool> DownloadScripts(const std::wstring& uri);
 
-		std::list<std::wstring> GetScriptsListFromJSON(Platform::String^ json);
+    static std::list<std::wstring> SplitPath(const std::wstring& path);
 
-		static concurrency::task<Platform::String^> ReadTextFromFile(
-			Windows::Storage::StorageFolder^ rootFolder,
-			std::list<std::wstring>& pathElements,
-			std::wstring& fileName);
+    std::list<std::wstring> GetScriptsListFromJSON(Platform::String ^ json);
 
-		static concurrency::task<Platform::String^> DownloadTextFromURI(Windows::Foundation::Uri^ uri);
+    static concurrency::task<Platform::String ^> ReadTextFromFile(Windows::Storage::StorageFolder ^ rootFolder,
+                                                                  std::list<std::wstring>& pathElements,
+                                                                  std::wstring& fileName);
 
-		static concurrency::task<Windows::Storage::Streams::IBuffer^> ReadBinaryFromFile(
-			Windows::Storage::StorageFolder^ rootFolder,
-			std::list<std::wstring>& pathElements,
-			std::wstring& fileName);
+    static concurrency::task<Platform::String ^> DownloadTextFromURI(Windows::Foundation::Uri ^ uri);
 
-		static concurrency::task<Windows::Storage::Streams::IRandomAccessStreamWithContentType^> GetStreamFromFile(
-			Windows::Storage::StorageFolder^ rootFolder,
-			std::list<std::wstring>& pathElements,
-			std::wstring& fileName);
+    static concurrency::task<Windows::Storage::Streams::IBuffer ^> ReadBinaryFromFile(
+        Windows::Storage::StorageFolder ^ rootFolder, std::list<std::wstring>& pathElements, std::wstring& fileName);
 
-		static std::wstring GetFileSystemBasePathForJsonPath(const std::wstring& jsonFilePath);
-		static std::wstring GetBaseUriForJsonUri(const std::wstring& jsonUri);
-	
-		void ExecuteScripts();
+    static concurrency::task<Windows::Storage::Streams::IRandomAccessStreamWithContentType ^> GetStreamFromFile(
+        Windows::Storage::StorageFolder ^ rootFolder, std::list<std::wstring>& pathElements, std::wstring& fileName);
 
-		std::list<std::shared_ptr<Script>> m_loadedScripts;
-		JsSourceContext m_jsSourceContext = 0;
+    static std::wstring GetFileSystemBasePathForJsonPath(const std::wstring& jsonFilePath);
+    static std::wstring GetBaseUriForJsonUri(const std::wstring& jsonUri);
 
-	};
-}
+    void ExecuteScripts();
+
+    std::list<std::shared_ptr<Script>> m_loadedScripts;
+    JsSourceContext m_jsSourceContext = 0;
+};
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/ScriptsLoader.h
+++ b/HoloJS/HoloJsHost/ScriptsLoader.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "ChakraForHoloJS.h"
+#include "FileSystemLoader.h"
+#include "WebLoader.h"
 
 namespace HologramJS {
 struct Script {
@@ -8,34 +10,21 @@ struct Script {
     std::wstring code;
 };
 
-class ScriptsLoader {
+class ScriptsLoader : HologramJS::Loaders::FileSystemLoader, HologramJS::Loaders::WebLoader {
    public:
-    ScriptsLoader();
-    ~ScriptsLoader();
+    ScriptsLoader() {}
 
-    concurrency::task<bool> LoadScripts(Windows::Storage::StorageFolder ^ root, const std::wstring& jsonPath);
-    concurrency::task<bool> DownloadScripts(const std::wstring& uri);
-
-    static std::list<std::wstring> SplitPath(const std::wstring& path);
+    concurrency::task<bool> LoadScriptsAsync(Windows::Storage::StorageFolder ^ root, const std::wstring& jsonPath);
+    concurrency::task<bool> DownloadScriptsAsync(const std::wstring& uri);
 
     std::list<std::wstring> GetScriptsListFromJSON(Platform::String ^ json);
-
-    static concurrency::task<Platform::String ^> ReadTextFromFile(Windows::Storage::StorageFolder ^ rootFolder,
-                                                                  std::list<std::wstring>& pathElements,
-                                                                  std::wstring& fileName);
-
-    static concurrency::task<Platform::String ^> DownloadTextFromURI(Windows::Foundation::Uri ^ uri);
-
-    static concurrency::task<Windows::Storage::Streams::IBuffer ^> ReadBinaryFromFile(
-        Windows::Storage::StorageFolder ^ rootFolder, std::list<std::wstring>& pathElements, std::wstring& fileName);
-
-    static concurrency::task<Windows::Storage::Streams::IRandomAccessStreamWithContentType ^> GetStreamFromFile(
-        Windows::Storage::StorageFolder ^ rootFolder, std::list<std::wstring>& pathElements, std::wstring& fileName);
 
     static std::wstring GetFileSystemBasePathForJsonPath(const std::wstring& jsonFilePath);
     static std::wstring GetBaseUriForJsonUri(const std::wstring& jsonUri);
 
     void ExecuteScripts();
+
+   private:
 
     std::list<std::shared_ptr<Script>> m_loadedScripts;
     JsSourceContext m_jsSourceContext = 0;

--- a/HoloJS/HoloJsHost/SpatialInput.cpp
+++ b/HoloJS/HoloJsHost/SpatialInput.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "SpatialInput.h"
+#include "ScriptErrorHandling.h"
 
 using namespace HologramJS::Input;
 using namespace Windows::UI::Input::Spatial;
@@ -9,147 +10,141 @@ using namespace Windows::Perception::Spatial;
 
 SpatialInput::SpatialInput()
 {
-	if (!SpatialInteractionManager::GetForCurrentView())
-	{
-		return;
-	}
+    if (!SpatialInteractionManager::GetForCurrentView()) {
+        return;
+    }
 
-	m_sourcePressedToken = SpatialInteractionManager::GetForCurrentView()->SourcePressed += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
-		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
-	{
-		QueueEventOrFireCallback(SpatialInputEventType::Pressed, args);
-	});
+    m_sourcePressedToken = SpatialInteractionManager::GetForCurrentView()->SourcePressed +=
+        ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
+            [this](SpatialInteractionManager ^ sender, SpatialInteractionSourceEventArgs ^ args) {
+                QueueEventOrFireCallback(SpatialInputEventType::Pressed, args);
+            });
 
-	m_sourceReleasedToken = SpatialInteractionManager::GetForCurrentView()->SourceReleased += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
-		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
-	{
-		QueueEventOrFireCallback(SpatialInputEventType::Released, args);
-	});
+    m_sourceReleasedToken = SpatialInteractionManager::GetForCurrentView()->SourceReleased +=
+        ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
+            [this](SpatialInteractionManager ^ sender, SpatialInteractionSourceEventArgs ^ args) {
+                QueueEventOrFireCallback(SpatialInputEventType::Released, args);
+            });
 
-	m_sourceDetectedToken = SpatialInteractionManager::GetForCurrentView()->SourceDetected += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
-		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
-	{
-		QueueEventOrFireCallback(SpatialInputEventType::Detected, args);
-	});
+    m_sourceDetectedToken = SpatialInteractionManager::GetForCurrentView()->SourceDetected +=
+        ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
+            [this](SpatialInteractionManager ^ sender, SpatialInteractionSourceEventArgs ^ args) {
+                QueueEventOrFireCallback(SpatialInputEventType::Detected, args);
+            });
 
-	m_sourceLostToken = SpatialInteractionManager::GetForCurrentView()->SourceLost += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
-		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
-	{
-		QueueEventOrFireCallback(SpatialInputEventType::Lost, args);
-	});
+    m_sourceLostToken = SpatialInteractionManager::GetForCurrentView()->SourceLost +=
+        ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
+            [this](SpatialInteractionManager ^ sender, SpatialInteractionSourceEventArgs ^ args) {
+                QueueEventOrFireCallback(SpatialInputEventType::Lost, args);
+            });
 
-	m_sourceUpdateToken = SpatialInteractionManager::GetForCurrentView()->SourceUpdated += ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
-		[this](SpatialInteractionManager ^sender, SpatialInteractionSourceEventArgs ^args)
-	{
-		QueueEventOrFireCallback(SpatialInputEventType::Update, args);
-	});
+    m_sourceUpdateToken = SpatialInteractionManager::GetForCurrentView()->SourceUpdated +=
+        ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
+            [this](SpatialInteractionManager ^ sender, SpatialInteractionSourceEventArgs ^ args) {
+                QueueEventOrFireCallback(SpatialInputEventType::Update, args);
+            });
 
-	m_spatialInputAvailable = true;
+    m_spatialInputAvailable = true;
 }
 
 SpatialInput::~SpatialInput()
 {
-	SpatialInteractionManager::GetForCurrentView()->SourceReleased -= m_sourceReleasedToken;
-	SpatialInteractionManager::GetForCurrentView()->SourcePressed -= m_sourcePressedToken;
-	SpatialInteractionManager::GetForCurrentView()->SourceDetected -= m_sourceDetectedToken;
-	SpatialInteractionManager::GetForCurrentView()->SourceLost -= m_sourceLostToken;
-	SpatialInteractionManager::GetForCurrentView()->SourceUpdated -= m_sourceUpdateToken;
-
+    SpatialInteractionManager::GetForCurrentView()->SourceReleased -= m_sourceReleasedToken;
+    SpatialInteractionManager::GetForCurrentView()->SourcePressed -= m_sourcePressedToken;
+    SpatialInteractionManager::GetForCurrentView()->SourceDetected -= m_sourceDetectedToken;
+    SpatialInteractionManager::GetForCurrentView()->SourceLost -= m_sourceLostToken;
+    SpatialInteractionManager::GetForCurrentView()->SourceUpdated -= m_sourceUpdateToken;
 }
 
-void
-SpatialInput::DrainQueuedSpatialInputEvents()
+void SpatialInput::DrainQueuedSpatialInputEvents()
 {
-	// Quick check if there's something in the queue
-	// Technically there could be a race condition in checking the size outside of the lock
-	// but worst case scenario event1 will be delivered on the next vsync
-	if (m_queuedEvents.size() == 0)
-	{
-		return;
-	}
+    // Quick check if there's something in the queue
+    // Technically there could be a race condition in checking the size outside of the lock
+    // but worst case scenario event1 will be delivered on the next vsync
+    if (m_queuedEvents.size() == 0) {
+        return;
+    }
 
-	std::lock_guard<std::mutex> guard(m_eventsQueue);
+    std::lock_guard<std::mutex> guard(m_eventsQueue);
 
-	for (const auto& eventData : m_queuedEvents)
-	{
-		CallbackScriptForSpatialInput(eventData);
-	}
+    for (const auto& eventData : m_queuedEvents) {
+        CallbackScriptForSpatialInput(eventData);
+    }
 
-	m_queuedEvents.clear();
+    m_queuedEvents.clear();
 }
 
-void
-SpatialInput::CallbackScriptForSpatialInput(const SpatialEventData& eventData)
+void SpatialInput::CallbackScriptForSpatialInput(const SpatialEventData& eventData)
 {
+    EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
+    EXIT_IF_FALSE(m_spatialInputAvailable);
 
-	EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
-	EXIT_IF_FALSE(m_spatialInputAvailable);
+    JsValueRef parameters[8];
+    parameters[0] = m_scriptCallback;
+    JsValueRef* eventTypeParam = &parameters[1];
+    JsValueRef* xParam = &parameters[2];
+    JsValueRef* yParam = &parameters[3];
+    JsValueRef* zParam = &parameters[4];
+    JsValueRef* isPressedParam = &parameters[5];
+    JsValueRef* sourceKindParam = &parameters[6];
+    JsValueRef* spatialInputTypeParam = &parameters[7];
 
-	JsValueRef parameters[8];
-	parameters[0] = m_scriptCallback;
-	JsValueRef* eventTypeParam = &parameters[1];
-	JsValueRef* xParam = &parameters[2];
-	JsValueRef* yParam = &parameters[3];
-	JsValueRef* zParam = &parameters[4];
-	JsValueRef* isPressedParam = &parameters[5];
-	JsValueRef* sourceKindParam = &parameters[6];
-	JsValueRef* spatialInputTypeParam = &parameters[7];
+    EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::SpatialInput), eventTypeParam));
+    EXIT_IF_JS_ERROR(JsDoubleToNumber(eventData.position.x, xParam));
+    EXIT_IF_JS_ERROR(JsDoubleToNumber(eventData.position.y, yParam));
+    EXIT_IF_JS_ERROR(JsDoubleToNumber(eventData.position.z, zParam));
+    EXIT_IF_JS_ERROR(JsBoolToBoolean(eventData.isPressed, isPressedParam));
+    EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(eventData.kind), sourceKindParam));
+    EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(eventData.type), spatialInputTypeParam));
 
-	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::SpatialInput), eventTypeParam));
-	EXIT_IF_JS_ERROR(JsDoubleToNumber(eventData.position.x, xParam));
-	EXIT_IF_JS_ERROR(JsDoubleToNumber(eventData.position.y, yParam));
-	EXIT_IF_JS_ERROR(JsDoubleToNumber(eventData.position.z, zParam));
-	EXIT_IF_JS_ERROR(JsBoolToBoolean(eventData.isPressed, isPressedParam));
-	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(eventData.kind), sourceKindParam));
-	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(eventData.type), spatialInputTypeParam));
-
-	JsValueRef result;
-	HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
+    JsValueRef result;
+    HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
 }
 
-void
-SpatialInput::QueueEventOrFireCallback(SpatialInputEventType type, Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs^ args)
+void SpatialInput::QueueEventOrFireCallback(SpatialInputEventType type,
+                                            Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs ^ args)
 {
-	EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
-	EXIT_IF_FALSE(m_spatialInputAvailable);
+    EXIT_IF_TRUE(m_scriptCallback == JS_INVALID_REFERENCE);
+    EXIT_IF_FALSE(m_spatialInputAvailable);
 
-	JsValueRef parameters[8];
-	parameters[0] = m_scriptCallback;
-	JsValueRef* eventTypeParam = &parameters[1];
-	JsValueRef* xParam = &parameters[2];
-	JsValueRef* yParam = &parameters[3];
-	JsValueRef* zParam = &parameters[4];
-	JsValueRef* isPressedParam = &parameters[5];
-	JsValueRef* sourceKindParam = &parameters[6];
-	JsValueRef* spatialInputTypeParam = &parameters[7];
+    JsValueRef parameters[8];
+    parameters[0] = m_scriptCallback;
+    JsValueRef* eventTypeParam = &parameters[1];
+    JsValueRef* xParam = &parameters[2];
+    JsValueRef* yParam = &parameters[3];
+    JsValueRef* zParam = &parameters[4];
+    JsValueRef* isPressedParam = &parameters[5];
+    JsValueRef* sourceKindParam = &parameters[6];
+    JsValueRef* spatialInputTypeParam = &parameters[7];
 
-	const auto location = args->State->Properties->TryGetLocation(m_frameOfReference->CoordinateSystem);
-	const float x = location ? location->Position->Value.x : 0;
-	const float y = location ? location->Position->Value.y : 0;
-	const float z = location ? location->Position->Value.z : 0;
+    const auto location = args->State->Properties->TryGetLocation(m_frameOfReference->CoordinateSystem);
+    const float x = location ? location->Position->Value.x : 0;
+    const float y = location ? location->Position->Value.y : 0;
+    const float z = location ? location->Position->Value.z : 0;
 
-	JsContextRef currentContext = nullptr;
-	EXIT_IF_JS_ERROR(JsGetCurrentContext(&currentContext));
+    JsContextRef currentContext = nullptr;
+    EXIT_IF_JS_ERROR(JsGetCurrentContext(&currentContext));
 
-	if (currentContext != nullptr)
-	{
-		// We are on the UI thread; prepare the parameters and fire the callback to the script guest
-		EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::SpatialInput), eventTypeParam));
-		EXIT_IF_JS_ERROR(JsDoubleToNumber(x, xParam));
-		EXIT_IF_JS_ERROR(JsDoubleToNumber(y, yParam));
-		EXIT_IF_JS_ERROR(JsDoubleToNumber(z, zParam));
-		EXIT_IF_JS_ERROR(JsBoolToBoolean(args->State->IsPressed, isPressedParam));
-		EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(args->State->Source->Kind), sourceKindParam));
-		EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(type), spatialInputTypeParam));
+    if (currentContext != nullptr) {
+        // We are on the UI thread; prepare the parameters and fire the callback to the script guest
+        EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::SpatialInput), eventTypeParam));
+        EXIT_IF_JS_ERROR(JsDoubleToNumber(x, xParam));
+        EXIT_IF_JS_ERROR(JsDoubleToNumber(y, yParam));
+        EXIT_IF_JS_ERROR(JsDoubleToNumber(z, zParam));
+        EXIT_IF_JS_ERROR(JsBoolToBoolean(args->State->IsPressed, isPressedParam));
+        EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(args->State->Source->Kind), sourceKindParam));
+        EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(type), spatialInputTypeParam));
 
-		JsValueRef result;
-		HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
-	}
-	else
-	{
-		// We are not on the JS thread; queue the event and it will be picked up later
-		// by the message pump on the UI/JS thread.
-		std::lock_guard<std::mutex> guard(m_eventsQueue);
-		m_queuedEvents.emplace_back(SpatialEventData(args->State->Source->Kind, type, args->State->IsPressed, (location ? location->Position->Value : Windows::Foundation::Numerics::float3())));
-	}
+        JsValueRef result;
+        HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
+    } else {
+        // We are not on the JS thread; queue the event and it will be picked up later
+        // by the message pump on the UI/JS thread.
+        std::lock_guard<std::mutex> guard(m_eventsQueue);
+        m_queuedEvents.emplace_back(
+            SpatialEventData(args->State->Source->Kind,
+                             type,
+                             args->State->IsPressed,
+                             (location ? location->Position->Value : Windows::Foundation::Numerics::float3())));
+    }
 }

--- a/HoloJS/HoloJsHost/SpatialInput.h
+++ b/HoloJS/HoloJsHost/SpatialInput.h
@@ -1,73 +1,73 @@
 #pragma once
+#include "ChakraForHoloJS.h"
 #include "InputInterface.h"
 
-namespace HologramJS
-{
-	namespace Input
-	{
-		class SpatialInput
-		{
-		public:
-			SpatialInput();
-			~SpatialInput();
+namespace HologramJS {
+namespace Input {
+class SpatialInput {
+   public:
+    SpatialInput();
+    ~SpatialInput();
 
-			void SetScriptCallback(JsValueRef scriptCallback) { m_scriptCallback = scriptCallback; }
+    void SetScriptCallback(JsValueRef scriptCallback) { m_scriptCallback = scriptCallback; }
 
-			void SetStationaryFrameOfReference(Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ frameOfReference)
-			{
-				m_frameOfReference = frameOfReference;
-			}
+    void SetStationaryFrameOfReference(Windows::Perception::Spatial::SpatialStationaryFrameOfReference ^
+                                       frameOfReference)
+    {
+        m_frameOfReference = frameOfReference;
+    }
 
-			// Called on the UI thread to drain all events that were queued on worker threads
-			// Remove this once RS1 is no longer supported; in RS2+ spatial input events are
-			// guaranteed to come on the UI thread
-			void DrainQueuedSpatialInputEvents();
+    // Called on the UI thread to drain all events that were queued on worker threads
+    // Remove this once RS1 is no longer supported; in RS2+ spatial input events are
+    // guaranteed to come on the UI thread
+    void DrainQueuedSpatialInputEvents();
 
-		private:
-			JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
+   private:
+    JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
 
-			Windows::Foundation::EventRegistrationToken m_sourcePressedToken;
-			Windows::Foundation::EventRegistrationToken m_sourceReleasedToken;
-			Windows::Foundation::EventRegistrationToken m_sourceLostToken;
-			Windows::Foundation::EventRegistrationToken m_sourceDetectedToken;
-			Windows::Foundation::EventRegistrationToken m_sourceUpdateToken;
+    Windows::Foundation::EventRegistrationToken m_sourcePressedToken;
+    Windows::Foundation::EventRegistrationToken m_sourceReleasedToken;
+    Windows::Foundation::EventRegistrationToken m_sourceLostToken;
+    Windows::Foundation::EventRegistrationToken m_sourceDetectedToken;
+    Windows::Foundation::EventRegistrationToken m_sourceUpdateToken;
 
-			bool m_spatialInputAvailable = false;
+    bool m_spatialInputAvailable = false;
 
-			// Stores decoded information about a spatial event
-			struct SpatialEventData
-			{
-				Windows::UI::Input::Spatial::SpatialInteractionSourceKind kind;
-				SpatialInputEventType type;
-				bool isPressed;
-				Windows::Foundation::Numerics::float3 position;
+    // Stores decoded information about a spatial event
+    struct SpatialEventData {
+        Windows::UI::Input::Spatial::SpatialInteractionSourceKind kind;
+        SpatialInputEventType type;
+        bool isPressed;
+        Windows::Foundation::Numerics::float3 position;
 
-				SpatialEventData(Windows::UI::Input::Spatial::SpatialInteractionSourceKind kind, SpatialInputEventType type, bool isPressed, Windows::Foundation::Numerics::float3 position)
-				{
-					this->kind = kind;
-					this->type = type;
-					this->isPressed = isPressed;
-					this->position = position;
-				}
-			};
+        SpatialEventData(Windows::UI::Input::Spatial::SpatialInteractionSourceKind kind,
+                         SpatialInputEventType type,
+                         bool isPressed,
+                         Windows::Foundation::Numerics::float3 position)
+        {
+            this->kind = kind;
+            this->type = type;
+            this->isPressed = isPressed;
+            this->position = position;
+        }
+    };
 
-			void CallbackScriptForSpatialInput(const SpatialEventData& eventData);
-			void QueueEventOrFireCallback(SpatialInputEventType type, Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs^ args);
+    void CallbackScriptForSpatialInput(const SpatialEventData& eventData);
+    void QueueEventOrFireCallback(SpatialInputEventType type,
+                                  Windows::UI::Input::Spatial::SpatialInteractionSourceEventArgs ^ args);
 
-			JsValueRef m_spatialInputEventName;
-			JsValueRef m_spatialInputSourcePressedName;
-			JsValueRef m_spatialInputSourceReleasedName;
+    JsValueRef m_spatialInputEventName;
+    JsValueRef m_spatialInputSourcePressedName;
+    JsValueRef m_spatialInputSourceReleasedName;
 
-			Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ m_frameOfReference;
+    Windows::Perception::Spatial::SpatialStationaryFrameOfReference ^ m_frameOfReference;
 
-			// Lock to synchronize access to the queued events vector
-			std::mutex m_eventsQueue;
+    // Lock to synchronize access to the queued events vector
+    std::mutex m_eventsQueue;
 
-			// List of events that were queued because they came on a non-UI thread;
-			// This list is drained on v-sync
-			std::vector<SpatialEventData> m_queuedEvents;
-
-		};
-	}
-}
-
+    // List of events that were queued because they came on a non-UI thread;
+    // This list is drained on v-sync
+    std::vector<SpatialEventData> m_queuedEvents;
+};
+}  // namespace Input
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/SpatialMapping.cpp
+++ b/HoloJS/HoloJsHost/SpatialMapping.cpp
@@ -1,9 +1,11 @@
 #include "pch.h"
 #include "SpatialMapping.h"
-#include <WindowsNumerics.h>
-#include <Robuffer.h>
 #include "InputInterface.h"
+#include "ScriptErrorHandling.h"
+#include "ScriptHostUtilities.h"
 #include <DirectXMath.h>
+#include <Robuffer.h>
+#include <WindowsNumerics.h>
 
 using namespace HologramJS::Input;
 using namespace Windows::Perception::Spatial;
@@ -14,252 +16,241 @@ using namespace Windows::Graphics::DirectX;
 using namespace HologramJS::Utilities;
 using namespace DirectX;
 
-SpatialMapping::SpatialMapping()
+SpatialMapping::SpatialMapping() {}
+
+SpatialMapping::~SpatialMapping() {}
+
+JsValueRef SpatialMapping::GetSpatialData(float extentX, float extentY, float extentZ, int trianglesPerCubicMeter)
 {
+    RETURN_INVALID_REF_IF_FALSE(m_surfaceAccessAllowed);
+    RETURN_INVALID_REF_IF_FALSE(CreateSurfaceObserver(extentX, extentY, extentZ));
+
+    m_trianglesResolution = trianglesPerCubicMeter;
+
+    auto mapContainingSurfaceCollection = m_surfaceObserver->GetObservedSurfaces();
+
+    int counter = 0;
+    for (auto const& pair : mapContainingSurfaceCollection) {
+        // Store the ID and metadata for each surface.
+        auto const& id = pair->Key;
+        auto const& surfaceInfo = pair->Value;
+        ProcessSurface(pair->Value);
+    }
+
+    return JS_INVALID_REFERENCE;
 }
 
-
-SpatialMapping::~SpatialMapping()
+void SpatialMapping::EnableSpatialMapping(SpatialStationaryFrameOfReference ^ frameOfReference)
 {
+    m_frameOfReference = frameOfReference;
+
+    auto initSurfaceObserverTask = create_task(SpatialSurfaceObserver::RequestAccessAsync());
+    initSurfaceObserverTask.then([this](Windows::Perception::Spatial::SpatialPerceptionAccessStatus status) {
+        switch (status) {
+            case SpatialPerceptionAccessStatus::Allowed:
+                m_surfaceAccessAllowed = true;
+                break;
+            default:
+                // Access was denied. This usually happens because your AppX manifest file does not declare the
+                // spatialPerception capability.
+                // For info on what else can cause this, see:
+                // http://msdn.microsoft.com/library/windows/apps/mt621422.aspx
+                m_surfaceAccessAllowed = false;
+                break;
+        }
+    });
 }
 
-JsValueRef
-SpatialMapping::GetSpatialData(float extentX, float extentY, float extentZ, int trianglesPerCubicMeter)
+bool SpatialMapping::CreateSurfaceObserver(float extentX, float extentY, float extentZ)
 {
-	RETURN_INVALID_REF_IF_FALSE(m_surfaceAccessAllowed);
-	RETURN_INVALID_REF_IF_FALSE(CreateSurfaceObserver(extentX, extentY, extentZ));
+    RETURN_IF_FALSE(m_surfaceAccessAllowed);
 
-	m_trianglesResolution = trianglesPerCubicMeter;
+    if (m_surfaceObserver != nullptr) {
+        return true;
+    }
 
-	auto mapContainingSurfaceCollection = m_surfaceObserver->GetObservedSurfaces();
+    SpatialBoundingBox axisAlignedBoundingBox = {
+        {0.f, 0.f, 0.f}, {extentX, extentY, extentZ},
+    };
+    SpatialBoundingVolume ^ bounds =
+        SpatialBoundingVolume::FromBox(m_frameOfReference->CoordinateSystem, axisAlignedBoundingBox);
 
-	int counter = 0;
-	for (auto const& pair : mapContainingSurfaceCollection)
-	{
-		// Store the ID and metadata for each surface.
-		auto const& id = pair->Key;
-		auto const& surfaceInfo = pair->Value;
-		ProcessSurface(pair->Value);
-	}
-	
-	return JS_INVALID_REFERENCE;
+    m_surfaceMeshOptions = ref new SpatialSurfaceMeshOptions();
+    unsigned int formatIndex = 0;
+
+    // Set the vertex format
+    IVectorView<DirectXPixelFormat> ^ supportedVertexPositionFormats =
+        m_surfaceMeshOptions->SupportedVertexPositionFormats;
+
+    RETURN_IF_FALSE(supportedVertexPositionFormats->IndexOf(DirectXPixelFormat::R32G32B32A32Float, &formatIndex));
+    m_surfaceMeshOptions->VertexPositionFormat = DirectXPixelFormat::R32G32B32A32Float;
+
+    // Set the normals format
+    IVectorView<DirectXPixelFormat> ^ supportedVertexNormalFormats = m_surfaceMeshOptions->SupportedVertexNormalFormats;
+    RETURN_IF_FALSE(supportedVertexNormalFormats->IndexOf(DirectXPixelFormat::R8G8B8A8IntNormalized, &formatIndex));
+    m_surfaceMeshOptions->VertexNormalFormat = DirectXPixelFormat::R8G8B8A8IntNormalized;
+
+    for (const auto format : m_surfaceMeshOptions->SupportedTriangleIndexFormats) {
+        OutputDebugStringW(format.ToString()->Data());
+    }
+
+    m_surfaceMeshOptions->IncludeVertexNormals = true;
+
+    // Create the observer.
+    m_surfaceObserver = ref new SpatialSurfaceObserver();
+    RETURN_IF_NULL(m_surfaceObserver);
+
+    m_surfaceObserver->SetBoundingVolume(bounds);
+
+    return true;
 }
 
-void
-SpatialMapping::EnableSpatialMapping(SpatialStationaryFrameOfReference^ frameOfReference)
+byte* GetPointerToData(Windows::Storage::Streams::IBuffer ^ buffer)
 {
-	m_frameOfReference = frameOfReference;
+    Microsoft::WRL::ComPtr<Windows::Storage::Streams::IBufferByteAccess> bufferByteAccess;
+    reinterpret_cast<IInspectable*>(buffer)->QueryInterface(IID_PPV_ARGS(&bufferByteAccess));
 
-	auto initSurfaceObserverTask = create_task(SpatialSurfaceObserver::RequestAccessAsync());
-	initSurfaceObserverTask.then([this](Windows::Perception::Spatial::SpatialPerceptionAccessStatus status)
-	{
- 		switch (status)
-		{
-		case SpatialPerceptionAccessStatus::Allowed:
-			m_surfaceAccessAllowed = true;
-			break;
-		default:
-			// Access was denied. This usually happens because your AppX manifest file does not declare the
-			// spatialPerception capability.
-			// For info on what else can cause this, see: http://msdn.microsoft.com/library/windows/apps/mt621422.aspx
-			m_surfaceAccessAllowed = false;
-			break;
-		}
-	});
+    byte* pointer;
+    bufferByteAccess->Buffer(&pointer);
+
+    return pointer;
 }
 
-bool
-SpatialMapping::CreateSurfaceObserver(float extentX, float extentY, float extentZ)
+void SpatialMapping::ProcessOneSpatialMappingDataUpdate()
 {
-	RETURN_IF_FALSE(m_surfaceAccessAllowed);
+    if (m_scriptCallback == JS_INVALID_REFERENCE) {
+        return;
+    }
 
-	if (m_surfaceObserver != nullptr)
-	{
-		return true;
-	}
+    std::lock_guard<std::mutex> guard(m_processingLock);
+    if (m_meshIds.size() == 0) {
+        return;
+    }
 
-	SpatialBoundingBox axisAlignedBoundingBox =
-	{
-		{ 0.f,  0.f, 0.f },
-		{ extentX, extentY, extentZ },
-	};
-	SpatialBoundingVolume^ bounds = SpatialBoundingVolume::FromBox(m_frameOfReference->CoordinateSystem, axisAlignedBoundingBox);
-		
-	m_surfaceMeshOptions = ref new SpatialSurfaceMeshOptions();
-	unsigned int formatIndex = 0;
+    JsTypedArrayType arrayType;
+    int elementSize;
+    unsigned int typedArraySize;
+    byte* typedArrayStorage;
 
-	// Set the vertex format
-	IVectorView<DirectXPixelFormat>^ supportedVertexPositionFormats = m_surfaceMeshOptions->SupportedVertexPositionFormats;
+    JsValueRef originToSurfaceRef;
+    EXIT_IF_JS_ERROR(JsCreateTypedArray(
+        JsArrayTypeFloat32, JS_INVALID_REFERENCE, 0, m_originToSurfaces.front().size(), &originToSurfaceRef));
+    EXIT_IF_JS_ERROR(
+        JsGetTypedArrayStorage(originToSurfaceRef, &typedArrayStorage, &typedArraySize, &arrayType, &elementSize));
+    memcpy(typedArrayStorage, m_originToSurfaces.front().data(), typedArraySize);
 
-	RETURN_IF_FALSE(supportedVertexPositionFormats->IndexOf(DirectXPixelFormat::R32G32B32A32Float, &formatIndex));
-	m_surfaceMeshOptions->VertexPositionFormat = DirectXPixelFormat::R32G32B32A32Float;
+    JsValueRef normalBufferRef;
+    EXIT_IF_JS_ERROR(
+        JsCreateTypedArray(JsArrayTypeInt8, JS_INVALID_REFERENCE, 0, m_normalBuffers.front().size(), &normalBufferRef));
+    EXIT_IF_JS_ERROR(
+        JsGetTypedArrayStorage(normalBufferRef, &typedArrayStorage, &typedArraySize, &arrayType, &elementSize));
+    memcpy(typedArrayStorage, m_normalBuffers.front().data(), typedArraySize);
 
-	// Set the normals format
-	IVectorView<DirectXPixelFormat>^ supportedVertexNormalFormats = m_surfaceMeshOptions->SupportedVertexNormalFormats;
-	RETURN_IF_FALSE(supportedVertexNormalFormats->IndexOf(DirectXPixelFormat::R8G8B8A8IntNormalized, &formatIndex));
-	m_surfaceMeshOptions->VertexNormalFormat = DirectXPixelFormat::R8G8B8A8IntNormalized;
+    JsValueRef indexBufferRef;
+    EXIT_IF_JS_ERROR(
+        JsCreateTypedArray(JsArrayTypeInt16, JS_INVALID_REFERENCE, 0, m_indexBuffers.front().size(), &indexBufferRef));
+    EXIT_IF_JS_ERROR(
+        JsGetTypedArrayStorage(indexBufferRef, &typedArrayStorage, &typedArraySize, &arrayType, &elementSize));
+    memcpy(typedArrayStorage, m_indexBuffers.front().data(), typedArraySize);
 
-	for (const auto format : m_surfaceMeshOptions->SupportedTriangleIndexFormats)
-	{
-		OutputDebugStringW(format.ToString()->Data());
-	}
+    JsValueRef vertexBufferRef;
+    EXIT_IF_JS_ERROR(JsCreateTypedArray(
+        JsArrayTypeFloat32, JS_INVALID_REFERENCE, 0, m_vertexBuffers.front().size(), &vertexBufferRef));
+    EXIT_IF_JS_ERROR(
+        JsGetTypedArrayStorage(vertexBufferRef, &typedArrayStorage, &typedArraySize, &arrayType, &elementSize));
+    memcpy(typedArrayStorage, m_vertexBuffers.front().data(), typedArraySize);
 
-	m_surfaceMeshOptions->IncludeVertexNormals = true;
+    JsValueRef meshIdRef;
+    EXIT_IF_JS_ERROR(
+        JsCreateTypedArray(JsArrayTypeInt8, JS_INVALID_REFERENCE, 0, m_meshIds.front().size(), &meshIdRef));
+    EXIT_IF_JS_ERROR(JsGetTypedArrayStorage(meshIdRef, &typedArrayStorage, &typedArraySize, &arrayType, &elementSize));
+    memcpy(typedArrayStorage, m_meshIds.front().data(), typedArraySize);
 
-	// Create the observer.
-	m_surfaceObserver = ref new SpatialSurfaceObserver();
-	RETURN_IF_NULL(m_surfaceObserver);
-	
-	m_surfaceObserver->SetBoundingVolume(bounds);
+    JsValueRef meshObjectRef;
+    EXIT_IF_JS_ERROR(JsCreateObject(&meshObjectRef));
+    EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObjectRef, L"originToSurfaceTransform", originToSurfaceRef));
+    EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObjectRef, L"normals", normalBufferRef));
+    EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObjectRef, L"indices", indexBufferRef));
+    EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObjectRef, L"vertices", vertexBufferRef));
+    EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObjectRef, L"id", meshIdRef));
 
-	return true;
+    // Create JS callback parameters
+    JsValueRef parameters[3];
+    parameters[0] = m_scriptCallback;
+    EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::SpatialMapping), &parameters[1]));
+    parameters[2] = meshObjectRef;
+
+    // Invoke JS callback
+    JsValueRef result;
+    HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
+
+    m_meshIds.pop_front();
+    m_vertexBuffers.pop_front();
+    m_indexBuffers.pop_front();
+    m_normalBuffers.pop_front();
+    m_originToSurfaces.pop_front();
 }
 
-byte* GetPointerToData(Windows::Storage::Streams::IBuffer^ buffer)
+void SpatialMapping::ProcessSurface(SpatialSurfaceInfo ^ surface)
 {
-	Microsoft::WRL::ComPtr<Windows::Storage::Streams::IBufferByteAccess> bufferByteAccess;
-	reinterpret_cast<IInspectable*>(buffer)->QueryInterface(IID_PPV_ARGS(&bufferByteAccess));
+    auto computeMeshTask = create_task(surface->TryComputeLatestMeshAsync(m_trianglesResolution, m_surfaceMeshOptions));
 
-	byte* pointer;
-	bufferByteAccess->Buffer(&pointer);
+    computeMeshTask.then(
+        [this](SpatialSurfaceMesh ^ mesh) {
+            if (mesh == nullptr) {
+                return;
+            }
 
-	return pointer;
-}
+            m_processingLock.lock();
 
-void
-SpatialMapping::ProcessOneSpatialMappingDataUpdate()
-{
-	if (m_scriptCallback == JS_INVALID_REFERENCE)
-	{
-		return;
-	}
-	
-	std::lock_guard<std::mutex> guard(m_processingLock);
-	if (m_meshIds.size() == 0)
-	{
-		return;
-	}
+            // Combine origin transform with mesh scale to create position transform
+            auto originToSurface = mesh->CoordinateSystem->TryGetTransformTo(m_frameOfReference->CoordinateSystem);
+            DirectX::XMMATRIX translationMat = XMLoadFloat4x4(&originToSurface->Value);
+            XMMATRIX scaleMat =
+                XMMatrixScaling(mesh->VertexPositionScale.x, mesh->VertexPositionScale.y, mesh->VertexPositionScale.z);
+            XMMATRIX posTransformMat = scaleMat * translationMat;
+            XMFLOAT4X4 posTransformf4;
+            XMStoreFloat4x4(&posTransformf4, posTransformMat);
 
-	JsTypedArrayType arrayType;
-	int elementSize;
-	unsigned int typedArraySize;
-	byte* typedArrayStorage;
+            // Copy position transform to buffer
+            m_originToSurfaces.emplace_back(sizeof(posTransformf4));
+            memcpy(m_originToSurfaces.back().data(), posTransformf4.m, sizeof(posTransformf4));
 
-	JsValueRef originToSurfaceRef;
-	EXIT_IF_JS_ERROR(JsCreateTypedArray(JsArrayTypeFloat32, JS_INVALID_REFERENCE, 0, m_originToSurfaces.front().size(), &originToSurfaceRef));
-	EXIT_IF_JS_ERROR(JsGetTypedArrayStorage(originToSurfaceRef, &typedArrayStorage, &typedArraySize, &arrayType, &elementSize));
-	memcpy(typedArrayStorage, m_originToSurfaces.front().data(), typedArraySize);
+            // Copy normals to buffer; go from float4 to float3
+            m_normalBuffers.emplace_back(3 * mesh->VertexNormals->ElementCount);
+            auto destNormalPointer = m_normalBuffers.back().data();
+            auto sourceNormalPointer = reinterpret_cast<byte*>(GetPointerToData(mesh->VertexNormals->Data));
+            for (unsigned int i = 0; i < mesh->VertexNormals->ElementCount; i++) {
+                memcpy(destNormalPointer, sourceNormalPointer, 3 * sizeof(byte));
+                destNormalPointer += 3;
+                sourceNormalPointer += 4;
+            }
 
-	JsValueRef normalBufferRef;
-	EXIT_IF_JS_ERROR(JsCreateTypedArray(JsArrayTypeInt8, JS_INVALID_REFERENCE, 0, m_normalBuffers.front().size(), &normalBufferRef));
-	EXIT_IF_JS_ERROR(JsGetTypedArrayStorage(normalBufferRef, &typedArrayStorage, &typedArraySize, &arrayType, &elementSize));
-	memcpy(typedArrayStorage, m_normalBuffers.front().data(), typedArraySize);
+            // Copy indices to buffer; swap order to CW
+            m_indexBuffers.emplace_back(mesh->TriangleIndices->ElementCount);
+            auto destIndexPointer = m_indexBuffers.back().data();
+            auto sourceIndexPointer = reinterpret_cast<short int*>(GetPointerToData(mesh->TriangleIndices->Data));
+            for (unsigned int i = 0; i <= mesh->TriangleIndices->ElementCount - 3; i += 3) {
+                destIndexPointer[i] = sourceIndexPointer[i + 2];
+                destIndexPointer[i + 1] = sourceIndexPointer[i + 1];
+                destIndexPointer[i + 2] = sourceIndexPointer[i];
+            }
 
-	JsValueRef indexBufferRef;
-	EXIT_IF_JS_ERROR(JsCreateTypedArray(JsArrayTypeInt16, JS_INVALID_REFERENCE, 0, m_indexBuffers.front().size(), &indexBufferRef));
-	EXIT_IF_JS_ERROR(JsGetTypedArrayStorage(indexBufferRef, &typedArrayStorage, &typedArraySize, &arrayType, &elementSize));
-	memcpy(typedArrayStorage, m_indexBuffers.front().data(), typedArraySize);
+            // Copy positions to buffer; go from float4 to float3
+            m_vertexBuffers.emplace_back(3 * mesh->VertexPositions->ElementCount);
+            auto destVertexPointer = m_vertexBuffers.back().data();
+            auto sourceVertexPointer = reinterpret_cast<float*>(GetPointerToData(mesh->VertexPositions->Data));
+            for (unsigned int i = 0; i < mesh->VertexPositions->ElementCount; i++) {
+                memcpy(destVertexPointer, sourceVertexPointer, 3 * sizeof(float));
+                destVertexPointer += 3;
+                sourceVertexPointer += 4;
+            }
 
-	JsValueRef vertexBufferRef;
-	EXIT_IF_JS_ERROR(JsCreateTypedArray(JsArrayTypeFloat32, JS_INVALID_REFERENCE, 0, m_vertexBuffers.front().size(), &vertexBufferRef));
-	EXIT_IF_JS_ERROR(JsGetTypedArrayStorage(vertexBufferRef, &typedArrayStorage, &typedArraySize, &arrayType, &elementSize));
-	memcpy(typedArrayStorage, m_vertexBuffers.front().data(), typedArraySize);
+            // Copy mesh ID
+            m_meshIds.emplace_back(sizeof(GUID));
+            memcpy(m_meshIds.back().data(), &mesh->SurfaceInfo->Id, sizeof(GUID));
 
-	JsValueRef meshIdRef;
-	EXIT_IF_JS_ERROR(JsCreateTypedArray(JsArrayTypeInt8, JS_INVALID_REFERENCE, 0, m_meshIds.front().size(), &meshIdRef));
-	EXIT_IF_JS_ERROR(JsGetTypedArrayStorage(meshIdRef, &typedArrayStorage, &typedArraySize, &arrayType, &elementSize));
-	memcpy(typedArrayStorage, m_meshIds.front().data(), typedArraySize);
-
-	JsValueRef meshObjectRef;
-	EXIT_IF_JS_ERROR(JsCreateObject(&meshObjectRef));
-	EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObjectRef, L"originToSurfaceTransform", originToSurfaceRef));
-	EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObjectRef, L"normals", normalBufferRef));
-	EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObjectRef, L"indices", indexBufferRef));
-	EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObjectRef, L"vertices", vertexBufferRef));
-	EXIT_IF_FALSE(ScriptHostUtilities::SetJsProperty(meshObjectRef, L"id", meshIdRef));
-
-	// Create JS callback parameters
-	JsValueRef parameters[3];
-	parameters[0] = m_scriptCallback;
-	EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(NativeToScriptInputType::SpatialMapping), &parameters[1]));
-	parameters[2] = meshObjectRef;
-
-	// Invoke JS callback
-	JsValueRef result;
-	HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(m_scriptCallback, parameters, ARRAYSIZE(parameters), &result));
-
-	m_meshIds.pop_front();
-	m_vertexBuffers.pop_front();
-	m_indexBuffers.pop_front();
-	m_normalBuffers.pop_front();
-	m_originToSurfaces.pop_front();
-}
-
-void
-SpatialMapping::ProcessSurface(
-	SpatialSurfaceInfo^ surface
-)
-{
-	auto computeMeshTask = create_task(surface->TryComputeLatestMeshAsync(m_trianglesResolution, m_surfaceMeshOptions));
-
-	computeMeshTask.then([this](SpatialSurfaceMesh^ mesh)
-	{
-		if (mesh == nullptr)
-		{
-			return;
-		}
-
-		m_processingLock.lock();
-
-		// Combine origin transform with mesh scale to create position transform
-		auto originToSurface = mesh->CoordinateSystem->TryGetTransformTo(m_frameOfReference->CoordinateSystem);
-		DirectX::XMMATRIX translationMat = XMLoadFloat4x4(&originToSurface->Value);
-		XMMATRIX scaleMat = XMMatrixScaling(mesh->VertexPositionScale.x, mesh->VertexPositionScale.y, mesh->VertexPositionScale.z);
-		XMMATRIX posTransformMat = scaleMat *translationMat;
-		XMFLOAT4X4 posTransformf4;
-		XMStoreFloat4x4(&posTransformf4, posTransformMat);
-
-		// Copy position transform to buffer
-		m_originToSurfaces.emplace_back(sizeof(posTransformf4));
-		memcpy(m_originToSurfaces.back().data(), posTransformf4.m, sizeof(posTransformf4));
-
-		// Copy normals to buffer; go from float4 to float3
-		m_normalBuffers.emplace_back(3 * mesh->VertexNormals->ElementCount);
-		auto destNormalPointer = m_normalBuffers.back().data();
-		auto sourceNormalPointer = reinterpret_cast<byte*>(GetPointerToData(mesh->VertexNormals->Data));
-		for (int i = 0; i < mesh->VertexNormals->ElementCount; i++)
-		{
-			memcpy(destNormalPointer, sourceNormalPointer, 3 * sizeof(byte));
-			destNormalPointer += 3;
-			sourceNormalPointer += 4;
-		}
-
-		// Copy indices to buffer; swap order to CW
-		m_indexBuffers.emplace_back(mesh->TriangleIndices->ElementCount);
-		auto destIndexPointer = m_indexBuffers.back().data();
-		auto sourceIndexPointer = reinterpret_cast<short int*>(GetPointerToData(mesh->TriangleIndices->Data));
-		for (int i = 0; i <= mesh->TriangleIndices->ElementCount - 3; i += 3)
-		{
-			destIndexPointer[i] = sourceIndexPointer[i + 2];
-			destIndexPointer[i + 1] = sourceIndexPointer[i + 1];
-			destIndexPointer[i + 2] = sourceIndexPointer[i];
-		}
-
-		// Copy positions to buffer; go from float4 to float3
-		m_vertexBuffers.emplace_back(3 * mesh->VertexPositions->ElementCount);
-		auto destVertexPointer = m_vertexBuffers.back().data();
-		auto sourceVertexPointer = reinterpret_cast<float*>(GetPointerToData(mesh->VertexPositions->Data));
-		for (int i = 0; i < mesh->VertexPositions->ElementCount; i++)
-		{
-			memcpy(destVertexPointer, sourceVertexPointer, 3 * sizeof(float));
-			destVertexPointer += 3;
-			sourceVertexPointer += 4;
-		}
-
-		// Copy mesh ID
-		m_meshIds.emplace_back(sizeof(GUID));
-		memcpy(m_meshIds.back().data(), &mesh->SurfaceInfo->Id, sizeof(GUID));
-
-		m_processingLock.unlock();
-	}, concurrency::task_continuation_context::use_arbitrary());
+            m_processingLock.unlock();
+        },
+        concurrency::task_continuation_context::use_arbitrary());
 }

--- a/HoloJS/HoloJsHost/SpatialMapping.h
+++ b/HoloJS/HoloJsHost/SpatialMapping.h
@@ -1,51 +1,46 @@
 #pragma once
+#include "ChakraForHoloJS.h"
 #include <list>
-namespace HologramJS
-{
-	namespace Input
-	{
-		class SpatialMapping
-		{
-		public:
-			SpatialMapping();
-			~SpatialMapping();
+namespace HologramJS {
+namespace Input {
+class SpatialMapping {
+   public:
+    SpatialMapping();
+    ~SpatialMapping();
 
-			void EnableSpatialMapping(Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ frameOfReference);
-			void DisableSpatialMapping() { m_frameOfReference = nullptr; }
+    void EnableSpatialMapping(Windows::Perception::Spatial::SpatialStationaryFrameOfReference ^ frameOfReference);
+    void DisableSpatialMapping() { m_frameOfReference = nullptr; }
 
-			void SetScriptCallback(JsValueRef scriptCallback) { m_scriptCallback = scriptCallback; }
+    void SetScriptCallback(JsValueRef scriptCallback) { m_scriptCallback = scriptCallback; }
 
-			JsValueRef GetSpatialData(float extentX, float extentY, float extentZ, int trianglesPerCubicMeter);
+    JsValueRef GetSpatialData(float extentX, float extentY, float extentZ, int trianglesPerCubicMeter);
 
-			void ProcessOneSpatialMappingDataUpdate();
+    void ProcessOneSpatialMappingDataUpdate();
 
-		private:
+   private:
+    JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
 
-			JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
+    Windows::Perception::Spatial::SpatialStationaryFrameOfReference ^ m_frameOfReference;
+    bool m_surfaceAccessAllowed = false;
+    Windows::Perception::Spatial::Surfaces::SpatialSurfaceObserver ^ m_surfaceObserver;
+    Windows::Perception::Spatial::Surfaces::SpatialSurfaceMeshOptions ^ m_surfaceMeshOptions;
 
-			Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ m_frameOfReference;
-			bool m_surfaceAccessAllowed = false;
-			Windows::Perception::Spatial::Surfaces::SpatialSurfaceObserver^ m_surfaceObserver;
-			Windows::Perception::Spatial::Surfaces::SpatialSurfaceMeshOptions^ m_surfaceMeshOptions;
+    bool CreateSurfaceObserver(float extentX, float extentY, float extentZ);
 
-			bool CreateSurfaceObserver(float extentX, float extentY, float extentZ);
+    void ProcessSurface(Windows::Perception::Spatial::Surfaces::SpatialSurfaceInfo ^ surface);
 
-			void ProcessSurface(Windows::Perception::Spatial::Surfaces::SpatialSurfaceInfo^ surface);
+    std::mutex m_processingLock;
 
-			std::mutex m_processingLock;
+    std::list<std::vector<short int>> m_indexBuffers;
+    std::list<std::vector<float>> m_vertexBuffers;
+    std::list<std::vector<byte>> m_normalBuffers;
+    std::list<std::vector<float>> m_originToSurfaces;
+    std::list<std::vector<byte>> m_meshIds;
 
-			std::list<std::vector<short int>> m_indexBuffers;
-			std::list<std::vector<float>> m_vertexBuffers;
-			std::list<std::vector<byte>> m_normalBuffers;
-			std::list<std::vector<float>> m_originToSurfaces;
-			std::list<std::vector<byte>> m_meshIds;
+    bool m_spatialMappingDataAvailable = false;
 
-			bool m_spatialMappingDataAvailable = false;
+    int m_trianglesResolution = 1000;
+};
 
-			int m_trianglesResolution = 1000;
-		};
-
-
-	}
-}
-
+}  // namespace Input
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/System.cpp
+++ b/HoloJS/HoloJsHost/System.cpp
@@ -1,34 +1,28 @@
 #include "pch.h"
 #include "System.h"
-
+#include "ScriptHostUtilities.h"
 
 using namespace HologramJS::API;
 using namespace HologramJS::Utilities;
 using namespace concurrency;
 using namespace std;
 
-bool
-System::Initialize()
+bool System::Initialize()
 {
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"log", L"system", logStatic, this, &m_logFunction));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"log", L"system", logStatic, this, &m_logFunction));
 
-	return true;
+    return true;
 }
 
-JsValueRef
-System::log(
-	JsValueRef callee,
-	JsValueRef* arguments,
-	unsigned short argumentCount
-)
+JsValueRef System::log(JsValueRef callee, JsValueRef* arguments, unsigned short argumentCount)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
 
-	const wchar_t* logString;
-	size_t logStringLength;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsStringToPointer(arguments[1], &logString, &logStringLength));
+    const wchar_t* logString;
+    size_t logStringLength;
+    RETURN_INVALID_REF_IF_JS_ERROR(JsStringToPointer(arguments[1], &logString, &logStringLength));
 
-	OutputDebugString(logString);
+    OutputDebugString(logString);
 
-	return JS_INVALID_REFERENCE;
+    return JS_INVALID_REFERENCE;
 }

--- a/HoloJS/HoloJsHost/System.h
+++ b/HoloJS/HoloJsHost/System.h
@@ -1,37 +1,29 @@
 #pragma once
 
-namespace HologramJS
-{
-	namespace API
-	{
-		class System
-		{
-		public:
-			System() {}
-			~System() {}
+#include "ChakraForHoloJS.h"
 
-			bool Initialize();
+namespace HologramJS {
+namespace API {
+class System {
+   public:
+    System() {}
+    ~System() {}
 
-		private:
+    bool Initialize();
 
-			JsValueRef m_logFunction = JS_INVALID_REFERENCE;
-			static JsValueRef CHAKRA_CALLBACK logStatic(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			)
-			{
-				return reinterpret_cast<System*>(callbackData)->log(callee, arguments, argumentCount);
-			}
+   private:
+    JsValueRef m_logFunction = JS_INVALID_REFERENCE;
+    static JsValueRef CHAKRA_CALLBACK logStatic(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData)
+    {
+        return reinterpret_cast<System*>(callbackData)->log(callee, arguments, argumentCount);
+    }
 
-			JsValueRef log(
-				JsValueRef callee,
-				JsValueRef* arguments,
-				unsigned short argumentCount
-			);
-		};
+    JsValueRef log(JsValueRef callee, JsValueRef* arguments, unsigned short argumentCount);
+};
 
-	}
-}
+}  // namespace API
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/Timers.cpp
+++ b/HoloJS/HoloJsHost/Timers.cpp
@@ -1,5 +1,7 @@
 #include "pch.h"
 #include "Timers.h"
+#include "ScriptErrorHandling.h"
+#include "ScriptHostUtilities.h"
 #include <concrt.h>
 
 using namespace HologramJS::API;
@@ -7,232 +9,195 @@ using namespace concurrency;
 using namespace std;
 using namespace HologramJS::Utilities;
 
-bool
-Timers::Initialize()
+bool Timers::Initialize()
 {
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"setTimeout", L"timers", setTimeoutStatic, this, &m_setTimeoutFunction));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"clearTimer", L"timers", clearTimerStatic, this, &m_clearTimerFunction));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"setInterval", L"timers", setIntervalStatic, this, &m_setIntervalFunction));
+    RETURN_IF_FALSE(
+        ScriptHostUtilities::ProjectFunction(L"setTimeout", L"timers", setTimeoutStatic, this, &m_setTimeoutFunction));
+    RETURN_IF_FALSE(
+        ScriptHostUtilities::ProjectFunction(L"clearTimer", L"timers", clearTimerStatic, this, &m_clearTimerFunction));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(
+        L"setInterval", L"timers", setIntervalStatic, this, &m_setIntervalFunction));
 
-	return true;
+    return true;
 }
 
-Timers::TimerDefinition::TimerDefinition(TimerType type, int duration)
-	: Type(type)
+Timers::TimerDefinition::TimerDefinition(TimerType type, int duration) : Type(type)
 {
-	Timer = make_unique<timer<int>>(duration, 0, nullptr, (type == TimerType::Timeout ? false : true));
-	
-	concurrency::task_completion_event<void> completionEvent;
-	InternalCallback = make_unique<call<int>>([completionEvent](int)
-	{
-		completionEvent.set();
-	});
+    Timer = make_unique<timer<int>>(duration, 0, nullptr, (type == TimerType::Timeout ? false : true));
 
-	// Connect the timer to the callback and start the timer.
-	Timer->link_target(InternalCallback.get());
-	Timer->start();
-	Continuation = make_unique<task<void>>(completionEvent);
-	
-	ID = 0;
+    concurrency::task_completion_event<void> completionEvent;
+    InternalCallback = make_unique<call<int>>([completionEvent](int) { completionEvent.set(); });
+
+    // Connect the timer to the callback and start the timer.
+    Timer->link_target(InternalCallback.get());
+    Timer->start();
+    Continuation = make_unique<task<void>>(completionEvent);
+
+    ID = 0;
 }
 
-void
-Timers::TimerDefinition::Continue()
+void Timers::TimerDefinition::Continue()
 {
-	// Create a new completion event;
-	// For a periodic timer, Continue must be called every interval otherwise the task_completion_event won't
-	// fire again
-	concurrency::task_completion_event<void> completionEvent;
-	InternalCallback = make_unique<call<int>>([completionEvent](int)
-	{
-		completionEvent.set();
-	});
+    // Create a new completion event;
+    // For a periodic timer, Continue must be called every interval otherwise the task_completion_event won't
+    // fire again
+    concurrency::task_completion_event<void> completionEvent;
+    InternalCallback = make_unique<call<int>>([completionEvent](int) { completionEvent.set(); });
 
-	// Connect the timer to the callback and start the timer.
-	Timer->link_target(InternalCallback.get());
-	Continuation = make_unique<task<void>>(completionEvent);
-	Continuation->then(NativeCallback, concurrency::task_continuation_context::use_current());
+    // Connect the timer to the callback and start the timer.
+    Timer->link_target(InternalCallback.get());
+    Continuation = make_unique<task<void>>(completionEvent);
+    Continuation->then(NativeCallback, concurrency::task_continuation_context::use_current());
 }
 
-bool
-Timers::TimerDefinition::CaptureScriptResources(JsValueRef scriptCallback, const std::vector<JsValueRef>& scriptCallbackParameters)
+bool Timers::TimerDefinition::CaptureScriptResources(JsValueRef scriptCallback,
+                                                     const std::vector<JsValueRef>& scriptCallbackParameters)
 {
-	ScriptCallback = scriptCallback;
-	ScriptCallbackParameters = scriptCallbackParameters;
+    ScriptCallback = scriptCallback;
+    ScriptCallbackParameters = scriptCallbackParameters;
 
-	// Increase the ref count to prevent garbage collection before the timer fires
-	unsigned int refCount;
-	RETURN_IF_JS_ERROR(JsAddRef(ScriptCallback, &refCount));
+    // Increase the ref count to prevent garbage collection before the timer fires
+    unsigned int refCount;
+    RETURN_IF_JS_ERROR(JsAddRef(ScriptCallback, &refCount));
 
-	for (auto& parameter : ScriptCallbackParameters)
-	{
-		RETURN_IF_JS_ERROR(JsAddRef(parameter, &refCount));
-	}
+    for (auto& parameter : ScriptCallbackParameters) {
+        RETURN_IF_JS_ERROR(JsAddRef(parameter, &refCount));
+    }
 
-	return true;
+    return true;
 }
 
-bool
-Timers::TimerDefinition::ReleaseScriptResources()
+bool Timers::TimerDefinition::ReleaseScriptResources()
 {
-	// Release JS resources
-	unsigned int refCount;
+    // Release JS resources
+    unsigned int refCount;
 
-	if (ScriptCallback != JS_INVALID_REFERENCE)
-	{
-		RETURN_IF_JS_ERROR(JsRelease(ScriptCallback, &refCount));
-	}
-	
-	for (const auto& parameter : ScriptCallbackParameters)
-	{
-		RETURN_IF_JS_ERROR(JsRelease(parameter, &refCount));
-	}
+    if (ScriptCallback != JS_INVALID_REFERENCE) {
+        RETURN_IF_JS_ERROR(JsRelease(ScriptCallback, &refCount));
+    }
 
-	return true;
+    for (const auto& parameter : ScriptCallbackParameters) {
+        RETURN_IF_JS_ERROR(JsRelease(parameter, &refCount));
+    }
+
+    return true;
 }
 
-bool
-Timers::TimerDefinition::InvokeScriptCallback()
+bool Timers::TimerDefinition::InvokeScriptCallback()
 {
-	// Call the script
-	
-	RETURN_IF_TRUE(ScriptCallback == JS_INVALID_REFERENCE);
+    // Call the script
 
-	JsValueRef result;
-	RETURN_ON_SCRIPT_ERROR(
-		JsCallFunction(
-			ScriptCallback,
-			ScriptCallbackParameters.data(),
-			static_cast<unsigned short>(ScriptCallbackParameters.size()),
-			&result));
+    RETURN_IF_TRUE(ScriptCallback == JS_INVALID_REFERENCE);
 
-	return true;
+    JsValueRef result;
+    RETURN_ON_SCRIPT_ERROR(JsCallFunction(ScriptCallback,
+                                          ScriptCallbackParameters.data(),
+                                          static_cast<unsigned short>(ScriptCallbackParameters.size()),
+                                          &result));
+
+    return true;
 }
 
-JsValueRef
-Timers::ClearTimer(
-	JsValueRef callee,
-	JsValueRef* arguments,
-	unsigned short argumentCount
-)
+JsValueRef Timers::ClearTimer(JsValueRef callee, JsValueRef* arguments, unsigned short argumentCount)
 {
-	RETURN_INVALID_REF_IF_TRUE(argumentCount < 2);
+    RETURN_INVALID_REF_IF_TRUE(argumentCount < 2);
 
-	int timerId;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsNumberToInt(arguments[1], &timerId));
+    int timerId;
+    RETURN_INVALID_REF_IF_JS_ERROR(JsNumberToInt(arguments[1], &timerId));
 
-	shared_ptr<TimerDefinition> timer = ProcessTimersList(ListOperationType::Remove, timerId);
-	if (!timer)
-	{
-		// The timeout must have fired already; return
-		return JS_INVALID_REFERENCE;
-	}
+    shared_ptr<TimerDefinition> timer = ProcessTimersList(ListOperationType::Remove, timerId);
+    if (!timer) {
+        // The timeout must have fired already; return
+        return JS_INVALID_REFERENCE;
+    }
 
-	timer->Stop();
+    timer->Stop();
 
-	return JS_INVALID_REFERENCE;
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-Timers::CreateTimer(
-	TimerType type,
-	JsValueRef callee,
-	JsValueRef* arguments,
-	unsigned short argumentCount
-)
+JsValueRef Timers::CreateTimer(TimerType type, JsValueRef callee, JsValueRef* arguments, unsigned short argumentCount)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount >= 3);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount >= 3);
 
-	int timeoutValue;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsNumberToInt(arguments[2], &timeoutValue));
+    int timeoutValue;
+    RETURN_INVALID_REF_IF_JS_ERROR(JsNumberToInt(arguments[2], &timeoutValue));
 
-	// Capture the parameters intended for the callback function;
-	const JsValueRef scriptCallback = arguments[1];
-	vector<JsValueRef> capturedParameters(argumentCount - 2);
-	capturedParameters[0] = callee;
-	for (int i = 3; i < argumentCount; i++)
-	{
-		capturedParameters[i - 2] = arguments[i];
-	}
+    // Capture the parameters intended for the callback function;
+    const JsValueRef scriptCallback = arguments[1];
+    vector<JsValueRef> capturedParameters(argumentCount - 2);
+    capturedParameters[0] = callee;
+    for (int i = 3; i < argumentCount; i++) {
+        capturedParameters[i - 2] = arguments[i];
+    }
 
-	shared_ptr<TimerDefinition> timer = make_shared<TimerDefinition>(type, timeoutValue);
+    shared_ptr<TimerDefinition> timer = make_shared<TimerDefinition>(type, timeoutValue);
 
-	// Declare the script code to execute when the timer fires and what parameters to pass to it
-	RETURN_INVALID_REF_IF_FALSE(timer->CaptureScriptResources(scriptCallback, capturedParameters));
+    // Declare the script code to execute when the timer fires and what parameters to pass to it
+    RETURN_INVALID_REF_IF_FALSE(timer->CaptureScriptResources(scriptCallback, capturedParameters));
 
-	const int id = InsertInTimersList(timer);
+    const int id = InsertInTimersList(timer);
 
-	// Declare the native code to be executed when the timer fires
-	timer->SetNativeCallback([this, id]()
-	{
-		shared_ptr<TimerDefinition> timer = ProcessTimersList(ListOperationType::ProcessTick, id);
-		if (!timer)
-		{
-			// The timer must have been cleared; return
-			return;
-		}
+    // Declare the native code to be executed when the timer fires
+    timer->SetNativeCallback([this, id]() {
+        shared_ptr<TimerDefinition> timer = ProcessTimersList(ListOperationType::ProcessTick, id);
+        if (!timer) {
+            // The timer must have been cleared; return
+            return;
+        }
 
-		// Call the script
-		timer->InvokeScriptCallback();
+        // Call the script
+        timer->InvokeScriptCallback();
 
-		if (timer->GetType() == TimerType::Interval)
-		{
-			timer->Continue();
-		}
-	});
+        if (timer->GetType() == TimerType::Interval) {
+            timer->Continue();
+        }
+    });
 
-	JsValueRef retValue;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(timer->ID, &retValue));
-	return retValue;
+    JsValueRef retValue;
+    RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(timer->ID, &retValue));
+    return retValue;
 }
 
-shared_ptr<Timers::TimerDefinition>
-Timers::ProcessTimersList(ListOperationType operationType, int id)
+shared_ptr<Timers::TimerDefinition> Timers::ProcessTimersList(ListOperationType operationType, int id)
 {
-	shared_ptr<TimerDefinition> timer;
-	
-	// Lock the list of timers
-	std::lock_guard<std::mutex> guard(m_timersLock);
+    shared_ptr<TimerDefinition> timer;
 
-	// Lookup timer in list;
-	for (auto& timeoutInstance : m_timers)
-	{
-		if (id == timeoutInstance->ID)
-		{
-			// Found it
-			timer = timeoutInstance;
+    // Lock the list of timers
+    std::lock_guard<std::mutex> guard(m_timersLock);
 
-			if ((operationType == ListOperationType::ProcessTick && timer->GetType() == TimerType::Timeout)
-				|| operationType == ListOperationType::Remove)
-			{
-				m_timers.remove(timer);
-			}
+    // Lookup timer in list;
+    for (auto& timeoutInstance : m_timers) {
+        if (id == timeoutInstance->ID) {
+            // Found it
+            timer = timeoutInstance;
 
-			break;
-		}
-	}
+            if ((operationType == ListOperationType::ProcessTick && timer->GetType() == TimerType::Timeout) ||
+                operationType == ListOperationType::Remove) {
+                m_timers.remove(timer);
+            }
 
-	return timer;
+            break;
+        }
+    }
+
+    return timer;
 }
 
-int
-Timers::InsertInTimersList(std::shared_ptr<TimerDefinition> timer)
+int Timers::InsertInTimersList(std::shared_ptr<TimerDefinition> timer)
 {
-	std::lock_guard<std::mutex> guard(m_timersLock);
+    std::lock_guard<std::mutex> guard(m_timersLock);
 
-	timer->ID = 0;
+    timer->ID = 0;
 
-	// Determine a unique ID: largest ID + 1
-	for (const auto& timerInstance : m_timers)
-	{
-		if (timer->ID <= timerInstance->ID)
-		{
-			timer->ID = timerInstance->ID + 1;
-		}
-	}
-	
-	m_timers.push_back(timer);
+    // Determine a unique ID: largest ID + 1
+    for (const auto& timerInstance : m_timers) {
+        if (timer->ID <= timerInstance->ID) {
+            timer->ID = timerInstance->ID + 1;
+        }
+    }
 
-	return timer->ID;
+    m_timers.push_back(timer);
+
+    return timer->ID;
 }
-

--- a/HoloJS/HoloJsHost/VideoElement.h
+++ b/HoloJS/HoloJsHost/VideoElement.h
@@ -1,101 +1,91 @@
 #pragma once
 
-namespace HologramJS
-{
-	namespace API
-	{
-		class VideoElement : public HologramJS::Utilities::ElementWithEvents, public HologramJS::Utilities::IRelease
-		{
-		public:
-			VideoElement() {}
+#include "ChakraForHoloJS.h"
+#include "IRelease.h"
+#include "ObjectEvents.h"
 
-			virtual ~VideoElement()
-			{
-				Release();
-			}
+namespace HologramJS {
+namespace API {
+class VideoElement : public HologramJS::Utilities::ElementWithEvents, public HologramJS::Utilities::IRelease {
+   public:
+    VideoElement() {}
 
-			virtual void Release()
-			{
-				UnlockFrame();
-				m_stopStreamingRequested = true;
-				while (m_isStreaming)
-				{
-					Sleep(100);
-				}
-			}
+    virtual ~VideoElement() { Release(); }
 
-			static bool Initialize();
+    virtual void Release()
+    {
+        UnlockFrame();
+        m_stopStreamingRequested = true;
+        while (m_isStreaming) {
+            Sleep(100);
+        }
+    }
 
-			static bool UseFileSystem;
-			static std::wstring BaseUrl;
-			static std::wstring BasePath;
+    static bool Initialize();
 
-			int Width() { return m_width; }
-			int Height() { return m_height; }
+    static bool UseFileSystem;
+    static std::wstring BaseUrl;
+    static std::wstring BasePath;
 
-            bool IsNewFrameAvailable() { return m_newFrameAvailable; };
-			bool LockNextFrame(void** frameData, unsigned int* frameDataLength);
-			bool UnlockFrame();
+    int Width() { return m_width; }
+    int Height() { return m_height; }
 
-		private:
+    bool IsNewFrameAvailable() { return m_newFrameAvailable; };
+    bool LockNextFrame(void** frameData, unsigned int* frameDataLength);
+    bool UnlockFrame();
 
-			std::wstring m_source;
+   private:
+    std::wstring m_source;
 
-			concurrency::task<bool> LoadAsync();
-			bool ConfigureVideoReader();
-			bool StreamAndDecode();
-			bool m_isStreaming;
-			bool m_stopStreamingRequested = false;
+    concurrency::task<bool> LoadAsync();
+    bool ConfigureVideoReader();
+    bool StreamAndDecode();
+    bool m_isStreaming;
+    bool m_stopStreamingRequested = false;
 
-			void FireOnLoadEvent();
+    void FireOnLoadEvent();
 
-			unsigned int m_width;
-			unsigned int m_height;
+    unsigned int m_width;
+    unsigned int m_height;
 
-			static JsValueRef m_createVideoFunction;
-			static JsValueRef CHAKRA_CALLBACK createVideo(
-				_In_ JsValueRef callee,
-				_In_ bool isConstructCall,
-				_In_ JsValueRef *arguments,
-				_In_ unsigned short argumentCount,
-				_In_ PVOID callbackData
-			);
+    static JsValueRef m_createVideoFunction;
+    static JsValueRef CHAKRA_CALLBACK createVideo(_In_ JsValueRef callee,
+                                                  _In_ bool isConstructCall,
+                                                  _In_ JsValueRef* arguments,
+                                                  _In_ unsigned short argumentCount,
+                                                  _In_ PVOID callbackData);
 
-			static JsValueRef m_setVideoSourceFunction;
-			static JsValueRef CHAKRA_CALLBACK setVideoSource(
-				_In_ JsValueRef callee,
-				_In_ bool isConstructCall,
-				_In_ JsValueRef *arguments,
-				_In_ unsigned short argumentCount,
-				_In_ PVOID callbackData
-			);
+    static JsValueRef m_setVideoSourceFunction;
+    static JsValueRef CHAKRA_CALLBACK setVideoSource(_In_ JsValueRef callee,
+                                                     _In_ bool isConstructCall,
+                                                     _In_ JsValueRef* arguments,
+                                                     _In_ unsigned short argumentCount,
+                                                     _In_ PVOID callbackData);
 
-			bool ConfigureDecoder(IMFSourceReader* reader);
+    bool ConfigureDecoder(IMFSourceReader* reader);
 
-			Microsoft::WRL::ComPtr<IMFSourceReader> m_videoReader;
-			Microsoft::WRL::ComPtr<IMFSample> m_frontSample;
-			Microsoft::WRL::ComPtr<IMFSample> m_backSample;
-			Microsoft::WRL::ComPtr<IMFMediaBuffer> m_backMediaBuffer;
-            Microsoft::WRL::ComPtr<IMFMediaBuffer> m_frontMediaBuffer;
+    Microsoft::WRL::ComPtr<IMFSourceReader> m_videoReader;
+    Microsoft::WRL::ComPtr<IMFSample> m_frontSample;
+    Microsoft::WRL::ComPtr<IMFSample> m_backSample;
+    Microsoft::WRL::ComPtr<IMFMediaBuffer> m_backMediaBuffer;
+    Microsoft::WRL::ComPtr<IMFMediaBuffer> m_frontMediaBuffer;
 
-			std::mutex m_frameBufferLock;
-			bool m_newFrameAvailable = false;
+    std::mutex m_frameBufferLock;
+    bool m_newFrameAvailable = false;
 
-            bool InitializeHardwareDecoding();
+    bool InitializeHardwareDecoding();
 
-            Microsoft::WRL::ComPtr<ID3D11Device> m_device;
-            Microsoft::WRL::ComPtr<ID3D11DeviceContext> m_deviceContext;
-            Microsoft::WRL::ComPtr<IMFDXGIDeviceManager> m_dxgiManager;
-            UINT m_dxgiManagerResetToken;
+    Microsoft::WRL::ComPtr<ID3D11Device> m_device;
+    Microsoft::WRL::ComPtr<ID3D11DeviceContext> m_deviceContext;
+    Microsoft::WRL::ComPtr<IMFDXGIDeviceManager> m_dxgiManager;
+    UINT m_dxgiManagerResetToken;
 
-            byte* m_frontBufferMemory = nullptr;
-            byte* m_backBufferMemory = nullptr;
-            DWORD m_frontBufferMemorySize = 0;
-            DWORD m_backBufferMemorySize = 0;
+    byte* m_frontBufferMemory = nullptr;
+    byte* m_backBufferMemory = nullptr;
+    DWORD m_frontBufferMemorySize = 0;
+    DWORD m_backBufferMemorySize = 0;
 
-            void SwapBuffers();
-		};
-	}
-}
-
-
+    void SwapBuffers();
+};
+}  // namespace API
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/WebGLObjects.cpp
+++ b/HoloJS/HoloJsHost/WebGLObjects.cpp
@@ -1,7 +1,6 @@
 #include "pch.h"
 #include "WebGLObjects.h"
 
-
 using namespace HologramJS::WebGL;
 using namespace std;
 using namespace Platform;
@@ -13,366 +12,228 @@ WebGLShaderPrecisionFormat::WebGLShaderPrecisionFormat(GLint min, GLint max, GLi
     this->rangeMin = min;
 }
 
-void
-WebGLShaderPrecisionFormat::Release()
-{
+void WebGLShaderPrecisionFormat::Release() {}
 
+WebGLTexture::WebGLTexture() { glGenTextures(1, &id); }
+
+void WebGLTexture::Release() { glDeleteTextures(1, &id); }
+
+void WebGLTexture::framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, GLint level)
+{
+    glFramebufferTexture2D(target, attachment, textarget, this->id, level);
 }
 
-WebGLTexture::WebGLTexture()
+void WebGLTexture::Bind(GLenum target) { glBindTexture(target, id); }
+
+WebGLBuffer::WebGLBuffer() { glGenBuffers(1, &id); }
+
+void WebGLBuffer::Release() { glDeleteBuffers(1, &id); }
+
+void WebGLBuffer::Bind(GLenum target) { glBindBuffer(target, id); }
+
+WebGLProgram::WebGLProgram() { id = glCreateProgram(); }
+
+void WebGLProgram::Release() { glDeleteProgram(id); }
+
+void WebGLProgram::AttachShader(WebGLShader* shader) { glAttachShader(id, shader->id); }
+
+void WebGLProgram::BindAttribLocation(GLuint index, PCSTR name) { glBindAttribLocation(id, index, name); }
+
+void WebGLProgram::Link() { glLinkProgram(id); }
+
+JsValueRef WebGLProgram::GetParameter(GLenum pname)
 {
-    glGenTextures(1, &id);
+    if (pname == GL_DELETE_STATUS || pname == GL_LINK_STATUS || pname == GL_VALIDATE_STATUS) {
+        GLint retValue;
+        glGetProgramiv(id, pname, &retValue);
+
+        JsValueRef retJsValue;
+        RETURN_NULL_IF_JS_ERROR(JsBoolToBoolean(retValue == 0 ? GL_FALSE : GL_TRUE, &retJsValue));
+        return retJsValue;
+    } else if (pname == GL_ATTACHED_SHADERS || pname == GL_ACTIVE_ATTRIBUTES || pname == GL_ACTIVE_UNIFORMS) {
+        GLint retValue;
+        glGetProgramiv(id, pname, &retValue);
+
+        JsValueRef retJsValue;
+        RETURN_NULL_IF_JS_ERROR(JsIntToNumber(retValue, &retJsValue));
+        return retJsValue;
+    } else {
+        return nullptr;
+    }
 }
 
-void
-WebGLTexture::Release()
+void WebGLProgram::Delete() { glDeleteProgram(id); }
+
+std::wstring WebGLProgram::GetInfoLog()
 {
-	glDeleteTextures(1, &id);
+    GLint logLength;
+    glGetProgramiv(id, GL_INFO_LOG_LENGTH, &logLength);
+    if (logLength == 0) {
+        return L"";
+    } else {
+        vector<char> logBuffer(logLength);
+        GLint actualLength = 0;
+        glGetProgramInfoLog(id, logLength, &actualLength, logBuffer.data());
+        wstring logUnicode(logBuffer.begin(), logBuffer.end());
+        return logUnicode;
+    }
 }
 
-void
-WebGLTexture::framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, GLint level)
+WebGLActiveInfo* WebGLProgram::GetActiveUniform(GLuint index)
 {
-	glFramebufferTexture2D(target, attachment, textarget, this->id, level);
+    WebGLActiveInfo* retValue = new WebGLActiveInfo();
+
+    GLint nameLength;
+    glGetProgramiv(id, GL_ACTIVE_UNIFORM_MAX_LENGTH, &nameLength);
+
+    if (nameLength > 0) {
+        vector<GLchar> nameBufferAscii(nameLength);
+        GLsizei nameLengthActual = 0;
+        GLint size;
+        GLenum type;
+        glGetActiveUniform(id, index, nameLength, &nameLengthActual, &size, &type, nameBufferAscii.data());
+
+        wstring nameUnicode(nameBufferAscii.begin(), nameBufferAscii.end());
+        retValue->name = std::move(nameUnicode);
+        retValue->size = size;
+        retValue->type = type;
+    }
+
+    return retValue;
 }
 
-void
-WebGLTexture::Bind(GLenum target)
+WebGLUniformLocation* WebGLProgram::GetUniformLocation(PCSTR name)
 {
-	glBindTexture(target, id);
+    const auto location = glGetUniformLocation(id, name);
+
+    if (location == -1) {
+        return nullptr;
+    } else {
+        WebGLUniformLocation* retValue = new WebGLUniformLocation();
+        retValue->location = location;
+        return retValue;
+    }
 }
 
-WebGLBuffer::WebGLBuffer()
+WebGLActiveInfo* WebGLProgram::GetActiveAttrib(GLuint index)
 {
-	glGenBuffers(1, &id);
+    WebGLActiveInfo* retValue = new WebGLActiveInfo();
+
+    GLint nameLength;
+    glGetProgramiv(id, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, &nameLength);
+
+    if (nameLength > 0) {
+        vector<GLchar> nameBufferAscii(nameLength);
+        GLsizei nameLengthActual = 0;
+        GLint size;
+        GLenum type;
+        glGetActiveAttrib(id, index, nameLength, &nameLengthActual, &size, &type, nameBufferAscii.data());
+
+        wstring nameUnicode(nameBufferAscii.begin(), nameBufferAscii.end());
+        retValue->name = std::move(nameUnicode);
+        retValue->size = size;
+        retValue->type = type;
+    }
+
+    return retValue;
 }
 
-void
-WebGLBuffer::Release()
-{
-	glDeleteBuffers(1, &id);
-}
+void WebGLProgram::Validate() { glValidateProgram(id); }
 
-void
-WebGLBuffer::Bind(GLenum target)
-{
-	glBindBuffer(target, id);
-}
+void WebGLProgram::Use() { glUseProgram(id); }
 
-WebGLProgram::WebGLProgram()
-{
-	id = glCreateProgram();
-}
-
-void
-WebGLProgram::Release()
-{
-	glDeleteProgram(id);
-}
-
-void
-WebGLProgram::AttachShader(WebGLShader* shader)
-{
-	glAttachShader(id, shader->id);
-}
-
-void
-WebGLProgram::BindAttribLocation(GLuint index, PCSTR name)
-{
-	glBindAttribLocation(id, index, name);
-}
-
-void
-WebGLProgram::Link()
-{
-	glLinkProgram(id);
-}
-
-JsValueRef
-WebGLProgram::GetParameter(GLenum pname)
-{
-	if (pname == GL_DELETE_STATUS || pname == GL_LINK_STATUS || pname == GL_VALIDATE_STATUS)
-	{
-		GLint retValue;
-		glGetProgramiv(id, pname, &retValue);
-
-		JsValueRef retJsValue;
-		RETURN_NULL_IF_JS_ERROR(JsBoolToBoolean(retValue == 0 ? GL_FALSE : GL_TRUE, &retJsValue));
-		return retJsValue;
-	}
-	else if (pname == GL_ATTACHED_SHADERS || pname == GL_ACTIVE_ATTRIBUTES || pname == GL_ACTIVE_UNIFORMS)
-	{
-		GLint retValue;
-		glGetProgramiv(id, pname, &retValue);
-
-		JsValueRef retJsValue;
-		RETURN_NULL_IF_JS_ERROR(JsIntToNumber(retValue, &retJsValue));
-		return retJsValue;
-	}
-	else
-	{
-		return nullptr;
-	}
-}
-
-void
-WebGLProgram::Delete()
-{
-	glDeleteProgram(id);
-}
-
-std::wstring
-WebGLProgram::GetInfoLog()
-{
-	GLint logLength;
-	glGetProgramiv(id, GL_INFO_LOG_LENGTH, &logLength);
-	if (logLength == 0)
-	{
-		return L"";
-	}
-	else
-	{
-		vector<char> logBuffer(logLength);
-		GLint actualLength = 0;
-		glGetProgramInfoLog(id, logLength, &actualLength, logBuffer.data());
-		wstring logUnicode(logBuffer.begin(), logBuffer.end());
-		return logUnicode;
-	}
-}
-
-WebGLActiveInfo*
-WebGLProgram::GetActiveUniform(GLuint index)
-{
-	WebGLActiveInfo* retValue = new WebGLActiveInfo();
-
-	GLint nameLength;
-	glGetProgramiv(id, GL_ACTIVE_UNIFORM_MAX_LENGTH, &nameLength);
-
-	if (nameLength > 0)
-	{
-		vector<GLchar> nameBufferAscii(nameLength);
-		GLsizei nameLengthActual = 0;
-		GLint size;
-		GLenum type;
-		glGetActiveUniform(id, index, nameLength, &nameLengthActual, &size, &type, nameBufferAscii.data());
-
-		wstring nameUnicode(nameBufferAscii.begin(), nameBufferAscii.end());
-		retValue->name = std::move(nameUnicode);
-		retValue->size = size;
-		retValue->type = type;
-	}
-
-	return retValue;
-}
-
-WebGLUniformLocation*
-WebGLProgram::GetUniformLocation(PCSTR name)
-{
-	const auto location = glGetUniformLocation(id, name);
-
-	if (location == -1)
-	{
-		return nullptr;
-	}
-	else
-	{
-		WebGLUniformLocation* retValue = new WebGLUniformLocation();
-		retValue->location = location;
-		return retValue;
-	}
-}
-
-WebGLActiveInfo*
-WebGLProgram::GetActiveAttrib(GLuint index)
-{
-	WebGLActiveInfo* retValue = new WebGLActiveInfo();
-
-	GLint nameLength;
-	glGetProgramiv(id, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, &nameLength);
-
-	if (nameLength > 0)
-	{
-		vector<GLchar> nameBufferAscii(nameLength);
-		GLsizei nameLengthActual = 0;
-		GLint size;
-		GLenum type;
-		glGetActiveAttrib(id, index, nameLength, &nameLengthActual, &size, &type, nameBufferAscii.data());
-
-		wstring nameUnicode(nameBufferAscii.begin(), nameBufferAscii.end());
-		retValue->name = std::move(nameUnicode);
-		retValue->size = size;
-		retValue->type = type;
-	}
-
-	return retValue;
-}
-
-void
-WebGLProgram::Validate()
-{
-	glValidateProgram(id);
-}
-
-void
-WebGLProgram::Use()
-{
-	glUseProgram(id);
-}
-
-GLint
-WebGLProgram::GetAttribLocation(PCSTR name)
-{
-	return glGetAttribLocation(id, name);
-}
+GLint WebGLProgram::GetAttribLocation(PCSTR name) { return glGetAttribLocation(id, name); }
 
 WebGLShader::WebGLShader(GLenum type)
 {
-	this->type = type;
-	id = glCreateShader(type);
+    this->type = type;
+    id = glCreateShader(type);
 }
 
-void
-WebGLShader::Release()
+void WebGLShader::Release() { glDeleteShader(id); }
+
+void WebGLShader::SetSource(PCSTR source)
 {
-	glDeleteShader(id);
+    PCSTR sourceArray[] = {source};
+    int lengthArray[] = {static_cast<int>(strlen(source))};
+    glShaderSource(id, 1, sourceArray, lengthArray);
 }
 
-void
-WebGLShader::SetSource(PCSTR source)
+void WebGLShader::Compile() { glCompileShader(id); }
+
+JsValueRef WebGLShader::GetParameter(GLenum pname)
 {
-	PCSTR sourceArray[] = { source };
-	int lengthArray[] = { static_cast<int>(strlen(source)) };
-	glShaderSource(id, 1, sourceArray, lengthArray);
+    if (pname == GL_DELETE_STATUS || pname == GL_COMPILE_STATUS) {
+        GLint retValue;
+        glGetShaderiv(id, pname, &retValue);
+
+        JsValueRef retJsValue;
+        RETURN_NULL_IF_JS_ERROR(JsBoolToBoolean(retValue == 0 ? GL_FALSE : GL_TRUE, &retJsValue));
+        return retJsValue;
+    } else if (pname == GL_SHADER_TYPE) {
+        GLint retValue;
+        glGetShaderiv(id, pname, &retValue);
+
+        JsValueRef retJsValue;
+        RETURN_NULL_IF_JS_ERROR(JsIntToNumber(retValue, &retJsValue));
+        return retJsValue;
+    } else {
+        return nullptr;
+    }
 }
 
-void
-WebGLShader::Compile()
+std::wstring WebGLShader::GetInfoLog()
 {
-	glCompileShader(id);
+    GLint logLength;
+    glGetShaderiv(id, GL_INFO_LOG_LENGTH, &logLength);
+    if (logLength == 0) {
+        return L"";
+    } else {
+        vector<char> logBuffer(logLength);
+        GLint actualLength = 0;
+        glGetShaderInfoLog(id, logLength, &actualLength, logBuffer.data());
+        wstring logUnicode(logBuffer.begin(), logBuffer.end());
+        return logUnicode;
+    }
 }
 
-JsValueRef
-WebGLShader::GetParameter(GLenum pname)
-{
-	if (pname == GL_DELETE_STATUS || pname == GL_COMPILE_STATUS)
-	{
-		GLint retValue;
-		glGetShaderiv(id, pname, &retValue);
+void WebGLShader::Delete() { glDeleteShader(id); }
 
-		JsValueRef retJsValue;
-		RETURN_NULL_IF_JS_ERROR(JsBoolToBoolean(retValue == 0 ? GL_FALSE : GL_TRUE, &retJsValue));
-		return retJsValue;
-	}
-	else if (pname == GL_SHADER_TYPE)
-	{
-		GLint retValue;
-		glGetShaderiv(id, pname, &retValue);
-		
-		JsValueRef retJsValue;
-		RETURN_NULL_IF_JS_ERROR(JsIntToNumber(retValue, &retJsValue));
-		return retJsValue;
-	}
-	else
-	{
-		return nullptr;
-	}
-}
+WebGLActiveInfo::WebGLActiveInfo() {}
 
-std::wstring
-WebGLShader::GetInfoLog()
-{
-	GLint logLength;
-	glGetShaderiv(id, GL_INFO_LOG_LENGTH, &logLength);
-	if (logLength == 0)
-	{
-		return L"";
-	}
-	else
-	{
-		vector<char> logBuffer(logLength);
-		GLint actualLength = 0;
-		glGetShaderInfoLog(id, logLength, &actualLength, logBuffer.data());
-		wstring logUnicode(logBuffer.begin(), logBuffer.end());
-		return logUnicode;
-	}
-}
+WebGLUniformLocation::WebGLUniformLocation() {}
 
-void
-WebGLShader::Delete()
-{
-	glDeleteShader(id);
-}
+ANGLE_instanced_arrays::ANGLE_instanced_arrays() {}
 
-WebGLActiveInfo::WebGLActiveInfo()
-{
-
-}
-
-WebGLUniformLocation::WebGLUniformLocation()
-{
-
-}
-
-ANGLE_instanced_arrays::ANGLE_instanced_arrays()
-{
-
-}
-
-void
-ANGLE_instanced_arrays::drawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount)
+void ANGLE_instanced_arrays::drawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount)
 {
     glDrawArraysInstancedANGLE(mode, first, count, primcount);
 }
 
-void
-ANGLE_instanced_arrays::drawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLint indices, GLsizei primcount)
+void ANGLE_instanced_arrays::drawElementsInstancedANGLE(
+    GLenum mode, GLsizei count, GLenum type, GLint indices, GLsizei primcount)
 {
-    glDrawElementsInstancedANGLE(mode, count, type, (const void *)indices, primcount);
+    glDrawElementsInstancedANGLE(mode, count, type, (const void*)indices, primcount);
 }
 
-void
-ANGLE_instanced_arrays::vertexAttribDivisorANGLE(GLuint index, GLuint divisor)
+void ANGLE_instanced_arrays::vertexAttribDivisorANGLE(GLuint index, GLuint divisor)
 {
     glVertexAttribDivisorANGLE(index, divisor);
 }
 
-WebGLRenderbuffer::WebGLRenderbuffer()
+WebGLRenderbuffer::WebGLRenderbuffer() { glGenRenderbuffers(1, &id); }
+
+void WebGLRenderbuffer::Release() { glDeleteRenderbuffers(1, &id); }
+
+void WebGLRenderbuffer::bindRenderbuffer(GLenum target) { glBindRenderbuffer(target, this->id); }
+
+void WebGLRenderbuffer::framebufferRenderbuffer(GLenum target, GLenum attachment, GLenum renderbuffertarget)
 {
-	glGenRenderbuffers(1, &id);
+    glFramebufferRenderbuffer(target, attachment, renderbuffertarget, id);
 }
 
-void
-WebGLRenderbuffer::Release()
-{
-	glDeleteRenderbuffers(1, &id);
-}
+WebGLFramebuffer::WebGLFramebuffer() { glGenFramebuffers(1, &id); }
 
-void
-WebGLRenderbuffer::bindRenderbuffer(GLenum target)
-{
-	glBindRenderbuffer(target, this->id);
-}
+void WebGLFramebuffer::Release() { glDeleteFramebuffers(1, &id); }
 
-void
-WebGLRenderbuffer::framebufferRenderbuffer(GLenum target, GLenum attachment, GLenum renderbuffertarget)
-{
-	glFramebufferRenderbuffer(target, attachment, renderbuffertarget, id);
-}
-
-
-WebGLFramebuffer::WebGLFramebuffer()
-{
-	glGenFramebuffers(1, &id);
-}
-
-void
-WebGLFramebuffer::Release()
-{
-	glDeleteFramebuffers(1, &id);
-}
-
-void
-WebGLFramebuffer::bindFramebuffer(GLenum target)
-{
-	glBindFramebuffer(target, this->id);
-}
+void WebGLFramebuffer::bindFramebuffer(GLenum target) { glBindFramebuffer(target, this->id); }

--- a/HoloJS/HoloJsHost/WebGLObjects.h
+++ b/HoloJS/HoloJsHost/WebGLObjects.h
@@ -1,136 +1,127 @@
 #pragma once
 
-namespace HologramJS
-{
-	namespace WebGL
-	{
-		class WebGLShaderPrecisionFormat : public HologramJS::Utilities::IRelease
-		{
-		public:
-			GLint rangeMin;
-			GLint rangeMax;
-			GLint precision;
-			WebGLShaderPrecisionFormat(GLint min, GLint max, GLint precision);
+#include "IRelease.h"
+#include "ChakraForHoloJS.h"
 
-			virtual void Release();
+namespace HologramJS {
+namespace WebGL {
+class WebGLShaderPrecisionFormat : public HologramJS::Utilities::IRelease {
+   public:
+    GLint rangeMin;
+    GLint rangeMax;
+    GLint precision;
+    WebGLShaderPrecisionFormat(GLint min, GLint max, GLint precision);
 
-			virtual ~WebGLShaderPrecisionFormat() {}
-		};
+    virtual void Release();
 
-		class WebGLRenderbuffer : public HologramJS::Utilities::IRelease
-		{
-		public:
-			WebGLRenderbuffer();
-			virtual void Release();
-			virtual ~WebGLRenderbuffer() {}
-			void bindRenderbuffer(GLenum target);
-			void framebufferRenderbuffer(GLenum target, GLenum attachment, GLenum renderbuffertarget);
-			GLuint id;
-		};
+    virtual ~WebGLShaderPrecisionFormat() {}
+};
 
-		class WebGLFramebuffer : public HologramJS::Utilities::IRelease
-		{
-		public:
-			WebGLFramebuffer();
-			virtual void Release();
-			virtual ~WebGLFramebuffer() {}
-			void bindFramebuffer(GLenum target);
-			GLuint id;
-		};
+class WebGLRenderbuffer : public HologramJS::Utilities::IRelease {
+   public:
+    WebGLRenderbuffer();
+    virtual void Release();
+    virtual ~WebGLRenderbuffer() {}
+    void bindRenderbuffer(GLenum target);
+    void framebufferRenderbuffer(GLenum target, GLenum attachment, GLenum renderbuffertarget);
+    GLuint id;
+};
 
-		class WebGLTexture : public HologramJS::Utilities::IRelease
-		{
-		public:
-			WebGLTexture();
-			virtual void Release();
-			virtual ~WebGLTexture() {}
-			void framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, GLint level);
+class WebGLFramebuffer : public HologramJS::Utilities::IRelease {
+   public:
+    WebGLFramebuffer();
+    virtual void Release();
+    virtual ~WebGLFramebuffer() {}
+    void bindFramebuffer(GLenum target);
+    GLuint id;
+};
 
-			void Bind(GLenum target);
-			GLuint id;
-		};
+class WebGLTexture : public HologramJS::Utilities::IRelease {
+   public:
+    WebGLTexture();
+    virtual void Release();
+    virtual ~WebGLTexture() {}
+    void framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, GLint level);
 
-		class WebGLBuffer : public HologramJS::Utilities::IRelease
-		{
-		public:
-			WebGLBuffer();
-			virtual void Release();
-			virtual ~WebGLBuffer() {}
+    void Bind(GLenum target);
+    GLuint id;
+};
 
-			void Bind(GLenum target);
-			GLuint id;
-		};
+class WebGLBuffer : public HologramJS::Utilities::IRelease {
+   public:
+    WebGLBuffer();
+    virtual void Release();
+    virtual ~WebGLBuffer() {}
 
-		class WebGLShader : public HologramJS::Utilities::IRelease
-		{
-		public:
-			WebGLShader(GLenum type);
-			virtual void Release();
-			virtual ~WebGLShader() {}
+    void Bind(GLenum target);
+    GLuint id;
+};
 
-			void SetSource(PCSTR source);
-			void Compile();
-			JsValueRef GetParameter(GLenum pname);
-			std::wstring GetInfoLog();
-			void Delete();
+class WebGLShader : public HologramJS::Utilities::IRelease {
+   public:
+    WebGLShader(GLenum type);
+    virtual void Release();
+    virtual ~WebGLShader() {}
 
-			GLuint id;
-			GLenum type;
-		};
+    void SetSource(PCSTR source);
+    void Compile();
+    JsValueRef GetParameter(GLenum pname);
+    std::wstring GetInfoLog();
+    void Delete();
 
-		class WebGLActiveInfo : public HologramJS::Utilities::IRelease
-		{
-		public:
-			WebGLActiveInfo();
-			void Release() {}
-			virtual ~WebGLActiveInfo() {}
-			std::wstring name;
-			int size;
-			int type;
-		};
+    GLuint id;
+    GLenum type;
+};
 
-		class WebGLUniformLocation : public HologramJS::Utilities::IRelease
-		{
-		public:
-			WebGLUniformLocation();
-			void Release() {}
-			virtual ~WebGLUniformLocation() {}
-			int location;
-		};
+class WebGLActiveInfo : public HologramJS::Utilities::IRelease {
+   public:
+    WebGLActiveInfo();
+    void Release() {}
+    virtual ~WebGLActiveInfo() {}
+    std::wstring name;
+    int size;
+    int type;
+};
 
-		class WebGLProgram : public HologramJS::Utilities::IRelease
-		{
-		public:
-			WebGLProgram();
-			virtual void Release();
-			virtual ~WebGLProgram() {}
+class WebGLUniformLocation : public HologramJS::Utilities::IRelease {
+   public:
+    WebGLUniformLocation();
+    void Release() {}
+    virtual ~WebGLUniformLocation() {}
+    int location;
+};
 
-			void AttachShader(WebGLShader* shader);
-			void BindAttribLocation(GLuint index, PCSTR name);
-			void Link();
-			JsValueRef GetParameter(GLenum pname);
-			std::wstring GetInfoLog();
-			void Delete();
+class WebGLProgram : public HologramJS::Utilities::IRelease {
+   public:
+    WebGLProgram();
+    virtual void Release();
+    virtual ~WebGLProgram() {}
 
-			WebGLActiveInfo* GetActiveUniform(GLuint index);
-			WebGLUniformLocation* GetUniformLocation(PCSTR name);
+    void AttachShader(WebGLShader* shader);
+    void BindAttribLocation(GLuint index, PCSTR name);
+    void Link();
+    JsValueRef GetParameter(GLenum pname);
+    std::wstring GetInfoLog();
+    void Delete();
 
-			void Validate();
-			void Use();
+    WebGLActiveInfo* GetActiveUniform(GLuint index);
+    WebGLUniformLocation* GetUniformLocation(PCSTR name);
 
-			WebGLActiveInfo* GetActiveAttrib(GLuint index);
-			GLint GetAttribLocation(PCSTR name);
+    void Validate();
+    void Use();
 
-			GLuint id;
-		};
+    WebGLActiveInfo* GetActiveAttrib(GLuint index);
+    GLint GetAttribLocation(PCSTR name);
 
-		class ANGLE_instanced_arrays
-		{
-		public:
-			ANGLE_instanced_arrays();
-			void drawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);
-			void drawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLint indices, GLsizei primcount);
-			void vertexAttribDivisorANGLE(GLuint index, GLuint divisor);
-		};
-	}
-}
+    GLuint id;
+};
+
+class ANGLE_instanced_arrays {
+   public:
+    ANGLE_instanced_arrays();
+    void drawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);
+    void drawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLint indices, GLsizei primcount);
+    void vertexAttribDivisorANGLE(GLuint index, GLuint divisor);
+};
+}  // namespace WebGL
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/WebGLProjections.cpp
+++ b/HoloJS/HoloJsHost/WebGLProjections.cpp
@@ -1,590 +1,463 @@
 #include "pch.h"
-#include "VideoElement.h"
-#include "ImageElement.h"
-#include "WebGLObjects.h"
-#include "RenderingContext2D.h"
-#include "WebGLRenderingContext.h"
 #include "WebGLProjections.h"
+#include "ExternalObject.h"
+#include "ImageElement.h"
+#include "RenderingContext2D.h"
+#include "ScriptHostUtilities.h"
+#include "ScriptResourceTracker.h"
+#include "VideoElement.h"
+#include "WebGLObjects.h"
+#include "WebGLRenderingContext.h"
 
 using namespace HologramJS::WebGL;
 using namespace HologramJS::Utilities;
 using namespace HologramJS::API;
 
-bool
-WebGLProjections::Initialize()
+bool WebGLProjections::Initialize()
 {
-	// WebGL context projections
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createContext", L"webgl", createContext));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createContext2D", L"canvas2d", createContext2D));
-	
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getShaderPrecisionFormat", L"webgl", getShaderPrecisionFormat));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getExtension", L"webgl", getExtension));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getParameter", L"webgl", getParameter));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createRenderbuffer", L"webgl", createRenderbuffer));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"bindRenderbuffer", L"webgl", bindRenderbuffer));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"renderbufferStorage", L"webgl", renderbufferStorage));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createFramebuffer", L"webgl", createFramebuffer));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"bindFramebuffer", L"webgl", bindFramebuffer));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"framebufferRenderbuffer", L"webgl", framebufferRenderbuffer));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"framebufferTexture2D", L"webgl", framebufferTexture2D));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createTexture", L"webgl", createTexture));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"bindTexture", L"webgl", bindTexture));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"texParameteri", L"webgl", texParameteri));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"texImage2D1", L"webgl", texImage2D1));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"texImage2D2", L"webgl", texImage2D2));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"texImage2D3", L"webgl", texImage2D3));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"texImage2D4", L"webgl", texImage2D4));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"activeTexture", L"webgl", activeTexture));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"generateMipmap", L"webgl", generateMipmap));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"pixelStorei", L"webgl", pixelStorei));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"clearDepth", L"webgl", clearDepth));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"clearStencil", L"webgl", clearStencil));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"enable", L"webgl", enable));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"disable", L"webgl", disable));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"depthFunc", L"webgl", depthFunc));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"depthMask", L"webgl", depthMask));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"depthRange", L"webgl", depthRange));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"frontFace", L"webgl", frontFace));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"cullFace", L"webgl", cullFace));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"blendColor", L"webgl", blendColor));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"blendEquation", L"webgl", blendEquation));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"blendEquationSeparate", L"webgl", blendEquationSeparate));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"blendFunc", L"webgl", blendFunc));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"blendFuncSeparate", L"webgl", blendFuncSeparate));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"scissor", L"webgl", scissor));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"viewport", L"webgl", viewport));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"clearColor", L"webgl", clearColor));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"clear", L"webgl", clear));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createBuffer", L"webgl", createBuffer));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"deleteBuffer", L"webgl", deleteBuffer));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"bindBuffer", L"webgl", bindBuffer));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"bufferData1", L"webgl", bufferData1));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"bufferData2", L"webgl", bufferData2));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"colorMask", L"webgl", colorMask));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"drawArrays", L"webgl", drawArrays));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"drawElements", L"webgl", drawElements));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"enableVertexAttribArray", L"webgl", enableVertexAttribArray));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"disableVertexAttribArray", L"webgl", disableVertexAttribArray));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"vertexAttribPointer", L"webgl", vertexAttribPointer));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createProgram", L"webgl", createProgram));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"useProgram", L"webgl", useProgram));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"validateProgram", L"webgl", validateProgram));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"linkProgram", L"webgl", linkProgram));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getProgramParameter", L"webgl", getProgramParameter));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getProgramInfoLog", L"webgl", getProgramInfoLog));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"deleteProgram", L"webgl", deleteProgram));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"bindAttribLocation", L"webgl", bindAttribLocation));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getActiveUniform", L"webgl", getActiveUniform));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getActiveAttrib", L"webgl", getActiveAttrib));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getAttribLocation", L"webgl", getAttribLocation));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createShader", L"webgl", createShader));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"shaderSource", L"webgl", shaderSource));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"compileShader", L"webgl", compileShader));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getShaderParameter", L"webgl", getShaderParameter));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getShaderInfoLog", L"webgl", getShaderInfoLog));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"attachShader", L"webgl", attachShader));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"deleteShader", L"webgl", deleteShader));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getUniformLocation", L"webgl", getUniformLocation));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform1f", L"webgl", uniform1f));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform1fv", L"webgl", uniform1fv));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform1i", L"webgl", uniform1i));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform1iv", L"webgl", uniform1iv));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform2f", L"webgl", uniform2f));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform2fv", L"webgl", uniform2fv));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform2i", L"webgl", uniform2i));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform2iv", L"webgl", uniform2iv));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform3f", L"webgl", uniform3f));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform3fv", L"webgl", uniform3fv));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform3i", L"webgl", uniform3i));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform3iv", L"webgl", uniform3iv));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform4f", L"webgl", uniform4f));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform4fv", L"webgl", uniform4fv));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform4i", L"webgl", uniform4i));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform4iv", L"webgl", uniform4iv));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniformMatrix2fv", L"webgl", uniformMatrix2fv));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniformMatrix3fv", L"webgl", uniformMatrix3fv));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniformMatrix4fv", L"webgl", uniformMatrix4fv));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"stencilFunc", L"webgl", stencilFunc));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"stencilMask", L"webgl", stencilMask));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"stencilOp", L"webgl", stencilOp));
+    // WebGL context projections
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createContext", L"webgl", createContext));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createContext2D", L"canvas2d", createContext2D));
 
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"lineWidth", L"webgl", lineWidth));
+    RETURN_IF_FALSE(
+        ScriptHostUtilities::ProjectFunction(L"getShaderPrecisionFormat", L"webgl", getShaderPrecisionFormat));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getExtension", L"webgl", getExtension));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getParameter", L"webgl", getParameter));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createRenderbuffer", L"webgl", createRenderbuffer));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"bindRenderbuffer", L"webgl", bindRenderbuffer));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"renderbufferStorage", L"webgl", renderbufferStorage));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createFramebuffer", L"webgl", createFramebuffer));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"bindFramebuffer", L"webgl", bindFramebuffer));
+    RETURN_IF_FALSE(
+        ScriptHostUtilities::ProjectFunction(L"framebufferRenderbuffer", L"webgl", framebufferRenderbuffer));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"framebufferTexture2D", L"webgl", framebufferTexture2D));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createTexture", L"webgl", createTexture));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"bindTexture", L"webgl", bindTexture));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"texParameteri", L"webgl", texParameteri));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"texImage2D1", L"webgl", texImage2D1));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"texImage2D2", L"webgl", texImage2D2));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"texImage2D3", L"webgl", texImage2D3));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"texImage2D4", L"webgl", texImage2D4));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"activeTexture", L"webgl", activeTexture));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"generateMipmap", L"webgl", generateMipmap));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"pixelStorei", L"webgl", pixelStorei));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"clearDepth", L"webgl", clearDepth));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"clearStencil", L"webgl", clearStencil));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"enable", L"webgl", enable));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"disable", L"webgl", disable));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"depthFunc", L"webgl", depthFunc));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"depthMask", L"webgl", depthMask));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"depthRange", L"webgl", depthRange));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"frontFace", L"webgl", frontFace));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"cullFace", L"webgl", cullFace));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"blendColor", L"webgl", blendColor));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"blendEquation", L"webgl", blendEquation));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"blendEquationSeparate", L"webgl", blendEquationSeparate));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"blendFunc", L"webgl", blendFunc));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"blendFuncSeparate", L"webgl", blendFuncSeparate));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"scissor", L"webgl", scissor));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"viewport", L"webgl", viewport));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"clearColor", L"webgl", clearColor));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"clear", L"webgl", clear));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createBuffer", L"webgl", createBuffer));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"deleteBuffer", L"webgl", deleteBuffer));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"bindBuffer", L"webgl", bindBuffer));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"bufferData1", L"webgl", bufferData1));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"bufferData2", L"webgl", bufferData2));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"colorMask", L"webgl", colorMask));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"drawArrays", L"webgl", drawArrays));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"drawElements", L"webgl", drawElements));
+    RETURN_IF_FALSE(
+        ScriptHostUtilities::ProjectFunction(L"enableVertexAttribArray", L"webgl", enableVertexAttribArray));
+    RETURN_IF_FALSE(
+        ScriptHostUtilities::ProjectFunction(L"disableVertexAttribArray", L"webgl", disableVertexAttribArray));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"vertexAttribPointer", L"webgl", vertexAttribPointer));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createProgram", L"webgl", createProgram));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"useProgram", L"webgl", useProgram));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"validateProgram", L"webgl", validateProgram));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"linkProgram", L"webgl", linkProgram));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getProgramParameter", L"webgl", getProgramParameter));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getProgramInfoLog", L"webgl", getProgramInfoLog));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"deleteProgram", L"webgl", deleteProgram));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"bindAttribLocation", L"webgl", bindAttribLocation));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getActiveUniform", L"webgl", getActiveUniform));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getActiveAttrib", L"webgl", getActiveAttrib));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getAttribLocation", L"webgl", getAttribLocation));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"createShader", L"webgl", createShader));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"shaderSource", L"webgl", shaderSource));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"compileShader", L"webgl", compileShader));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getShaderParameter", L"webgl", getShaderParameter));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getShaderInfoLog", L"webgl", getShaderInfoLog));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"attachShader", L"webgl", attachShader));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"deleteShader", L"webgl", deleteShader));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getUniformLocation", L"webgl", getUniformLocation));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform1f", L"webgl", uniform1f));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform1fv", L"webgl", uniform1fv));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform1i", L"webgl", uniform1i));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform1iv", L"webgl", uniform1iv));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform2f", L"webgl", uniform2f));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform2fv", L"webgl", uniform2fv));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform2i", L"webgl", uniform2i));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform2iv", L"webgl", uniform2iv));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform3f", L"webgl", uniform3f));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform3fv", L"webgl", uniform3fv));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform3i", L"webgl", uniform3i));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform3iv", L"webgl", uniform3iv));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform4f", L"webgl", uniform4f));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform4fv", L"webgl", uniform4fv));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform4i", L"webgl", uniform4i));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniform4iv", L"webgl", uniform4iv));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniformMatrix2fv", L"webgl", uniformMatrix2fv));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniformMatrix3fv", L"webgl", uniformMatrix3fv));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"uniformMatrix4fv", L"webgl", uniformMatrix4fv));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"stencilFunc", L"webgl", stencilFunc));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"stencilMask", L"webgl", stencilMask));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"stencilOp", L"webgl", stencilOp));
 
-	// Canvas 2D context projections
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"drawImage1", L"canvas2d", drawImage1));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"drawImage2", L"canvas2d", drawImage2));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"drawImage3", L"canvas2d", drawImage3));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getImageData", L"canvas2d", getImageData));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"lineWidth", L"webgl", lineWidth));
 
-	return true;
+    // Canvas 2D context projections
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"drawImage1", L"canvas2d", drawImage1));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"drawImage2", L"canvas2d", drawImage2));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"drawImage3", L"canvas2d", drawImage3));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getImageData", L"canvas2d", getImageData));
+
+    return true;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::createContext(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::createContext(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	return ScriptResourceTracker::ObjectToDirectExternal(new WebGLRenderingContext());
+    return ScriptResourceTracker::ObjectToDirectExternal(new WebGLRenderingContext());
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::createContext2D(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::createContext2D(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	return ScriptResourceTracker::ObjectToDirectExternal(new RenderingContext2D());
+    return ScriptResourceTracker::ObjectToDirectExternal(new RenderingContext2D());
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::getShaderPrecisionFormat(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::getShaderPrecisionFormat(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum shadertype = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLenum precisiontype = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
-	auto precisionFormat = context->getShaderPrecisionFormat(shadertype, precisiontype);
+    GLenum shadertype = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLenum precisiontype = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
+    auto precisionFormat = context->getShaderPrecisionFormat(shadertype, precisiontype);
 
-	// Project object to script; note that the projected object is opaque to the script
-	auto returnObject = ScriptResourceTracker::ObjectToExternal(precisionFormat);
+    // Project object to script; note that the projected object is opaque to the script
+    auto returnObject = ScriptResourceTracker::ObjectToExternal(precisionFormat);
 
-	JsValueRef rangeMinValue;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(precisionFormat->rangeMin, &rangeMinValue));
+    JsValueRef rangeMinValue;
+    RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(precisionFormat->rangeMin, &rangeMinValue));
 
-	JsValueRef rangeMaxValue;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(precisionFormat->rangeMax, &rangeMaxValue));
+    JsValueRef rangeMaxValue;
+    RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(precisionFormat->rangeMax, &rangeMaxValue));
 
-	JsValueRef precisionValue;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(precisionFormat->precision, &precisionValue));
+    JsValueRef precisionValue;
+    RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(precisionFormat->precision, &precisionValue));
 
-	// Add properties as required for WebGLShaderPrecisionFormat
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"rangeMin", rangeMinValue));
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"rangeMax", rangeMaxValue));
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"precision", precisionValue));
+    // Add properties as required for WebGLShaderPrecisionFormat
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"rangeMin", rangeMinValue));
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"rangeMax", rangeMaxValue));
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"precision", precisionValue));
 
-	return returnObject;
+    return returnObject;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::getExtension(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::getExtension(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	std::wstring name;
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[2], name));
-	return JS_INVALID_REFERENCE;
+    std::wstring name;
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[2], name));
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::getParameter(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::getParameter(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum pname = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	return context->getParameter(pname);
+    GLenum pname = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    return context->getParameter(pname);
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::createRenderbuffer(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::createRenderbuffer(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	auto returnObject = context->createRenderbuffer();
-	return ScriptResourceTracker::ObjectToExternal(returnObject);
+    auto returnObject = context->createRenderbuffer();
+    return ScriptResourceTracker::ObjectToExternal(returnObject);
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::bindRenderbuffer(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::bindRenderbuffer(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	WebGLRenderbuffer* renderbuffer = ScriptResourceTracker::ExternalToObject<WebGLRenderbuffer>(arguments[3]);
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    WebGLRenderbuffer* renderbuffer = ScriptResourceTracker::ExternalToObject<WebGLRenderbuffer>(arguments[3]);
 
-	context->bindRenderbuffer(target, renderbuffer);
-	return JS_INVALID_REFERENCE;
+    context->bindRenderbuffer(target, renderbuffer);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::renderbufferStorage(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::renderbufferStorage(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLenum internalformat = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
-	GLsizei width = ScriptHostUtilities::GLsizeiFromJsRef(arguments[4]);
-	GLsizei height = ScriptHostUtilities::GLsizeiFromJsRef(arguments[5]);
-	context->renderbufferStorage(target, internalformat, width, height);
-	return JS_INVALID_REFERENCE;
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLenum internalformat = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
+    GLsizei width = ScriptHostUtilities::GLsizeiFromJsRef(arguments[4]);
+    GLsizei height = ScriptHostUtilities::GLsizeiFromJsRef(arguments[5]);
+    context->renderbufferStorage(target, internalformat, width, height);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::createFramebuffer(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::createFramebuffer(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	auto returnObject = context->createFramebuffer();
-	return ScriptResourceTracker::ObjectToExternal(returnObject);
+    auto returnObject = context->createFramebuffer();
+    return ScriptResourceTracker::ObjectToExternal(returnObject);
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::bindFramebuffer(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::bindFramebuffer(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	WebGLFramebuffer* framebuffer = ScriptResourceTracker::ExternalToObject<WebGLFramebuffer>(arguments[3]);
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    WebGLFramebuffer* framebuffer = ScriptResourceTracker::ExternalToObject<WebGLFramebuffer>(arguments[3]);
 
-	context->bindFramebuffer(target, framebuffer);
-	return JS_INVALID_REFERENCE;
+    context->bindFramebuffer(target, framebuffer);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::framebufferRenderbuffer(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::framebufferRenderbuffer(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLenum attachment = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
-	GLenum renderbuffertarget = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
-	WebGLRenderbuffer* renderbuffer = ScriptResourceTracker::ExternalToObject<WebGLRenderbuffer>(arguments[5]);
-	RETURN_INVALID_REF_IF_NULL(renderbuffer);
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLenum attachment = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
+    GLenum renderbuffertarget = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
+    WebGLRenderbuffer* renderbuffer = ScriptResourceTracker::ExternalToObject<WebGLRenderbuffer>(arguments[5]);
+    RETURN_INVALID_REF_IF_NULL(renderbuffer);
 
-	context->framebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer);
-	return JS_INVALID_REFERENCE;
+    context->framebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::framebufferTexture2D(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::framebufferTexture2D(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 7);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 7);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLenum attachment = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
-	GLenum textarget = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
-	WebGLTexture* texture = ScriptResourceTracker::ExternalToObject<WebGLTexture>(arguments[5]);
-	RETURN_INVALID_REF_IF_NULL(texture);
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLenum attachment = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
+    GLenum textarget = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
+    WebGLTexture* texture = ScriptResourceTracker::ExternalToObject<WebGLTexture>(arguments[5]);
+    RETURN_INVALID_REF_IF_NULL(texture);
 
-	GLint level = ScriptHostUtilities::GLintFromJsRef(arguments[6]);
-	context->framebufferTexture2D(target, attachment, textarget, texture, level);
-	return JS_INVALID_REFERENCE;
+    GLint level = ScriptHostUtilities::GLintFromJsRef(arguments[6]);
+    context->framebufferTexture2D(target, attachment, textarget, texture, level);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::createTexture(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::createTexture(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	auto returnObject = context->createTexture();
-	return ScriptResourceTracker::ObjectToExternal(returnObject);
+    auto returnObject = context->createTexture();
+    return ScriptResourceTracker::ObjectToExternal(returnObject);
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::bindTexture(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::bindTexture(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	WebGLTexture* texture = ScriptResourceTracker::ExternalToObject<WebGLTexture>(arguments[3]);
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    WebGLTexture* texture = ScriptResourceTracker::ExternalToObject<WebGLTexture>(arguments[3]);
 
-	context->bindTexture(target, texture);
-	return JS_INVALID_REFERENCE;
+    context->bindTexture(target, texture);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::texParameteri(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::texParameteri(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLenum pname = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
-	GLint param = ScriptHostUtilities::GLintFromJsRef(arguments[4]);
-	context->texParameteri(target, pname, param);
-	return JS_INVALID_REFERENCE;
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLenum pname = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
+    GLint param = ScriptHostUtilities::GLintFromJsRef(arguments[4]);
+    context->texParameteri(target, pname, param);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::texImage2D1(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::texImage2D1(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 11);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 11);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLint level = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	GLenum internalformat = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
-	GLsizei width = ScriptHostUtilities::GLsizeiFromJsRef(arguments[5]);
-	GLsizei height = ScriptHostUtilities::GLsizeiFromJsRef(arguments[6]);
-	GLint border = ScriptHostUtilities::GLintFromJsRef(arguments[7]);
-	GLenum format = ScriptHostUtilities::GLenumFromJsRef(arguments[8]);
-	GLenum type = ScriptHostUtilities::GLenumFromJsRef(arguments[9]);
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLint level = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    GLenum internalformat = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
+    GLsizei width = ScriptHostUtilities::GLsizeiFromJsRef(arguments[5]);
+    GLsizei height = ScriptHostUtilities::GLsizeiFromJsRef(arguments[6]);
+    GLint border = ScriptHostUtilities::GLintFromJsRef(arguments[7]);
+    GLenum format = ScriptHostUtilities::GLenumFromJsRef(arguments[8]);
+    GLenum type = ScriptHostUtilities::GLenumFromJsRef(arguments[9]);
 
-	JsValueType arrayRefType;
-	RETURN_NULL_IF_JS_ERROR(JsGetValueType(arguments[10], &arrayRefType));
-	if (arrayRefType != JsValueType::JsNull)
-	{
-		ChakraBytePtr pixels; unsigned int pixelsLength; int arrayElementSize; JsTypedArrayType arrayType;
-        RETURN_NULL_IF_JS_ERROR(JsGetTypedArrayStorage(arguments[10], &pixels, &pixelsLength, &arrayType, &arrayElementSize));
-		context->texImage2D(target, level, internalformat, width, height, border, format, type, pixels);
-	}
-	else
-	{
-		context->texImage2D(target, level, internalformat, width, height, border, format, type, nullptr);
-	}
-	
-	return JS_INVALID_REFERENCE;
+    JsValueType arrayRefType;
+    RETURN_NULL_IF_JS_ERROR(JsGetValueType(arguments[10], &arrayRefType));
+    if (arrayRefType != JsValueType::JsNull) {
+        ChakraBytePtr pixels;
+        unsigned int pixelsLength;
+        int arrayElementSize;
+        JsTypedArrayType arrayType;
+        RETURN_NULL_IF_JS_ERROR(
+            JsGetTypedArrayStorage(arguments[10], &pixels, &pixelsLength, &arrayType, &arrayElementSize));
+        context->texImage2D(target, level, internalformat, width, height, border, format, type, pixels);
+    } else {
+        context->texImage2D(target, level, internalformat, width, height, border, format, type, nullptr);
+    }
+
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::texImage2D2(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::texImage2D2(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 10);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 10);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLint level = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	GLenum internalformat = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLint level = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    GLenum internalformat = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
 
-	GLsizei width = ScriptHostUtilities::GLsizeiFromJsRef(arguments[5]);
-	GLsizei height = ScriptHostUtilities::GLsizeiFromJsRef(arguments[6]);
+    GLsizei width = ScriptHostUtilities::GLsizeiFromJsRef(arguments[5]);
+    GLsizei height = ScriptHostUtilities::GLsizeiFromJsRef(arguments[6]);
 
-	GLenum format = ScriptHostUtilities::GLenumFromJsRef(arguments[7]);
-	GLenum type = ScriptHostUtilities::GLenumFromJsRef(arguments[8]);
+    GLenum format = ScriptHostUtilities::GLenumFromJsRef(arguments[7]);
+    GLenum type = ScriptHostUtilities::GLenumFromJsRef(arguments[8]);
 
-	auto imageElement = ScriptResourceTracker::ExternalToObject<API::ImageElement>(arguments[9]);
-	RETURN_INVALID_REF_IF_NULL(imageElement);
+    auto imageElement = ScriptResourceTracker::ExternalToObject<API::ImageElement>(arguments[9]);
+    RETURN_INVALID_REF_IF_NULL(imageElement);
 
-	unsigned int imageBufferSize = 0;
-	WICInProcPointer imageMemory = nullptr;
-	unsigned int stride;
-	RETURN_INVALID_REF_IF_FALSE(imageElement->GetPixelsPointer(&imageMemory, &imageBufferSize, &stride));
-	
-	context->texImage2D(target, level, internalformat, width, height, 0, format, type, imageMemory);
-	return JS_INVALID_REFERENCE;
+    unsigned int imageBufferSize = 0;
+    WICInProcPointer imageMemory = nullptr;
+    unsigned int stride;
+    RETURN_INVALID_REF_IF_FALSE(imageElement->GetPixelsPointer(&imageMemory, &imageBufferSize, &stride));
+
+    context->texImage2D(target, level, internalformat, width, height, 0, format, type, imageMemory);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::texImage2D3(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::texImage2D3(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 10);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 10);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLint level = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	GLenum internalformat = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLint level = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    GLenum internalformat = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
 
-	GLsizei width = ScriptHostUtilities::GLsizeiFromJsRef(arguments[5]);
-	GLsizei height = ScriptHostUtilities::GLsizeiFromJsRef(arguments[6]);
+    GLsizei width = ScriptHostUtilities::GLsizeiFromJsRef(arguments[5]);
+    GLsizei height = ScriptHostUtilities::GLsizeiFromJsRef(arguments[6]);
 
-	GLenum format = ScriptHostUtilities::GLenumFromJsRef(arguments[7]);
-	GLenum type = ScriptHostUtilities::GLenumFromJsRef(arguments[8]);
+    GLenum format = ScriptHostUtilities::GLenumFromJsRef(arguments[7]);
+    GLenum type = ScriptHostUtilities::GLenumFromJsRef(arguments[8]);
 
-	RenderingContext2D* context2D = ScriptResourceTracker::ExternalToObject<RenderingContext2D>(arguments[9]);
-	RETURN_INVALID_REF_IF_NULL(context2D);
+    RenderingContext2D* context2D = ScriptResourceTracker::ExternalToObject<RenderingContext2D>(arguments[9]);
+    RETURN_INVALID_REF_IF_NULL(context2D);
 
-	auto pixels = context2D->getImageData(0, 0, width, height);
+    auto pixels = context2D->getImageData(0, 0, width, height);
 
-	context->texImage2D(target, level, internalformat, width, height, 0, format, type, pixels->Data);
-	return JS_INVALID_REFERENCE;
+    context->texImage2D(target, level, internalformat, width, height, 0, format, type, pixels->Data);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::texImage2D4(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::texImage2D4(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 10);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 10);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLint level = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	GLenum internalformat = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLint level = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    GLenum internalformat = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
 
-	GLsizei width = ScriptHostUtilities::GLsizeiFromJsRef(arguments[5]);
-	GLsizei height = ScriptHostUtilities::GLsizeiFromJsRef(arguments[6]);
+    GLsizei width = ScriptHostUtilities::GLsizeiFromJsRef(arguments[5]);
+    GLsizei height = ScriptHostUtilities::GLsizeiFromJsRef(arguments[6]);
 
-	GLenum format = ScriptHostUtilities::GLenumFromJsRef(arguments[7]);
-	GLenum type = ScriptHostUtilities::GLenumFromJsRef(arguments[8]);
+    GLenum format = ScriptHostUtilities::GLenumFromJsRef(arguments[7]);
+    GLenum type = ScriptHostUtilities::GLenumFromJsRef(arguments[8]);
 
-	auto videoElement= ScriptResourceTracker::ExternalToObject<VideoElement>(arguments[9]);
-	RETURN_INVALID_REF_IF_NULL(videoElement);
+    auto videoElement = ScriptResourceTracker::ExternalToObject<VideoElement>(arguments[9]);
+    RETURN_INVALID_REF_IF_NULL(videoElement);
 
-	void* pixels;
-	unsigned int pixelsSize;
-    if (videoElement->IsNewFrameAvailable())
-    {
+    void* pixels;
+    unsigned int pixelsSize;
+    if (videoElement->IsNewFrameAvailable()) {
         DWORD64 start = GetTickCount64();
         RETURN_INVALID_REF_IF_FALSE(videoElement->LockNextFrame(&pixels, &pixelsSize));
         std::wstring endString = std::to_wstring(GetTickCount64() - start) + L"\n";
@@ -593,1803 +466,1314 @@ WebGLProjections::texImage2D4(
         videoElement->UnlockFrame();
     }
 
-	return JS_INVALID_REFERENCE;
-}
-
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::activeTexture(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLenum texture = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	context->activeTexture(texture);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::generateMipmap(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	context->generateMipmap(target);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::pixelStorei(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLenum pname = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	if (pname == UNPACK_FLIP_Y_WEBGL || pname == UNPACK_PREMULTIPLY_ALPHA_WEBGL) {
-		GLboolean param = ScriptHostUtilities::GLbooleanFromJsRef(arguments[3]);
-		context->pixelStorei(pname, param);
-	}
-	else {
-		GLint param = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-		context->pixelStorei(pname, param);
-	}
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::clearDepth(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLclampf depth = ScriptHostUtilities::GLclampfFromJsRef(arguments[2]);
-	context->clearDepth(depth);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::clearStencil(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::activeTexture(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum texture = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    context->activeTexture(texture);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::generateMipmap(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    context->generateMipmap(target);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::pixelStorei(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum pname = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    if (pname == UNPACK_FLIP_Y_WEBGL || pname == UNPACK_PREMULTIPLY_ALPHA_WEBGL) {
+        GLboolean param = ScriptHostUtilities::GLbooleanFromJsRef(arguments[3]);
+        context->pixelStorei(pname, param);
+    } else {
+        GLint param = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+        context->pixelStorei(pname, param);
+    }
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::clearDepth(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLclampf depth = ScriptHostUtilities::GLclampfFromJsRef(arguments[2]);
+    context->clearDepth(depth);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::clearStencil(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLint s = ScriptHostUtilities::GLintFromJsRef(arguments[2]);
+    context->clearStencil(s);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::enable(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum cap = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    context->enable(cap);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::disable(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum cap = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    context->disable(cap);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::depthFunc(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum func = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    context->depthFunc(func);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::depthMask(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLboolean flag = ScriptHostUtilities::GLbooleanFromJsRef(arguments[2]);
+    context->depthMask(flag);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::depthRange(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLclampf zNear = ScriptHostUtilities::GLclampfFromJsRef(arguments[2]);
+    GLclampf zFar = ScriptHostUtilities::GLclampfFromJsRef(arguments[3]);
+    context->depthRange(zNear, zFar);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::frontFace(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum mode = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    context->frontFace(mode);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::cullFace(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum mode = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    context->cullFace(mode);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::blendColor(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLclampf red = ScriptHostUtilities::GLclampfFromJsRef(arguments[2]);
+    GLclampf green = ScriptHostUtilities::GLclampfFromJsRef(arguments[3]);
+    GLclampf blue = ScriptHostUtilities::GLclampfFromJsRef(arguments[4]);
+    GLclampf alpha = ScriptHostUtilities::GLclampfFromJsRef(arguments[5]);
+    context->blendColor(red, green, blue, alpha);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::blendEquation(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum mode = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    context->blendEquation(mode);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::blendEquationSeparate(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum modeRGB = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLenum modeAlpha = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
+    context->blendEquationSeparate(modeRGB, modeAlpha);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::blendFunc(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum sfactor = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLenum dfactor = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
+    context->blendFunc(sfactor, dfactor);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::blendFuncSeparate(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum srcRGB = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLenum dstRGB = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
+    GLenum srcAlpha = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
+    GLenum dstAlpha = ScriptHostUtilities::GLenumFromJsRef(arguments[5]);
+    context->blendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::scissor(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLint s = ScriptHostUtilities::GLintFromJsRef(arguments[2]);
-	context->clearStencil(s);
-	return JS_INVALID_REFERENCE;
+    GLint x = ScriptHostUtilities::GLintFromJsRef(arguments[2]);
+    GLint y = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    GLsizei width = ScriptHostUtilities::GLsizeiFromJsRef(arguments[4]);
+    GLsizei height = ScriptHostUtilities::GLsizeiFromJsRef(arguments[5]);
+    context->scissor(x, y, width, height);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::enable(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::viewport(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum cap = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	context->enable(cap);
-	return JS_INVALID_REFERENCE;
+    GLint x = ScriptHostUtilities::GLintFromJsRef(arguments[2]);
+    GLint y = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    GLsizei width = ScriptHostUtilities::GLsizeiFromJsRef(arguments[4]);
+    GLsizei height = ScriptHostUtilities::GLsizeiFromJsRef(arguments[5]);
+    context->viewport(x, y, width, height);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::disable(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::clearColor(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum cap = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	context->disable(cap);
-	return JS_INVALID_REFERENCE;
+    GLclampf red = ScriptHostUtilities::GLclampfFromJsRef(arguments[2]);
+    GLclampf green = ScriptHostUtilities::GLclampfFromJsRef(arguments[3]);
+    GLclampf blue = ScriptHostUtilities::GLclampfFromJsRef(arguments[4]);
+    GLclampf alpha = ScriptHostUtilities::GLclampfFromJsRef(arguments[5]);
+    context->clearColor(red, green, blue, alpha);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::depthFunc(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::clear(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum func = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	context->depthFunc(func);
-	return JS_INVALID_REFERENCE;
+    GLbitfield mask = ScriptHostUtilities::GLbitfieldFromJsRef(arguments[2]);
+    context->clear(mask);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::depthMask(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::createBuffer(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLboolean flag = ScriptHostUtilities::GLbooleanFromJsRef(arguments[2]);
-	context->depthMask(flag);
-	return JS_INVALID_REFERENCE;
-}
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::depthRange(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    auto returnObject = context->createBuffer();
+    return ScriptResourceTracker::ObjectToExternal(returnObject);
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::deleteBuffer(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    WebGLBuffer* buffer = ScriptResourceTracker::ExternalToObject<WebGLBuffer>(arguments[2]);
+
+    context->deleteBuffer(buffer);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::bindBuffer(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+
+    WebGLBuffer* buffer = ScriptResourceTracker::ExternalToObject<WebGLBuffer>(arguments[3]);
+
+    context->bindBuffer(target, buffer);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::bufferData1(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLsizeiptr size = ScriptHostUtilities::GLsizeiptrFromJsRef(arguments[3]);
+    GLenum usage = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
+    context->bufferData(target, size, nullptr, usage);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::bufferData2(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+
+    ChakraBytePtr data;
+    unsigned int dataLength;
+    int arrayElementSize;
+    JsTypedArrayType arrayType;
+    JsGetTypedArrayStorage(arguments[3], &data, &dataLength, &arrayType, &arrayElementSize);
+    GLenum usage = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
+    context->bufferData(target, dataLength, data, usage);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::colorMask(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLboolean red = ScriptHostUtilities::GLbooleanFromJsRef(arguments[2]);
+    GLboolean green = ScriptHostUtilities::GLbooleanFromJsRef(arguments[3]);
+    GLboolean blue = ScriptHostUtilities::GLbooleanFromJsRef(arguments[4]);
+    GLboolean alpha = ScriptHostUtilities::GLbooleanFromJsRef(arguments[5]);
+    context->colorMask(red, green, blue, alpha);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::drawArrays(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum mode = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLint first = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    GLsizei count = ScriptHostUtilities::GLsizeiFromJsRef(arguments[4]);
+    context->drawArrays(mode, first, count);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::drawElements(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLenum mode = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLsizei count = ScriptHostUtilities::GLsizeiFromJsRef(arguments[3]);
+    GLenum type = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
+    GLint offset = ScriptHostUtilities::GLintFromJsRef(arguments[5]);
+    context->drawElements(mode, count, type, offset);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::enableVertexAttribArray(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLuint index = ScriptHostUtilities::GLuintFromJsRef(arguments[2]);
+    context->enableVertexAttribArray(index);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::disableVertexAttribArray(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLuint index = ScriptHostUtilities::GLuintFromJsRef(arguments[2]);
+    context->disableVertexAttribArray(index);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::vertexAttribPointer(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 8);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    GLuint indx = ScriptHostUtilities::GLuintFromJsRef(arguments[2]);
+    GLint size = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    GLenum type = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
+    GLboolean normalized = ScriptHostUtilities::GLbooleanFromJsRef(arguments[5]);
+    GLsizei stride = ScriptHostUtilities::GLsizeiFromJsRef(arguments[6]);
+    GLint offset = ScriptHostUtilities::GLintFromJsRef(arguments[7]);
+    context->vertexAttribPointer(indx, size, type, normalized, stride, offset);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::createProgram(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    auto returnObject = context->createProgram();
+    return ScriptResourceTracker::ObjectToExternal(returnObject);
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::useProgram(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(program);
+
+    context->useProgram(program);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::validateProgram(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(program);
+
+    context->validateProgram(program);
+    return JS_INVALID_REFERENCE;
+}
+
+JsValueRef CHAKRA_CALLBACK WebGLProjections::linkProgram(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLclampf zNear = ScriptHostUtilities::GLclampfFromJsRef(arguments[2]);
-	GLclampf zFar = ScriptHostUtilities::GLclampfFromJsRef(arguments[3]);
-	context->depthRange(zNear, zFar);
-	return JS_INVALID_REFERENCE;
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(program);
+
+    context->linkProgram(program);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::frontFace(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLenum mode = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	context->frontFace(mode);
-	return JS_INVALID_REFERENCE;
-}
+JsValueRef CHAKRA_CALLBACK WebGLProjections::getProgramParameter(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
+{
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::cullFace(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLenum mode = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	context->cullFace(mode);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::blendColor(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLclampf red = ScriptHostUtilities::GLclampfFromJsRef(arguments[2]);
-	GLclampf green = ScriptHostUtilities::GLclampfFromJsRef(arguments[3]);
-	GLclampf blue = ScriptHostUtilities::GLclampfFromJsRef(arguments[4]);
-	GLclampf alpha = ScriptHostUtilities::GLclampfFromJsRef(arguments[5]);
-	context->blendColor(red, green, blue, alpha);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::blendEquation(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLenum mode = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	context->blendEquation(mode);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::blendEquationSeparate(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLenum modeRGB = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLenum modeAlpha = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
-	context->blendEquationSeparate(modeRGB, modeAlpha);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::blendFunc(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLenum sfactor = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLenum dfactor = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
-	context->blendFunc(sfactor, dfactor);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::blendFuncSeparate(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLenum srcRGB = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLenum dstRGB = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
-	GLenum srcAlpha = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
-	GLenum dstAlpha = ScriptHostUtilities::GLenumFromJsRef(arguments[5]);
-	context->blendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::scissor(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLint x = ScriptHostUtilities::GLintFromJsRef(arguments[2]);
-	GLint y = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	GLsizei width = ScriptHostUtilities::GLsizeiFromJsRef(arguments[4]);
-	GLsizei height = ScriptHostUtilities::GLsizeiFromJsRef(arguments[5]);
-	context->scissor(x, y, width, height);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::viewport(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLint x = ScriptHostUtilities::GLintFromJsRef(arguments[2]);
-	GLint y = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	GLsizei width = ScriptHostUtilities::GLsizeiFromJsRef(arguments[4]);
-	GLsizei height = ScriptHostUtilities::GLsizeiFromJsRef(arguments[5]);
-	context->viewport(x, y, width, height);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::clearColor(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLclampf red = ScriptHostUtilities::GLclampfFromJsRef(arguments[2]);
-	GLclampf green = ScriptHostUtilities::GLclampfFromJsRef(arguments[3]);
-	GLclampf blue = ScriptHostUtilities::GLclampfFromJsRef(arguments[4]);
-	GLclampf alpha = ScriptHostUtilities::GLclampfFromJsRef(arguments[5]);
-	context->clearColor(red, green, blue, alpha);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::clear(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLbitfield mask = ScriptHostUtilities::GLbitfieldFromJsRef(arguments[2]);
-	context->clear(mask);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::createBuffer(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	auto returnObject = context->createBuffer();
-	return ScriptResourceTracker::ObjectToExternal(returnObject);
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::deleteBuffer(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	WebGLBuffer* buffer = ScriptResourceTracker::ExternalToObject<WebGLBuffer>(arguments[2]);
-
-	context->deleteBuffer(buffer);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::bindBuffer(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-
-	WebGLBuffer* buffer = ScriptResourceTracker::ExternalToObject<WebGLBuffer>(arguments[3]);
-
-	context->bindBuffer(target, buffer);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::bufferData1(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLsizeiptr size = ScriptHostUtilities::GLsizeiptrFromJsRef(arguments[3]);
-	GLenum usage = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
-	context->bufferData(target, size, nullptr, usage);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::bufferData2(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLenum target = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	
-	ChakraBytePtr data; unsigned int dataLength; int arrayElementSize; JsTypedArrayType arrayType;
-	JsGetTypedArrayStorage(arguments[3], &data, &dataLength, &arrayType, &arrayElementSize);
-	GLenum usage = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
-	context->bufferData(target, dataLength, data, usage);
-	return JS_INVALID_REFERENCE;
-}
-
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::colorMask(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLboolean red = ScriptHostUtilities::GLbooleanFromJsRef(arguments[2]);
-	GLboolean green = ScriptHostUtilities::GLbooleanFromJsRef(arguments[3]);
-	GLboolean blue = ScriptHostUtilities::GLbooleanFromJsRef(arguments[4]);
-	GLboolean alpha = ScriptHostUtilities::GLbooleanFromJsRef(arguments[5]);
-	context->colorMask(red, green, blue, alpha);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::drawArrays(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLenum mode = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLint first = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	GLsizei count = ScriptHostUtilities::GLsizeiFromJsRef(arguments[4]);
-	context->drawArrays(mode, first, count);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::drawElements(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLenum mode = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	GLsizei count = ScriptHostUtilities::GLsizeiFromJsRef(arguments[3]);
-	GLenum type = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
-	GLint offset = ScriptHostUtilities::GLintFromJsRef(arguments[5]);
-	context->drawElements(mode, count, type, offset);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::enableVertexAttribArray(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLuint index = ScriptHostUtilities::GLuintFromJsRef(arguments[2]);
-	context->enableVertexAttribArray(index);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::disableVertexAttribArray(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLuint index = ScriptHostUtilities::GLuintFromJsRef(arguments[2]);
-	context->disableVertexAttribArray(index);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::vertexAttribPointer(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 8);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	GLuint indx = ScriptHostUtilities::GLuintFromJsRef(arguments[2]);
-	GLint size = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	GLenum type = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
-	GLboolean normalized = ScriptHostUtilities::GLbooleanFromJsRef(arguments[5]);
-	GLsizei stride = ScriptHostUtilities::GLsizeiFromJsRef(arguments[6]);
-	GLint offset = ScriptHostUtilities::GLintFromJsRef(arguments[7]);
-	context->vertexAttribPointer(indx, size, type, normalized, stride, offset);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::createProgram(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	auto returnObject = context->createProgram();
-	return ScriptResourceTracker::ObjectToExternal(returnObject);
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::useProgram(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(program);
-
-	context->useProgram(program);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::validateProgram(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(program);
-
-	context->validateProgram(program);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::linkProgram(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(program);
+    WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(program);
+
+    GLenum pname = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
+    return context->getProgramParameter(program, pname);
+}
 
-	context->linkProgram(program);
-	return JS_INVALID_REFERENCE;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::getProgramParameter(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
-{
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(program);
-
-	GLenum pname = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
-	return context->getProgramParameter(program, pname);
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::getProgramInfoLog(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::getProgramInfoLog(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(program);
+
+    auto log = context->getProgramInfoLog(program);
+    JsValueRef retValue;
+    RETURN_NULL_IF_JS_ERROR(JsPointerToString(log.c_str(), log.length(), &retValue));
 
-	WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(program);
+    return retValue;
+}
 
-
-	auto log = context->getProgramInfoLog(program);
-	JsValueRef retValue;
-	RETURN_NULL_IF_JS_ERROR(JsPointerToString(log.c_str(), log.length(), &retValue));
-
-	return retValue;
-}
-
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::deleteProgram(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::deleteProgram(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(program);
+    WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(program);
 
-	context->deleteProgram(program);
-	return JS_INVALID_REFERENCE;
+    context->deleteProgram(program);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::bindAttribLocation(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::bindAttribLocation(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
-
-	WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(program);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLuint index = ScriptHostUtilities::GLuintFromJsRef(arguments[3]);
-	std::wstring name;
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[4], name));
-	context->bindAttribLocation(program, index, name);
-	return JS_INVALID_REFERENCE;
+    WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(program);
+
+    GLuint index = ScriptHostUtilities::GLuintFromJsRef(arguments[3]);
+    std::wstring name;
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[4], name));
+    context->bindAttribLocation(program, index, name);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::getActiveUniform(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::getActiveUniform(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(program);
 
-	WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(program);
-
-	GLuint index = ScriptHostUtilities::GLuintFromJsRef(arguments[3]);
-	auto activeUniform = context->getActiveUniform(program, index);
+    GLuint index = ScriptHostUtilities::GLuintFromJsRef(arguments[3]);
+    auto activeUniform = context->getActiveUniform(program, index);
 
-	// Project object to script; note that the projected object is opaque to the script
-	auto returnObject = ScriptResourceTracker::ObjectToExternal(activeUniform);
+    // Project object to script; note that the projected object is opaque to the script
+    auto returnObject = ScriptResourceTracker::ObjectToExternal(activeUniform);
 
-	JsValueRef namePropertyValue;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsPointerToString(activeUniform->name.c_str(), wcslen(activeUniform->name.data()), &namePropertyValue));
+    JsValueRef namePropertyValue;
+    RETURN_INVALID_REF_IF_JS_ERROR(
+        JsPointerToString(activeUniform->name.c_str(), wcslen(activeUniform->name.data()), &namePropertyValue));
 
-	JsValueRef sizePropertyValue;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(activeUniform->size, &sizePropertyValue));
+    JsValueRef sizePropertyValue;
+    RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(activeUniform->size, &sizePropertyValue));
 
-	JsValueRef typePropertyValue;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(activeUniform->type, &typePropertyValue));
+    JsValueRef typePropertyValue;
+    RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(activeUniform->type, &typePropertyValue));
 
-	// Add properties for WebGLActiveInfo as required by spec
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"name", namePropertyValue));
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"size", sizePropertyValue));
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"type", typePropertyValue));
-	
-	return returnObject;
+    // Add properties for WebGLActiveInfo as required by spec
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"name", namePropertyValue));
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"size", sizePropertyValue));
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"type", typePropertyValue));
+
+    return returnObject;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::getActiveAttrib(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::getActiveAttrib(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
+
+    WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(program);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    GLuint index = ScriptHostUtilities::GLuintFromJsRef(arguments[3]);
+    auto activeAttribute = context->getActiveAttrib(program, index);
 
-	WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(program);
+    // Project object to script; note that the projected object is opaque to the script
+    auto returnObject = ScriptResourceTracker::ObjectToExternal(activeAttribute);
 
-	GLuint index = ScriptHostUtilities::GLuintFromJsRef(arguments[3]);
-	auto activeAttribute = context->getActiveAttrib(program, index);
-
-	// Project object to script; note that the projected object is opaque to the script
-	auto returnObject = ScriptResourceTracker::ObjectToExternal(activeAttribute);
+    JsValueRef namePropertyValue;
+    RETURN_INVALID_REF_IF_JS_ERROR(
+        JsPointerToString(activeAttribute->name.c_str(), wcslen(activeAttribute->name.data()), &namePropertyValue));
 
-	JsValueRef namePropertyValue;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsPointerToString(activeAttribute->name.c_str(), wcslen(activeAttribute->name.data()), &namePropertyValue));
+    JsValueRef sizePropertyValue;
+    RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(activeAttribute->size, &sizePropertyValue));
 
-	JsValueRef sizePropertyValue;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(activeAttribute->size, &sizePropertyValue));
+    JsValueRef typePropertyValue;
+    RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(activeAttribute->type, &typePropertyValue));
 
-	JsValueRef typePropertyValue;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsIntToNumber(activeAttribute->type, &typePropertyValue));
+    // Add properties for WebGLActiveInfo as required by spec
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"name", namePropertyValue));
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"size", sizePropertyValue));
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"type", typePropertyValue));
 
-	// Add properties for WebGLActiveInfo as required by spec
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"name", namePropertyValue));
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"size", sizePropertyValue));
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::SetJsProperty(returnObject, L"type", typePropertyValue));
-	
-	return returnObject;
+    return returnObject;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::getAttribLocation(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::getAttribLocation(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(program);
+    WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(program);
 
-	std::wstring name;
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[3], name));
+    std::wstring name;
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[3], name));
 
-	JsValueRef retValue;
-	RETURN_NULL_IF_JS_ERROR(JsIntToNumber(context->getAttribLocation(program, name), &retValue));
-	return retValue;
+    JsValueRef retValue;
+    RETURN_NULL_IF_JS_ERROR(JsIntToNumber(context->getAttribLocation(program, name), &retValue));
+    return retValue;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::createShader(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::createShader(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLenum type = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-	auto returnObject = context->createShader(type);
-	return ScriptResourceTracker::ObjectToExternal(returnObject);
+    GLenum type = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    auto returnObject = context->createShader(type);
+    return ScriptResourceTracker::ObjectToExternal(returnObject);
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::shaderSource(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::shaderSource(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLShader* shader = ScriptResourceTracker::ExternalToObject<WebGLShader>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(shader);
+    WebGLShader* shader = ScriptResourceTracker::ExternalToObject<WebGLShader>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(shader);
 
-	std::wstring source;
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[3], source));
-	context->shaderSource(shader, source);
-	return JS_INVALID_REFERENCE;
+    std::wstring source;
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[3], source));
+    context->shaderSource(shader, source);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::compileShader(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::compileShader(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLShader* shader = ScriptResourceTracker::ExternalToObject<WebGLShader>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(shader);
+    WebGLShader* shader = ScriptResourceTracker::ExternalToObject<WebGLShader>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(shader);
 
-	context->compileShader(shader);
-	return JS_INVALID_REFERENCE;
+    context->compileShader(shader);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::getShaderParameter(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::getShaderParameter(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLShader* shader = ScriptResourceTracker::ExternalToObject<WebGLShader>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(shader);
+    WebGLShader* shader = ScriptResourceTracker::ExternalToObject<WebGLShader>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(shader);
 
-	GLenum pname = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
-	return context->getShaderParameter(shader, pname);
+    GLenum pname = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
+    return context->getShaderParameter(shader, pname);
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::getShaderInfoLog(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::getShaderInfoLog(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLShader* shader = ScriptResourceTracker::ExternalToObject<WebGLShader>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(shader);
+    WebGLShader* shader = ScriptResourceTracker::ExternalToObject<WebGLShader>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(shader);
 
-	auto log = context->getShaderInfoLog(shader);
+    auto log = context->getShaderInfoLog(shader);
 
-	JsValueRef logValue;
-	JsPointerToString(log.c_str(), log.length(), &logValue);
+    JsValueRef logValue;
+    JsPointerToString(log.c_str(), log.length(), &logValue);
 
-	return logValue;
+    return logValue;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::attachShader(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::attachShader(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(program);
+    WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(program);
 
-	WebGLShader* shader = ScriptResourceTracker::ExternalToObject<WebGLShader>(arguments[3]);
-	RETURN_INVALID_REF_IF_NULL(shader);
+    WebGLShader* shader = ScriptResourceTracker::ExternalToObject<WebGLShader>(arguments[3]);
+    RETURN_INVALID_REF_IF_NULL(shader);
 
-	context->attachShader(program, shader);
-	return JS_INVALID_REFERENCE;
+    context->attachShader(program, shader);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::deleteShader(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::deleteShader(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLShader* shader = ScriptResourceTracker::ExternalToObject<WebGLShader>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(shader);
+    WebGLShader* shader = ScriptResourceTracker::ExternalToObject<WebGLShader>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(shader);
 
-	context->deleteShader(shader);
-	return JS_INVALID_REFERENCE;
+    context->deleteShader(shader);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::getUniformLocation(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::getUniformLocation(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(program);
+    WebGLProgram* program = ScriptResourceTracker::ExternalToObject<WebGLProgram>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(program);
 
-	std::wstring name;
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[3], name));
-	auto returnObject = context->getUniformLocation(program, name);
+    std::wstring name;
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[3], name));
+    auto returnObject = context->getUniformLocation(program, name);
 
-	return ScriptResourceTracker::ObjectToExternal(returnObject);
+    return ScriptResourceTracker::ObjectToExternal(returnObject);
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform1f(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform1f(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	GLfloat x = ScriptHostUtilities::GLfloatFromJsRef(arguments[3]);
-	context->uniform1f(location, x);
-	return JS_INVALID_REFERENCE;
+    GLfloat x = ScriptHostUtilities::GLfloatFromJsRef(arguments[3]);
+    context->uniform1f(location, x);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform1fv(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform1fv(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	ChakraBytePtr v; unsigned int vLength; int arrayElementSize; JsTypedArrayType arrayType;
-	JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
-	context->uniform1fv(location, vLength / arrayElementSize / 1, reinterpret_cast<const GLfloat*>(v));
-	return JS_INVALID_REFERENCE;
+    ChakraBytePtr v;
+    unsigned int vLength;
+    int arrayElementSize;
+    JsTypedArrayType arrayType;
+    JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
+    context->uniform1fv(location, vLength / arrayElementSize / 1, reinterpret_cast<const GLfloat*>(v));
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform1i(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform1i(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	GLint x = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	context->uniform1i(location, x);
-	return JS_INVALID_REFERENCE;
+    GLint x = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    context->uniform1i(location, x);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform1iv(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform1iv(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	ChakraBytePtr v; unsigned int vLength; int arrayElementSize; JsTypedArrayType arrayType;
-	JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
-	context->uniform1iv(location, vLength / arrayElementSize / 1, reinterpret_cast<const GLint*>(v));
-	return JS_INVALID_REFERENCE;
+    ChakraBytePtr v;
+    unsigned int vLength;
+    int arrayElementSize;
+    JsTypedArrayType arrayType;
+    JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
+    context->uniform1iv(location, vLength / arrayElementSize / 1, reinterpret_cast<const GLint*>(v));
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform2f(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform2f(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	GLfloat x = ScriptHostUtilities::GLfloatFromJsRef(arguments[3]);
-	GLfloat y = ScriptHostUtilities::GLfloatFromJsRef(arguments[4]);
-	context->uniform2f(location, x, y);
-	return JS_INVALID_REFERENCE;
+    GLfloat x = ScriptHostUtilities::GLfloatFromJsRef(arguments[3]);
+    GLfloat y = ScriptHostUtilities::GLfloatFromJsRef(arguments[4]);
+    context->uniform2f(location, x, y);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform2fv(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform2fv(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	ChakraBytePtr v; unsigned int vLength; int arrayElementSize; JsTypedArrayType arrayType;
-	JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
-	context->uniform2fv(location, vLength / arrayElementSize / 2, reinterpret_cast<const GLfloat*>(v));
-	return JS_INVALID_REFERENCE;
+    ChakraBytePtr v;
+    unsigned int vLength;
+    int arrayElementSize;
+    JsTypedArrayType arrayType;
+    JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
+    context->uniform2fv(location, vLength / arrayElementSize / 2, reinterpret_cast<const GLfloat*>(v));
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform2i(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform2i(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	GLint x = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	GLint y = ScriptHostUtilities::GLintFromJsRef(arguments[4]);
-	context->uniform2i(location, x, y);
-	return JS_INVALID_REFERENCE;
+    GLint x = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    GLint y = ScriptHostUtilities::GLintFromJsRef(arguments[4]);
+    context->uniform2i(location, x, y);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform2iv(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform2iv(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	ChakraBytePtr v; unsigned int vLength; int arrayElementSize; JsTypedArrayType arrayType;
-	JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
-	context->uniform2iv(location, vLength / arrayElementSize / 2, reinterpret_cast<const GLint*>(v));
-	return JS_INVALID_REFERENCE;
+    ChakraBytePtr v;
+    unsigned int vLength;
+    int arrayElementSize;
+    JsTypedArrayType arrayType;
+    JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
+    context->uniform2iv(location, vLength / arrayElementSize / 2, reinterpret_cast<const GLint*>(v));
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform3f(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform3f(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	GLfloat x = ScriptHostUtilities::GLfloatFromJsRef(arguments[3]);
-	GLfloat y = ScriptHostUtilities::GLfloatFromJsRef(arguments[4]);
-	GLfloat z = ScriptHostUtilities::GLfloatFromJsRef(arguments[5]);
-	context->uniform3f(location, x, y, z);
-	return JS_INVALID_REFERENCE;
+    GLfloat x = ScriptHostUtilities::GLfloatFromJsRef(arguments[3]);
+    GLfloat y = ScriptHostUtilities::GLfloatFromJsRef(arguments[4]);
+    GLfloat z = ScriptHostUtilities::GLfloatFromJsRef(arguments[5]);
+    context->uniform3f(location, x, y, z);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform3fv(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform3fv(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	ChakraBytePtr v; unsigned int vLength; int arrayElementSize; JsTypedArrayType arrayType;
-	JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
-	context->uniform3fv(location, vLength / arrayElementSize / 3, reinterpret_cast<const GLfloat*>(v));
-	return JS_INVALID_REFERENCE;
+    ChakraBytePtr v;
+    unsigned int vLength;
+    int arrayElementSize;
+    JsTypedArrayType arrayType;
+    JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
+    context->uniform3fv(location, vLength / arrayElementSize / 3, reinterpret_cast<const GLfloat*>(v));
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform3i(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform3i(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	GLint x = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	GLint y = ScriptHostUtilities::GLintFromJsRef(arguments[4]);
-	GLint z = ScriptHostUtilities::GLintFromJsRef(arguments[5]);
-	context->uniform3i(location, x, y, z);
-	return JS_INVALID_REFERENCE;
+    GLint x = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    GLint y = ScriptHostUtilities::GLintFromJsRef(arguments[4]);
+    GLint z = ScriptHostUtilities::GLintFromJsRef(arguments[5]);
+    context->uniform3i(location, x, y, z);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform3iv(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform3iv(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	ChakraBytePtr v; unsigned int vLength; int arrayElementSize; JsTypedArrayType arrayType;
-	JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
-	context->uniform3iv(location, vLength / arrayElementSize / 3, reinterpret_cast<const GLint*>(v));
-	return JS_INVALID_REFERENCE;
+    ChakraBytePtr v;
+    unsigned int vLength;
+    int arrayElementSize;
+    JsTypedArrayType arrayType;
+    JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
+    context->uniform3iv(location, vLength / arrayElementSize / 3, reinterpret_cast<const GLint*>(v));
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform4f(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform4f(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 7);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 7);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	GLfloat x = ScriptHostUtilities::GLfloatFromJsRef(arguments[3]);
-	GLfloat y = ScriptHostUtilities::GLfloatFromJsRef(arguments[4]);
-	GLfloat z = ScriptHostUtilities::GLfloatFromJsRef(arguments[5]);
-	GLfloat w = ScriptHostUtilities::GLfloatFromJsRef(arguments[6]);
-	context->uniform4f(location, x, y, z, w);
-	return JS_INVALID_REFERENCE;
+    GLfloat x = ScriptHostUtilities::GLfloatFromJsRef(arguments[3]);
+    GLfloat y = ScriptHostUtilities::GLfloatFromJsRef(arguments[4]);
+    GLfloat z = ScriptHostUtilities::GLfloatFromJsRef(arguments[5]);
+    GLfloat w = ScriptHostUtilities::GLfloatFromJsRef(arguments[6]);
+    context->uniform4f(location, x, y, z, w);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform4fv(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform4fv(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	ChakraBytePtr v; unsigned int vLength; int arrayElementSize; JsTypedArrayType arrayType;
-	JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
-	context->uniform4fv(location, vLength / arrayElementSize / 4, reinterpret_cast<const GLfloat*>(v));
-	return JS_INVALID_REFERENCE;
+    ChakraBytePtr v;
+    unsigned int vLength;
+    int arrayElementSize;
+    JsTypedArrayType arrayType;
+    JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
+    context->uniform4fv(location, vLength / arrayElementSize / 4, reinterpret_cast<const GLfloat*>(v));
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform4i(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform4i(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 7);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 7);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	GLint x = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	GLint y = ScriptHostUtilities::GLintFromJsRef(arguments[4]);
-	GLint z = ScriptHostUtilities::GLintFromJsRef(arguments[5]);
-	GLint w = ScriptHostUtilities::GLintFromJsRef(arguments[6]);
-	context->uniform4i(location, x, y, z, w);
-	return JS_INVALID_REFERENCE;
+    GLint x = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    GLint y = ScriptHostUtilities::GLintFromJsRef(arguments[4]);
+    GLint z = ScriptHostUtilities::GLintFromJsRef(arguments[5]);
+    GLint w = ScriptHostUtilities::GLintFromJsRef(arguments[6]);
+    context->uniform4i(location, x, y, z, w);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniform4iv(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniform4iv(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	ChakraBytePtr v; unsigned int vLength; int arrayElementSize; JsTypedArrayType arrayType;
-	JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
-	context->uniform4iv(location, vLength / arrayElementSize / 4, reinterpret_cast<const GLint*>(v));
-	return JS_INVALID_REFERENCE;
+    ChakraBytePtr v;
+    unsigned int vLength;
+    int arrayElementSize;
+    JsTypedArrayType arrayType;
+    JsGetTypedArrayStorage(arguments[3], &v, &vLength, &arrayType, &arrayElementSize);
+    context->uniform4iv(location, vLength / arrayElementSize / 4, reinterpret_cast<const GLint*>(v));
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniformMatrix2fv(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniformMatrix2fv(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	GLboolean transpose = ScriptHostUtilities::GLbooleanFromJsRef(arguments[3]);
-	ChakraBytePtr value; unsigned int valueLength; int arrayElementSize; JsTypedArrayType arrayType;
-	JsGetTypedArrayStorage(arguments[4], &value, &valueLength, &arrayType, &arrayElementSize);
-	context->uniformMatrix2fv(location, transpose, valueLength / arrayElementSize / 4, reinterpret_cast<const GLfloat*>(value));
-	return JS_INVALID_REFERENCE;
+    GLboolean transpose = ScriptHostUtilities::GLbooleanFromJsRef(arguments[3]);
+    ChakraBytePtr value;
+    unsigned int valueLength;
+    int arrayElementSize;
+    JsTypedArrayType arrayType;
+    JsGetTypedArrayStorage(arguments[4], &value, &valueLength, &arrayType, &arrayElementSize);
+    context->uniformMatrix2fv(
+        location, transpose, valueLength / arrayElementSize / 4, reinterpret_cast<const GLfloat*>(value));
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniformMatrix3fv(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniformMatrix3fv(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	GLboolean transpose = ScriptHostUtilities::GLbooleanFromJsRef(arguments[3]);
-	ChakraBytePtr value; unsigned int valueLength; int arrayElementSize; JsTypedArrayType arrayType;
-	JsGetTypedArrayStorage(arguments[4], &value, &valueLength, &arrayType, &arrayElementSize);
-	context->uniformMatrix3fv(location, transpose, valueLength / arrayElementSize / 9, reinterpret_cast<const GLfloat*>(value));
-	return JS_INVALID_REFERENCE;
+    GLboolean transpose = ScriptHostUtilities::GLbooleanFromJsRef(arguments[3]);
+    ChakraBytePtr value;
+    unsigned int valueLength;
+    int arrayElementSize;
+    JsTypedArrayType arrayType;
+    JsGetTypedArrayStorage(arguments[4], &value, &valueLength, &arrayType, &arrayElementSize);
+    context->uniformMatrix3fv(
+        location, transpose, valueLength / arrayElementSize / 9, reinterpret_cast<const GLfloat*>(value));
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::uniformMatrix4fv(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::uniformMatrix4fv(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
-	RETURN_INVALID_REF_IF_NULL(location);
+    WebGLUniformLocation* location = ScriptResourceTracker::ExternalToObject<WebGLUniformLocation>(arguments[2]);
+    RETURN_INVALID_REF_IF_NULL(location);
 
-	GLboolean transpose = ScriptHostUtilities::GLbooleanFromJsRef(arguments[3]);
-	ChakraBytePtr value; unsigned int valueLength; int arrayElementSize; JsTypedArrayType arrayType;
-	JsGetTypedArrayStorage(arguments[4], &value, &valueLength, &arrayType, &arrayElementSize);
-	context->uniformMatrix4fv(location, transpose, valueLength / arrayElementSize / 16, reinterpret_cast<const GLfloat*>(value));
-	return JS_INVALID_REFERENCE;
+    GLboolean transpose = ScriptHostUtilities::GLbooleanFromJsRef(arguments[3]);
+    ChakraBytePtr value;
+    unsigned int valueLength;
+    int arrayElementSize;
+    JsTypedArrayType arrayType;
+    JsGetTypedArrayStorage(arguments[4], &value, &valueLength, &arrayType, &arrayElementSize);
+    context->uniformMatrix4fv(
+        location, transpose, valueLength / arrayElementSize / 16, reinterpret_cast<const GLfloat*>(value));
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::drawImage1(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::drawImage1(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 9);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 9);
 
-	RenderingContext2D* context = ScriptResourceTracker::ExternalToObject<RenderingContext2D>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    RenderingContext2D* context = ScriptResourceTracker::ExternalToObject<RenderingContext2D>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	int canvasWidth = ScriptHostUtilities::GLintFromJsRef(arguments[2]);
-	int canvasHeight = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	context->SetSize(canvasWidth, canvasHeight);
+    int canvasWidth = ScriptHostUtilities::GLintFromJsRef(arguments[2]);
+    int canvasHeight = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    context->SetSize(canvasWidth, canvasHeight);
 
-	auto imageElement = ScriptResourceTracker::ExternalToObject<API::ImageElement>(arguments[4]);
+    auto imageElement = ScriptResourceTracker::ExternalToObject<API::ImageElement>(arguments[4]);
 
-	int imageWidth = ScriptHostUtilities::GLintFromJsRef(arguments[5]);
-	int imageHeight = ScriptHostUtilities::GLintFromJsRef(arguments[6]);
+    int imageWidth = ScriptHostUtilities::GLintFromJsRef(arguments[5]);
+    int imageHeight = ScriptHostUtilities::GLintFromJsRef(arguments[6]);
 
-	int dx = ScriptHostUtilities::GLintFromJsRef(arguments[7]);
-	int dy = ScriptHostUtilities::GLintFromJsRef(arguments[8]);
+    int dx = ScriptHostUtilities::GLintFromJsRef(arguments[7]);
+    int dy = ScriptHostUtilities::GLintFromJsRef(arguments[8]);
 
-	context->drawImage1(imageElement, imageWidth, imageHeight, dx, dy);
-	return JS_INVALID_REFERENCE;
+    context->drawImage1(imageElement, imageWidth, imageHeight, dx, dy);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::drawImage2(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::drawImage2(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 11);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 11);
 
-	RenderingContext2D* context = ScriptResourceTracker::ExternalToObject<RenderingContext2D>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    RenderingContext2D* context = ScriptResourceTracker::ExternalToObject<RenderingContext2D>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	int canvasWidth = ScriptHostUtilities::GLintFromJsRef(arguments[2]);
-	int canvasHeight = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	context->SetSize(canvasWidth, canvasHeight);
+    int canvasWidth = ScriptHostUtilities::GLintFromJsRef(arguments[2]);
+    int canvasHeight = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    context->SetSize(canvasWidth, canvasHeight);
 
-	auto imageElement = ScriptResourceTracker::ExternalToObject<API::ImageElement>(arguments[4]);
+    auto imageElement = ScriptResourceTracker::ExternalToObject<API::ImageElement>(arguments[4]);
 
-	int imageWidth = ScriptHostUtilities::GLintFromJsRef(arguments[5]);
-	int imageHeight = ScriptHostUtilities::GLintFromJsRef(arguments[6]);
+    int imageWidth = ScriptHostUtilities::GLintFromJsRef(arguments[5]);
+    int imageHeight = ScriptHostUtilities::GLintFromJsRef(arguments[6]);
 
-	int dx = ScriptHostUtilities::GLintFromJsRef(arguments[7]);
-	int dy = ScriptHostUtilities::GLintFromJsRef(arguments[8]);
-	int dWidth = ScriptHostUtilities::GLintFromJsRef(arguments[9]);
-	int dHeight = ScriptHostUtilities::GLintFromJsRef(arguments[10]);
+    int dx = ScriptHostUtilities::GLintFromJsRef(arguments[7]);
+    int dy = ScriptHostUtilities::GLintFromJsRef(arguments[8]);
+    int dWidth = ScriptHostUtilities::GLintFromJsRef(arguments[9]);
+    int dHeight = ScriptHostUtilities::GLintFromJsRef(arguments[10]);
 
-	context->drawImage2(imageElement, imageWidth, imageHeight, dx, dx, dWidth, dHeight);
-	return JS_INVALID_REFERENCE;
+    context->drawImage2(imageElement, imageWidth, imageHeight, dx, dx, dWidth, dHeight);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::drawImage3(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::drawImage3(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 15);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 15);
 
-	RenderingContext2D* context = ScriptResourceTracker::ExternalToObject<RenderingContext2D>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    RenderingContext2D* context = ScriptResourceTracker::ExternalToObject<RenderingContext2D>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
     const auto canvasWidth = ScriptHostUtilities::GLintFromJsRef(arguments[2]);
-	const auto canvasHeight = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	context->SetSize(canvasWidth, canvasHeight);
+    const auto canvasHeight = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    context->SetSize(canvasWidth, canvasHeight);
 
-	auto imageElement = ScriptResourceTracker::ExternalToObject<API::ImageElement>(arguments[4]);
+    auto imageElement = ScriptResourceTracker::ExternalToObject<API::ImageElement>(arguments[4]);
 
-	int imageWidth = ScriptHostUtilities::GLintFromJsRef(arguments[5]);
-	int imageHeight = ScriptHostUtilities::GLintFromJsRef(arguments[6]);
+    int imageWidth = ScriptHostUtilities::GLintFromJsRef(arguments[5]);
+    int imageHeight = ScriptHostUtilities::GLintFromJsRef(arguments[6]);
 
-	int sx = ScriptHostUtilities::GLintFromJsRef(arguments[7]);
-	int sy = ScriptHostUtilities::GLintFromJsRef(arguments[8]);
-	int sWidth = ScriptHostUtilities::GLintFromJsRef(arguments[9]);
-	int sHeight = ScriptHostUtilities::GLintFromJsRef(arguments[10]);
+    int sx = ScriptHostUtilities::GLintFromJsRef(arguments[7]);
+    int sy = ScriptHostUtilities::GLintFromJsRef(arguments[8]);
+    int sWidth = ScriptHostUtilities::GLintFromJsRef(arguments[9]);
+    int sHeight = ScriptHostUtilities::GLintFromJsRef(arguments[10]);
 
-	int dx = ScriptHostUtilities::GLintFromJsRef(arguments[11]);
-	int dy = ScriptHostUtilities::GLintFromJsRef(arguments[12]);
-	int dWidth = ScriptHostUtilities::GLintFromJsRef(arguments[13]);
-	int dHeight = ScriptHostUtilities::GLintFromJsRef(arguments[14]);
+    int dx = ScriptHostUtilities::GLintFromJsRef(arguments[11]);
+    int dy = ScriptHostUtilities::GLintFromJsRef(arguments[12]);
+    int dWidth = ScriptHostUtilities::GLintFromJsRef(arguments[13]);
+    int dHeight = ScriptHostUtilities::GLintFromJsRef(arguments[14]);
 
-    
-	context->drawImage3(imageElement, imageWidth, imageHeight, sx, sy, sWidth, sHeight, dx, dx, dWidth, dHeight);
-	return JS_INVALID_REFERENCE;
+    context->drawImage3(imageElement, imageWidth, imageHeight, sx, sy, sWidth, sHeight, dx, dx, dWidth, dHeight);
+    return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::getImageData(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::getImageData(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 6);
 
-	RenderingContext2D* context = ScriptResourceTracker::ExternalToObject<RenderingContext2D>(arguments[1]);
-	
-	RETURN_INVALID_REF_IF_NULL(context);
+    RenderingContext2D* context = ScriptResourceTracker::ExternalToObject<RenderingContext2D>(arguments[1]);
 
-	int sx = ScriptHostUtilities::GLintFromJsRef(arguments[2]);
-	int sy = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
-	int sw = ScriptHostUtilities::GLintFromJsRef(arguments[4]);
-	int sh = ScriptHostUtilities::GLintFromJsRef(arguments[5]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	// Create storage for the pixels in JS
-	JsValueRef jsArray;
-	if (context->OptimizedBufferAvailable())
-	{
-		RETURN_NULL_IF_JS_ERROR(JsCreateTypedArray(JsTypedArrayType::JsArrayTypeUint8Clamped, nullptr, 0, context->GetOptimizedBufferSize(), &jsArray));
+    int sx = ScriptHostUtilities::GLintFromJsRef(arguments[2]);
+    int sy = ScriptHostUtilities::GLintFromJsRef(arguments[3]);
+    int sw = ScriptHostUtilities::GLintFromJsRef(arguments[4]);
+    int sh = ScriptHostUtilities::GLintFromJsRef(arguments[5]);
 
-		// Get a pointer to the newly allocated JS array
-		ChakraBytePtr jsArrayPointer;
-		JsTypedArrayType jsArrayType;
-		unsigned int jsArrayLength;
-		int jsArrayElementSize;
-		RETURN_NULL_IF_JS_ERROR(JsGetTypedArrayStorage(jsArray, &jsArrayPointer, &jsArrayLength, &jsArrayType, &jsArrayElementSize));
-		context->CopyOptimizedBitmapToBuffer(jsArrayPointer);
-	}
-	else
-	{
-		auto pixelsArray = context->getImageData(sx, sy, sw, sh);
+    // Create storage for the pixels in JS
+    JsValueRef jsArray;
+    if (context->OptimizedBufferAvailable()) {
+        RETURN_NULL_IF_JS_ERROR(JsCreateTypedArray(
+            JsTypedArrayType::JsArrayTypeUint8Clamped, nullptr, 0, context->GetOptimizedBufferSize(), &jsArray));
 
+        // Get a pointer to the newly allocated JS array
+        ChakraBytePtr jsArrayPointer;
+        JsTypedArrayType jsArrayType;
+        unsigned int jsArrayLength;
+        int jsArrayElementSize;
+        RETURN_NULL_IF_JS_ERROR(
+            JsGetTypedArrayStorage(jsArray, &jsArrayPointer, &jsArrayLength, &jsArrayType, &jsArrayElementSize));
+        context->CopyOptimizedBitmapToBuffer(jsArrayPointer);
+    } else {
+        auto pixelsArray = context->getImageData(sx, sy, sw, sh);
 
-		RETURN_NULL_IF_JS_ERROR(JsCreateTypedArray(JsTypedArrayType::JsArrayTypeUint8Clamped, nullptr, 0, pixelsArray->Length, &jsArray));
+        RETURN_NULL_IF_JS_ERROR(
+            JsCreateTypedArray(JsTypedArrayType::JsArrayTypeUint8Clamped, nullptr, 0, pixelsArray->Length, &jsArray));
 
-		// Get a pointer to the newly allocated JS array and copy the pixels there
-		ChakraBytePtr jsArrayPointer;
-		JsTypedArrayType jsArrayType;
-		unsigned int jsArrayLength;
-		int jsArrayElementSize;
+        // Get a pointer to the newly allocated JS array and copy the pixels there
+        ChakraBytePtr jsArrayPointer;
+        JsTypedArrayType jsArrayType;
+        unsigned int jsArrayLength;
+        int jsArrayElementSize;
 
-		RETURN_NULL_IF_JS_ERROR(JsGetTypedArrayStorage(jsArray, &jsArrayPointer, &jsArrayLength, &jsArrayType, &jsArrayElementSize));
+        RETURN_NULL_IF_JS_ERROR(
+            JsGetTypedArrayStorage(jsArray, &jsArrayPointer, &jsArrayLength, &jsArrayType, &jsArrayElementSize));
 
-		CopyMemory(jsArrayPointer, pixelsArray->begin(), pixelsArray->Length);
-	}
+        CopyMemory(jsArrayPointer, pixelsArray->begin(), pixelsArray->Length);
+    }
 
-	return jsArray;
+    return jsArray;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::stencilFunc(
-    JsValueRef callee,
-    bool isConstructCall,
-    JsValueRef* arguments,
-    unsigned short argumentCount,
-    PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::stencilFunc(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
     RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
 
@@ -2405,15 +1789,8 @@ WebGLProjections::stencilFunc(
     return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::stencilMask(
-    JsValueRef callee,
-    bool isConstructCall,
-    JsValueRef* arguments,
-    unsigned short argumentCount,
-    PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::stencilMask(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
     RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
 
@@ -2426,46 +1803,32 @@ WebGLProjections::stencilMask(
     return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::stencilOp(
-    JsValueRef callee,
-    bool isConstructCall,
-    JsValueRef* arguments,
-    unsigned short argumentCount,
-    PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::stencilOp(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
     RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
 
     WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
     RETURN_INVALID_REF_IF_NULL(context);
 
-    GLenum  fail = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
-    GLenum  zfail = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
-    GLenum  zpass = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
+    GLenum fail = ScriptHostUtilities::GLenumFromJsRef(arguments[2]);
+    GLenum zfail = ScriptHostUtilities::GLenumFromJsRef(arguments[3]);
+    GLenum zpass = ScriptHostUtilities::GLenumFromJsRef(arguments[4]);
     context->stencilOp(fail, zfail, zpass);
 
     return JS_INVALID_REFERENCE;
 }
 
-JsValueRef
-CHAKRA_CALLBACK
-WebGLProjections::lineWidth(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef* arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+JsValueRef CHAKRA_CALLBACK WebGLProjections::lineWidth(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
 
-	WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(context);
+    WebGLRenderingContext* context = ScriptResourceTracker::ExternalToObject<WebGLRenderingContext>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(context);
 
-	GLfloat width = ScriptHostUtilities::GLfloatFromJsRef(arguments[2]);
-	context->lineWidth(width);
+    GLfloat width = ScriptHostUtilities::GLfloatFromJsRef(arguments[2]);
+    context->lineWidth(width);
 
-	return JS_INVALID_REFERENCE;
+    return JS_INVALID_REFERENCE;
 }

--- a/HoloJS/HoloJsHost/WebGLProjections.h
+++ b/HoloJS/HoloJsHost/WebGLProjections.h
@@ -1,806 +1,606 @@
 #pragma once
 
-namespace HologramJS
-{
-	namespace WebGL
-	{
-		class WebGLProjections
-		{
-		public:
-
-			static bool Initialize();
-
-		private:
-
-			static JsValueRef CHAKRA_CALLBACK createContext(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK createContext2D(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			// WebGL context functions
-			static JsValueRef CHAKRA_CALLBACK getShaderPrecisionFormat(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK getExtension(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK getParameter(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK createRenderbuffer(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK bindRenderbuffer(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK renderbufferStorage(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK createFramebuffer(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK bindFramebuffer(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK framebufferRenderbuffer(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK framebufferTexture2D(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK createTexture(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK bindTexture(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK texParameteri(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK texImage2D(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK texImage2D1(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK texImage2D2(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK texImage2D3(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK texImage2D4(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK activeTexture(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK generateMipmap(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK pixelStorei(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK clearDepth(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK clearStencil(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK enable(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK disable(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK depthFunc(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK depthMask(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK depthRange(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK frontFace(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK cullFace(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK blendColor(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK blendEquation(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK blendEquationSeparate(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK blendFunc(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK blendFuncSeparate(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK scissor(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK viewport(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK clearColor(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK clear(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK createBuffer(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK deleteBuffer(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK bindBuffer(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK bufferData1(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK bufferData2(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK colorMask(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK drawArrays(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK drawElements(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK enableVertexAttribArray(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK disableVertexAttribArray(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK vertexAttribPointer(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK createProgram(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK useProgram(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK validateProgram(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK linkProgram(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK getProgramParameter(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK getProgramInfoLog(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK deleteProgram(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK bindAttribLocation(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK getActiveUniform(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK getActiveAttrib(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK getAttribLocation(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK createShader(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK shaderSource(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK compileShader(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK getShaderParameter(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK getShaderInfoLog(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK attachShader(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK deleteShader(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK getUniformLocation(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform1f(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform1fv(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform1i(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform1iv(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform2f(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform2fv(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform2i(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform2iv(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform3f(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform3fv(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform3i(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform3iv(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform4f(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform4fv(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform4i(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniform4iv(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniformMatrix2fv(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniformMatrix3fv(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK uniformMatrix4fv(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			// Canvas 3D context functions
-			static JsValueRef CHAKRA_CALLBACK drawImage1(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK drawImage2(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK drawImage3(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK getImageData(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK stencilFunc(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK stencilMask(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK stencilOp(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static JsValueRef CHAKRA_CALLBACK lineWidth(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			);
-
-			static const GLenum UNPACK_FLIP_Y_WEBGL = 0x9240;
-			static const GLenum UNPACK_PREMULTIPLY_ALPHA_WEBGL = 0x9241;
-		};
-	}
-}
-
+#include "ChakraForHoloJS.h"
+
+namespace HologramJS {
+namespace WebGL {
+class WebGLProjections {
+   public:
+    static bool Initialize();
+
+   private:
+    static JsValueRef CHAKRA_CALLBACK createContext(JsValueRef callee,
+                                                    bool isConstructCall,
+                                                    JsValueRef* arguments,
+                                                    unsigned short argumentCount,
+                                                    PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK createContext2D(JsValueRef callee,
+                                                      bool isConstructCall,
+                                                      JsValueRef* arguments,
+                                                      unsigned short argumentCount,
+                                                      PVOID callbackData);
+
+    // WebGL context functions
+    static JsValueRef CHAKRA_CALLBACK getShaderPrecisionFormat(JsValueRef callee,
+                                                               bool isConstructCall,
+                                                               JsValueRef* arguments,
+                                                               unsigned short argumentCount,
+                                                               PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK getExtension(JsValueRef callee,
+                                                   bool isConstructCall,
+                                                   JsValueRef* arguments,
+                                                   unsigned short argumentCount,
+                                                   PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK getParameter(JsValueRef callee,
+                                                   bool isConstructCall,
+                                                   JsValueRef* arguments,
+                                                   unsigned short argumentCount,
+                                                   PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK createRenderbuffer(JsValueRef callee,
+                                                         bool isConstructCall,
+                                                         JsValueRef* arguments,
+                                                         unsigned short argumentCount,
+                                                         PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK bindRenderbuffer(JsValueRef callee,
+                                                       bool isConstructCall,
+                                                       JsValueRef* arguments,
+                                                       unsigned short argumentCount,
+                                                       PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK renderbufferStorage(JsValueRef callee,
+                                                          bool isConstructCall,
+                                                          JsValueRef* arguments,
+                                                          unsigned short argumentCount,
+                                                          PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK createFramebuffer(JsValueRef callee,
+                                                        bool isConstructCall,
+                                                        JsValueRef* arguments,
+                                                        unsigned short argumentCount,
+                                                        PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK bindFramebuffer(JsValueRef callee,
+                                                      bool isConstructCall,
+                                                      JsValueRef* arguments,
+                                                      unsigned short argumentCount,
+                                                      PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK framebufferRenderbuffer(JsValueRef callee,
+                                                              bool isConstructCall,
+                                                              JsValueRef* arguments,
+                                                              unsigned short argumentCount,
+                                                              PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK framebufferTexture2D(JsValueRef callee,
+                                                           bool isConstructCall,
+                                                           JsValueRef* arguments,
+                                                           unsigned short argumentCount,
+                                                           PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK createTexture(JsValueRef callee,
+                                                    bool isConstructCall,
+                                                    JsValueRef* arguments,
+                                                    unsigned short argumentCount,
+                                                    PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK bindTexture(JsValueRef callee,
+                                                  bool isConstructCall,
+                                                  JsValueRef* arguments,
+                                                  unsigned short argumentCount,
+                                                  PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK texParameteri(JsValueRef callee,
+                                                    bool isConstructCall,
+                                                    JsValueRef* arguments,
+                                                    unsigned short argumentCount,
+                                                    PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK texImage2D(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK texImage2D1(JsValueRef callee,
+                                                  bool isConstructCall,
+                                                  JsValueRef* arguments,
+                                                  unsigned short argumentCount,
+                                                  PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK texImage2D2(JsValueRef callee,
+                                                  bool isConstructCall,
+                                                  JsValueRef* arguments,
+                                                  unsigned short argumentCount,
+                                                  PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK texImage2D3(JsValueRef callee,
+                                                  bool isConstructCall,
+                                                  JsValueRef* arguments,
+                                                  unsigned short argumentCount,
+                                                  PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK texImage2D4(JsValueRef callee,
+                                                  bool isConstructCall,
+                                                  JsValueRef* arguments,
+                                                  unsigned short argumentCount,
+                                                  PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK activeTexture(JsValueRef callee,
+                                                    bool isConstructCall,
+                                                    JsValueRef* arguments,
+                                                    unsigned short argumentCount,
+                                                    PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK generateMipmap(JsValueRef callee,
+                                                     bool isConstructCall,
+                                                     JsValueRef* arguments,
+                                                     unsigned short argumentCount,
+                                                     PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK pixelStorei(JsValueRef callee,
+                                                  bool isConstructCall,
+                                                  JsValueRef* arguments,
+                                                  unsigned short argumentCount,
+                                                  PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK clearDepth(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK clearStencil(JsValueRef callee,
+                                                   bool isConstructCall,
+                                                   JsValueRef* arguments,
+                                                   unsigned short argumentCount,
+                                                   PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK enable(JsValueRef callee,
+                                             bool isConstructCall,
+                                             JsValueRef* arguments,
+                                             unsigned short argumentCount,
+                                             PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK disable(JsValueRef callee,
+                                              bool isConstructCall,
+                                              JsValueRef* arguments,
+                                              unsigned short argumentCount,
+                                              PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK depthFunc(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK depthMask(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK depthRange(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK frontFace(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK cullFace(JsValueRef callee,
+                                               bool isConstructCall,
+                                               JsValueRef* arguments,
+                                               unsigned short argumentCount,
+                                               PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK blendColor(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK blendEquation(JsValueRef callee,
+                                                    bool isConstructCall,
+                                                    JsValueRef* arguments,
+                                                    unsigned short argumentCount,
+                                                    PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK blendEquationSeparate(JsValueRef callee,
+                                                            bool isConstructCall,
+                                                            JsValueRef* arguments,
+                                                            unsigned short argumentCount,
+                                                            PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK blendFunc(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK blendFuncSeparate(JsValueRef callee,
+                                                        bool isConstructCall,
+                                                        JsValueRef* arguments,
+                                                        unsigned short argumentCount,
+                                                        PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK scissor(JsValueRef callee,
+                                              bool isConstructCall,
+                                              JsValueRef* arguments,
+                                              unsigned short argumentCount,
+                                              PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK viewport(JsValueRef callee,
+                                               bool isConstructCall,
+                                               JsValueRef* arguments,
+                                               unsigned short argumentCount,
+                                               PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK clearColor(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK clear(JsValueRef callee,
+                                            bool isConstructCall,
+                                            JsValueRef* arguments,
+                                            unsigned short argumentCount,
+                                            PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK createBuffer(JsValueRef callee,
+                                                   bool isConstructCall,
+                                                   JsValueRef* arguments,
+                                                   unsigned short argumentCount,
+                                                   PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK deleteBuffer(JsValueRef callee,
+                                                   bool isConstructCall,
+                                                   JsValueRef* arguments,
+                                                   unsigned short argumentCount,
+                                                   PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK bindBuffer(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK bufferData1(JsValueRef callee,
+                                                  bool isConstructCall,
+                                                  JsValueRef* arguments,
+                                                  unsigned short argumentCount,
+                                                  PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK bufferData2(JsValueRef callee,
+                                                  bool isConstructCall,
+                                                  JsValueRef* arguments,
+                                                  unsigned short argumentCount,
+                                                  PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK colorMask(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK drawArrays(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK drawElements(JsValueRef callee,
+                                                   bool isConstructCall,
+                                                   JsValueRef* arguments,
+                                                   unsigned short argumentCount,
+                                                   PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK enableVertexAttribArray(JsValueRef callee,
+                                                              bool isConstructCall,
+                                                              JsValueRef* arguments,
+                                                              unsigned short argumentCount,
+                                                              PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK disableVertexAttribArray(JsValueRef callee,
+                                                               bool isConstructCall,
+                                                               JsValueRef* arguments,
+                                                               unsigned short argumentCount,
+                                                               PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK vertexAttribPointer(JsValueRef callee,
+                                                          bool isConstructCall,
+                                                          JsValueRef* arguments,
+                                                          unsigned short argumentCount,
+                                                          PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK createProgram(JsValueRef callee,
+                                                    bool isConstructCall,
+                                                    JsValueRef* arguments,
+                                                    unsigned short argumentCount,
+                                                    PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK useProgram(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK validateProgram(JsValueRef callee,
+                                                      bool isConstructCall,
+                                                      JsValueRef* arguments,
+                                                      unsigned short argumentCount,
+                                                      PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK linkProgram(JsValueRef callee,
+                                                  bool isConstructCall,
+                                                  JsValueRef* arguments,
+                                                  unsigned short argumentCount,
+                                                  PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK getProgramParameter(JsValueRef callee,
+                                                          bool isConstructCall,
+                                                          JsValueRef* arguments,
+                                                          unsigned short argumentCount,
+                                                          PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK getProgramInfoLog(JsValueRef callee,
+                                                        bool isConstructCall,
+                                                        JsValueRef* arguments,
+                                                        unsigned short argumentCount,
+                                                        PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK deleteProgram(JsValueRef callee,
+                                                    bool isConstructCall,
+                                                    JsValueRef* arguments,
+                                                    unsigned short argumentCount,
+                                                    PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK bindAttribLocation(JsValueRef callee,
+                                                         bool isConstructCall,
+                                                         JsValueRef* arguments,
+                                                         unsigned short argumentCount,
+                                                         PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK getActiveUniform(JsValueRef callee,
+                                                       bool isConstructCall,
+                                                       JsValueRef* arguments,
+                                                       unsigned short argumentCount,
+                                                       PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK getActiveAttrib(JsValueRef callee,
+                                                      bool isConstructCall,
+                                                      JsValueRef* arguments,
+                                                      unsigned short argumentCount,
+                                                      PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK getAttribLocation(JsValueRef callee,
+                                                        bool isConstructCall,
+                                                        JsValueRef* arguments,
+                                                        unsigned short argumentCount,
+                                                        PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK createShader(JsValueRef callee,
+                                                   bool isConstructCall,
+                                                   JsValueRef* arguments,
+                                                   unsigned short argumentCount,
+                                                   PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK shaderSource(JsValueRef callee,
+                                                   bool isConstructCall,
+                                                   JsValueRef* arguments,
+                                                   unsigned short argumentCount,
+                                                   PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK compileShader(JsValueRef callee,
+                                                    bool isConstructCall,
+                                                    JsValueRef* arguments,
+                                                    unsigned short argumentCount,
+                                                    PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK getShaderParameter(JsValueRef callee,
+                                                         bool isConstructCall,
+                                                         JsValueRef* arguments,
+                                                         unsigned short argumentCount,
+                                                         PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK getShaderInfoLog(JsValueRef callee,
+                                                       bool isConstructCall,
+                                                       JsValueRef* arguments,
+                                                       unsigned short argumentCount,
+                                                       PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK attachShader(JsValueRef callee,
+                                                   bool isConstructCall,
+                                                   JsValueRef* arguments,
+                                                   unsigned short argumentCount,
+                                                   PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK deleteShader(JsValueRef callee,
+                                                   bool isConstructCall,
+                                                   JsValueRef* arguments,
+                                                   unsigned short argumentCount,
+                                                   PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK getUniformLocation(JsValueRef callee,
+                                                         bool isConstructCall,
+                                                         JsValueRef* arguments,
+                                                         unsigned short argumentCount,
+                                                         PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform1f(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform1fv(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform1i(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform1iv(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform2f(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform2fv(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform2i(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform2iv(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform3f(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform3fv(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform3i(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform3iv(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform4f(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform4fv(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform4i(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniform4iv(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniformMatrix2fv(JsValueRef callee,
+                                                       bool isConstructCall,
+                                                       JsValueRef* arguments,
+                                                       unsigned short argumentCount,
+                                                       PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniformMatrix3fv(JsValueRef callee,
+                                                       bool isConstructCall,
+                                                       JsValueRef* arguments,
+                                                       unsigned short argumentCount,
+                                                       PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK uniformMatrix4fv(JsValueRef callee,
+                                                       bool isConstructCall,
+                                                       JsValueRef* arguments,
+                                                       unsigned short argumentCount,
+                                                       PVOID callbackData);
+
+    // Canvas 3D context functions
+    static JsValueRef CHAKRA_CALLBACK drawImage1(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK drawImage2(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK drawImage3(JsValueRef callee,
+                                                 bool isConstructCall,
+                                                 JsValueRef* arguments,
+                                                 unsigned short argumentCount,
+                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK getImageData(JsValueRef callee,
+                                                   bool isConstructCall,
+                                                   JsValueRef* arguments,
+                                                   unsigned short argumentCount,
+                                                   PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK stencilFunc(JsValueRef callee,
+                                                  bool isConstructCall,
+                                                  JsValueRef* arguments,
+                                                  unsigned short argumentCount,
+                                                  PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK stencilMask(JsValueRef callee,
+                                                  bool isConstructCall,
+                                                  JsValueRef* arguments,
+                                                  unsigned short argumentCount,
+                                                  PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK stencilOp(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK lineWidth(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
+
+    static const GLenum UNPACK_FLIP_Y_WEBGL = 0x9240;
+    static const GLenum UNPACK_PREMULTIPLY_ALPHA_WEBGL = 0x9241;
+};
+}  // namespace WebGL
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/WebGLRenderingContext.cpp
+++ b/HoloJS/HoloJsHost/WebGLRenderingContext.cpp
@@ -1,5 +1,4 @@
 ﻿#include "pch.h"
-#include "WebGLObjects.h"
 #include "WebGLRenderingContext.h"
 
 using namespace HologramJS::WebGL;
@@ -7,663 +6,456 @@ using namespace Platform;
 using namespace std;
 using namespace Windows::Graphics::Imaging;
 
-WebGLTexture*
-WebGLRenderingContext::createTexture()
+WebGLTexture* WebGLRenderingContext::createTexture() { return new WebGLTexture(); }
+
+void WebGLRenderingContext::bindTexture(GLenum target, WebGLTexture* texture)
 {
-    return new WebGLTexture();
+    if (texture == nullptr) {
+        glBindTexture(target, 0);
+    } else {
+        glBindTexture(target, texture->id);
+    }
 }
 
-void
-WebGLRenderingContext::bindTexture(GLenum target, WebGLTexture* texture)
-{
-	if (texture == nullptr)
-	{
-		glBindTexture(target, 0);
-	}
-	else
-	{
-		glBindTexture(target, texture->id);
-	}
-}
-
-void
-WebGLRenderingContext::texParameteri(GLenum target, GLenum pname, GLint param)
+void WebGLRenderingContext::texParameteri(GLenum target, GLenum pname, GLint param)
 {
     glTexParameteri(target, pname, param);
 }
 
-void
-WebGLRenderingContext::texImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, void* pixels)
+void WebGLRenderingContext::texImage2D(GLenum target,
+                                       GLint level,
+                                       GLenum internalformat,
+                                       GLsizei width,
+                                       GLsizei height,
+                                       GLint border,
+                                       GLenum format,
+                                       GLenum type,
+                                       void* pixels)
 {
     static std::vector<unsigned char> flipBuffer;
-    if (type == UNSIGNED_BYTE)
-    {
-		if (FlipYEnabled)
-		{
-			flipBuffer.reserve(width * height * 4);
-			unsigned char* pixelsBuffer = reinterpret_cast<unsigned char*>(pixels);
-			const size_t line_size = width * 4;
-			const int half_height = height / 2;
-			for (int i = 0; i < half_height; i++)
-			{
-				unsigned char* top_line_source = pixelsBuffer + i * line_size;
-				unsigned char* bottom_line_source = pixelsBuffer + (height - i - 1) * line_size;
-				unsigned char* top_line_destination = flipBuffer.data() + i * line_size;
-				unsigned char* bottom_line_destination = flipBuffer.data() + (height - i - 1) * line_size;
-				memcpy(bottom_line_destination, top_line_source, line_size);
-				memcpy(top_line_destination, bottom_line_source, line_size);
-			}
+    if (type == UNSIGNED_BYTE) {
+        if (FlipYEnabled) {
+            flipBuffer.reserve(width * height * 4);
+            unsigned char* pixelsBuffer = reinterpret_cast<unsigned char*>(pixels);
+            const size_t line_size = width * 4;
+            const int half_height = height / 2;
+            for (int i = 0; i < half_height; i++) {
+                unsigned char* top_line_source = pixelsBuffer + i * line_size;
+                unsigned char* bottom_line_source = pixelsBuffer + (height - i - 1) * line_size;
+                unsigned char* top_line_destination = flipBuffer.data() + i * line_size;
+                unsigned char* bottom_line_destination = flipBuffer.data() + (height - i - 1) * line_size;
+                memcpy(bottom_line_destination, top_line_source, line_size);
+                memcpy(top_line_destination, bottom_line_source, line_size);
+            }
 
-			glTexImage2D(target, level, internalformat, width, height, border, format, type, flipBuffer.data());
-		}
-		else
-		{
-			glTexImage2D(target, level, internalformat, width, height, border, format, type, pixels);
-		}
-        
-    }
-    else
-    {
+            glTexImage2D(target, level, internalformat, width, height, border, format, type, flipBuffer.data());
+        } else {
+            glTexImage2D(target, level, internalformat, width, height, border, format, type, pixels);
+        }
+
+    } else {
         throw ref new InvalidArgumentException();
     }
 }
 
-void
-WebGLRenderingContext::texImage2DNoFlip(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, void* pixels)
+void WebGLRenderingContext::texImage2DNoFlip(GLenum target,
+                                             GLint level,
+                                             GLenum internalformat,
+                                             GLsizei width,
+                                             GLsizei height,
+                                             GLint border,
+                                             GLenum format,
+                                             GLenum type,
+                                             void* pixels)
 {
-	if (type == UNSIGNED_BYTE)
-	{
-		glTexImage2D(target, level, internalformat, width, height, border, format, type, pixels);
-	}
-	else
-	{
-		throw ref new InvalidArgumentException();
-	}
+    if (type == UNSIGNED_BYTE) {
+        glTexImage2D(target, level, internalformat, width, height, border, format, type, pixels);
+    } else {
+        throw ref new InvalidArgumentException();
+    }
 }
 
-void
-WebGLRenderingContext::activeTexture(GLenum texture)
+void WebGLRenderingContext::activeTexture(GLenum texture) { glActiveTexture(texture); }
+
+void WebGLRenderingContext::generateMipmap(GLenum target) { glGenerateMipmap(target); }
+
+void WebGLRenderingContext::pixelStorei(GLenum pname, GLint param) { glPixelStorei(pname, param); }
+
+void WebGLRenderingContext::pixelStorei(GLenum pname, GLboolean param)
 {
-	glActiveTexture(texture);
+    if (pname == UNPACK_FLIP_Y_WEBGL) {
+        FlipYEnabled = (param == 0 ? false : true);
+    }
+
+    glPixelStorei(pname, param);
 }
 
-void
-WebGLRenderingContext::generateMipmap(GLenum target)
-{
-	glGenerateMipmap(target);
-}
+void WebGLRenderingContext::clearDepth(GLclampf depth) { glClearDepthf(depth); }
 
-void
-WebGLRenderingContext::pixelStorei(GLenum pname, GLint param)
-{
-	glPixelStorei(pname, param);
-}
+void WebGLRenderingContext::clearStencil(GLint s) { glClearStencil(s); }
 
-void
-WebGLRenderingContext::pixelStorei(GLenum pname, GLboolean param)
-{
-	if (pname == UNPACK_FLIP_Y_WEBGL)
-	{
-		FlipYEnabled = (param == 0 ? false : true);
-	}
+void WebGLRenderingContext::enable(GLenum cap) { glEnable(cap); }
 
-	glPixelStorei(pname, param);
-}
+void WebGLRenderingContext::depthFunc(GLenum func) { glDepthFunc(func); }
 
-void
-WebGLRenderingContext::clearDepth(GLclampf depth)
-{
-    glClearDepthf(depth);
-}
+void WebGLRenderingContext::depthMask(GLboolean flag) { glDepthMask(flag); }
+void WebGLRenderingContext::depthRange(GLclampf zNear, GLclampf zFar) { glDepthRangef(zNear, zFar); }
 
-void
-WebGLRenderingContext::clearStencil(GLint s)
-{
-    glClearStencil(s);
-}
+void WebGLRenderingContext::frontFace(GLenum mode) { glFrontFace(mode); }
 
-void
-WebGLRenderingContext::enable(GLenum cap)
-{
-    glEnable(cap);
-}
+void WebGLRenderingContext::cullFace(GLenum mode) { glCullFace(mode); }
 
-void
-WebGLRenderingContext::depthFunc(GLenum func)
-{
-    glDepthFunc(func);
-}
-
-void
-WebGLRenderingContext::depthMask(GLboolean flag)
-{
-	glDepthMask(flag);
-}
-void
-WebGLRenderingContext::depthRange(GLclampf zNear, GLclampf zFar)
-{
-	glDepthRangef(zNear, zFar);
-}
-
-void
-WebGLRenderingContext::frontFace(GLenum mode)
-{
-    glFrontFace(mode);
-}
-
-void
-WebGLRenderingContext::cullFace(GLenum mode)
-{
-    glCullFace(mode);
-}
-
-void
-WebGLRenderingContext::blendColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha)
+void WebGLRenderingContext::blendColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha)
 {
     glBlendColor(red, green, blue, alpha);
 }
 
-void
-WebGLRenderingContext::blendEquation(GLenum mode)
-{
-    glBlendEquation(mode);
-}
+void WebGLRenderingContext::blendEquation(GLenum mode) { glBlendEquation(mode); }
 
-void
-WebGLRenderingContext::blendEquationSeparate(GLenum modeRGB, GLenum modeAlpha)
+void WebGLRenderingContext::blendEquationSeparate(GLenum modeRGB, GLenum modeAlpha)
 {
     glBlendEquationSeparate(modeRGB, modeAlpha);
 }
 
-void
-WebGLRenderingContext::blendFunc(GLenum sfactor, GLenum dfactor)
-{
-    glBlendFunc(sfactor, dfactor);
-}
+void WebGLRenderingContext::blendFunc(GLenum sfactor, GLenum dfactor) { glBlendFunc(sfactor, dfactor); }
 
-void
-WebGLRenderingContext::blendFuncSeparate(GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha)
+void WebGLRenderingContext::blendFuncSeparate(GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha)
 {
     glBlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
 }
 
-void
-WebGLRenderingContext::scissor(GLint x, GLint y, GLsizei width, GLsizei height)
+void WebGLRenderingContext::scissor(GLint x, GLint y, GLsizei width, GLsizei height) { glScissor(x, y, width, height); }
+
+void WebGLRenderingContext::viewport(GLint x, GLint y, GLsizei width, GLsizei height)
 {
-    glScissor(x, y, width, height);
+    glViewport(x, y, width, height);
 }
 
-void
-WebGLRenderingContext::viewport(GLint x, GLint y, GLsizei width, GLsizei height)
+void WebGLRenderingContext::clearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha)
 {
-	glViewport(x, y, width, height);
+    glClearColor(red, green, blue, alpha);
 }
 
-void
-WebGLRenderingContext::clearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha)
+WebGLBuffer* WebGLRenderingContext::createBuffer() { return new WebGLBuffer(); }
+
+void WebGLRenderingContext::deleteBuffer(WebGLBuffer* buffer)
 {
-	glClearColor(red, green, blue, alpha);
+    if (buffer != nullptr) {
+        glDeleteBuffers(1, &buffer->id);
+    }
 }
 
-WebGLBuffer*
-WebGLRenderingContext::createBuffer()
+void WebGLRenderingContext::bindBuffer(GLenum target, WebGLBuffer* buffer)
 {
-	return new WebGLBuffer();	
+    if (buffer == nullptr) {
+        glBindBuffer(target, 0);
+    } else {
+        buffer->Bind(target);
+    }
 }
 
-void
-WebGLRenderingContext::deleteBuffer(WebGLBuffer* buffer)
+void WebGLRenderingContext::bufferData(GLenum target, GLsizeiptr size, void* data, GLenum usage)
 {
-	if (buffer != nullptr)
-	{
-		glDeleteBuffers(1, &buffer->id);
-	}
+    glBufferData(target, size, data, usage);
 }
 
+void WebGLRenderingContext::disable(GLenum cap) { glDisable(cap); }
 
-void
-WebGLRenderingContext::bindBuffer(GLenum target, WebGLBuffer* buffer)
+void WebGLRenderingContext::clear(GLbitfield mask) { glClear(mask); }
+
+void WebGLRenderingContext::colorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha)
 {
-	if (buffer == nullptr)
-	{
-		glBindBuffer(target, 0);
-	}
-	else
-	{
-		buffer->Bind(target);
-	}
+    glColorMask(red, green, blue, alpha);
 }
 
-void
-WebGLRenderingContext::bufferData(GLenum target, GLsizeiptr size, void* data, GLenum usage)
+WebGLProgram* WebGLRenderingContext::createProgram() { return new WebGLProgram(); }
+
+WebGLShader* WebGLRenderingContext::createShader(GLenum type) { return new WebGLShader(type); }
+
+void WebGLRenderingContext::shaderSource(WebGLShader* shader, std::wstring& source)
 {
-	glBufferData(target, size, data, usage);
+    string sourceAnsi(source.begin(), source.end());
+    shader->SetSource(sourceAnsi.c_str());
 }
 
-void
-WebGLRenderingContext::disable(GLenum cap)
+void WebGLRenderingContext::compileShader(WebGLShader* shader) { shader->Compile(); }
+
+JsValueRef WebGLRenderingContext::getShaderParameter(WebGLShader* shader, GLenum pname)
 {
-	glDisable(cap);
+    return shader->GetParameter(pname);
 }
 
-void
-WebGLRenderingContext::clear(GLbitfield mask)
+std::wstring WebGLRenderingContext::getShaderInfoLog(WebGLShader* shader) { return shader->GetInfoLog(); }
+
+void WebGLRenderingContext::attachShader(WebGLProgram* program, WebGLShader* shader) { program->AttachShader(shader); }
+
+void WebGLRenderingContext::bindAttribLocation(WebGLProgram* program, GLuint index, std::wstring& name)
 {
-	glClear(mask);
+    string ansiName(name.begin(), name.end());
+    program->BindAttribLocation(index, ansiName.c_str());
 }
 
-void
-WebGLRenderingContext::colorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha)
+void WebGLRenderingContext::enableVertexAttribArray(GLuint index) { glEnableVertexAttribArray(index); }
+
+void WebGLRenderingContext::disableVertexAttribArray(GLuint index) { glDisableVertexAttribArray(index); }
+
+void WebGLRenderingContext::linkProgram(WebGLProgram* program) { program->Link(); }
+
+JsValueRef WebGLRenderingContext::getProgramParameter(WebGLProgram* program, GLenum pname)
 {
-	glColorMask(red, green, blue, alpha);
+    return program->GetParameter(pname);
 }
 
-WebGLProgram*
-WebGLRenderingContext::createProgram()
+std::wstring WebGLRenderingContext::getProgramInfoLog(WebGLProgram* program) { return program->GetInfoLog(); }
+
+void WebGLRenderingContext::deleteProgram(WebGLProgram* program) { program->Delete(); }
+
+void WebGLRenderingContext::deleteShader(WebGLShader* shader) { shader->Delete(); }
+
+WebGLActiveInfo* WebGLRenderingContext::getActiveUniform(WebGLProgram* program, GLuint index)
 {
-	return new WebGLProgram();
+    return program->GetActiveUniform(index);
 }
 
-WebGLShader*
-WebGLRenderingContext::createShader(GLenum type)
+WebGLUniformLocation* WebGLRenderingContext::getUniformLocation(WebGLProgram* program, std::wstring& name)
 {
-	return new WebGLShader(type);
+    string ansiName(name.begin(), name.end());
+    return program->GetUniformLocation(ansiName.c_str());
 }
 
-void
-WebGLRenderingContext::shaderSource(WebGLShader* shader, std::wstring& source)
+WebGLActiveInfo* WebGLRenderingContext::getActiveAttrib(WebGLProgram* program, GLuint index)
 {
-	string sourceAnsi(source.begin(), source.end());
-	shader->SetSource(sourceAnsi.c_str());
+    return program->GetActiveAttrib(index);
 }
 
-void
-WebGLRenderingContext::compileShader(WebGLShader* shader)
+GLint WebGLRenderingContext::getAttribLocation(WebGLProgram* program, std::wstring& name)
 {
-	shader->Compile();
+    string ansiName(name.begin(), name.end());
+    return program->GetAttribLocation(ansiName.c_str());
 }
 
-JsValueRef
-WebGLRenderingContext::getShaderParameter(WebGLShader* shader, GLenum pname)
-{
-	return shader->GetParameter(pname);
-}
+void WebGLRenderingContext::useProgram(WebGLProgram* program) { program->Use(); }
 
-std::wstring
-WebGLRenderingContext::getShaderInfoLog(WebGLShader* shader)
-{
-	return shader->GetInfoLog();
-}
+void WebGLRenderingContext::validateProgram(WebGLProgram* program) { program->Validate(); }
 
-void
-WebGLRenderingContext::attachShader(WebGLProgram* program, WebGLShader* shader)
-{
-	program->AttachShader(shader);
-}
+void WebGLRenderingContext::uniform1f(WebGLUniformLocation* location, GLfloat x) { glUniform1f(location->location, x); }
 
-void
-WebGLRenderingContext::bindAttribLocation(WebGLProgram* program, GLuint index, std::wstring& name)
-{
-	string ansiName(name.begin(), name.end());
-	program->BindAttribLocation(index, ansiName.c_str());
-}
-
-void
-WebGLRenderingContext::enableVertexAttribArray(GLuint index)
-{
-    glEnableVertexAttribArray(index);
-}
-
-void
-WebGLRenderingContext::disableVertexAttribArray(GLuint index)
-{
-    glDisableVertexAttribArray(index);
-}
-
-void
-WebGLRenderingContext::linkProgram(WebGLProgram* program)
-{
-	program->Link();
-}
-
-JsValueRef
-WebGLRenderingContext::getProgramParameter(WebGLProgram* program, GLenum pname)
-{
-	return program->GetParameter(pname);
-}
-
-std::wstring
-WebGLRenderingContext::getProgramInfoLog(WebGLProgram* program)
-{
-	return program->GetInfoLog();
-}
-
-void
-WebGLRenderingContext::deleteProgram(WebGLProgram* program)
-{
-	program->Delete();
-}
-
-void
-WebGLRenderingContext::deleteShader(WebGLShader* shader)
-{
-	shader->Delete();
-}
-
-WebGLActiveInfo*
-WebGLRenderingContext::getActiveUniform(WebGLProgram* program, GLuint index)
-{
-	return program->GetActiveUniform(index);
-}
-
-WebGLUniformLocation*
-WebGLRenderingContext::getUniformLocation(WebGLProgram* program, std::wstring& name)
-{
-	string ansiName(name.begin(), name.end());
-	return program->GetUniformLocation(ansiName.c_str());
-}
-
-WebGLActiveInfo*
-WebGLRenderingContext::getActiveAttrib(WebGLProgram* program, GLuint index)
-{
-	return program->GetActiveAttrib(index);
-}
-
-GLint
-WebGLRenderingContext::getAttribLocation(WebGLProgram* program, std::wstring& name)
-{
-	string ansiName(name.begin(), name.end());
-	return program->GetAttribLocation(ansiName.c_str());
-}
-
-void
-WebGLRenderingContext::useProgram(WebGLProgram* program)
-{
-	program->Use();
-}
-
-void
-WebGLRenderingContext::validateProgram(WebGLProgram* program)
-{
-	program->Validate();
-}
-
-void
-WebGLRenderingContext::uniform1f(WebGLUniformLocation* location, GLfloat x)
-{
-    glUniform1f(location->location, x);
-}
-
-void
-WebGLRenderingContext::uniform1fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v)
+void WebGLRenderingContext::uniform1fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v)
 {
     glUniform1fv(location->location, count, v);
 }
 
-void
-WebGLRenderingContext::uniform1i(WebGLUniformLocation* location, GLint x)
-{
-    glUniform1i(location->location, x);
-}
+void WebGLRenderingContext::uniform1i(WebGLUniformLocation* location, GLint x) { glUniform1i(location->location, x); }
 
-void
-WebGLRenderingContext::uniform1iv(WebGLUniformLocation* location, GLsizei count, const GLint* v)
+void WebGLRenderingContext::uniform1iv(WebGLUniformLocation* location, GLsizei count, const GLint* v)
 {
     glUniform1iv(location->location, count, v);
 }
 
-void
-WebGLRenderingContext::uniform2f(WebGLUniformLocation* location, GLfloat x, GLfloat y)
+void WebGLRenderingContext::uniform2f(WebGLUniformLocation* location, GLfloat x, GLfloat y)
 {
     glUniform2f(location->location, x, y);
 }
 
-void
-WebGLRenderingContext::uniform2fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v)
+void WebGLRenderingContext::uniform2fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v)
 {
     glUniform2fv(location->location, count, (GLfloat*)v);
 }
 
-void
-WebGLRenderingContext::uniform2i(WebGLUniformLocation* location, GLint x, GLint y)
+void WebGLRenderingContext::uniform2i(WebGLUniformLocation* location, GLint x, GLint y)
 {
     glUniform2i(location->location, x, y);
 }
 
-void
-WebGLRenderingContext::uniform2iv(WebGLUniformLocation* location, GLsizei count, const GLint* v)
+void WebGLRenderingContext::uniform2iv(WebGLUniformLocation* location, GLsizei count, const GLint* v)
 {
     glUniform2iv(location->location, count, v);
 }
 
-void
-WebGLRenderingContext::uniform3f(WebGLUniformLocation* location, GLfloat x, GLfloat y, GLfloat z)
+void WebGLRenderingContext::uniform3f(WebGLUniformLocation* location, GLfloat x, GLfloat y, GLfloat z)
 {
     glUniform3f(location->location, x, y, z);
 }
 
-void
-WebGLRenderingContext::uniform3fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v)
+void WebGLRenderingContext::uniform3fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v)
 {
     glUniform3fv(location->location, count, v);
 }
 
-void
-WebGLRenderingContext::uniform3i(WebGLUniformLocation* location, GLint x, GLint y, GLint z)
+void WebGLRenderingContext::uniform3i(WebGLUniformLocation* location, GLint x, GLint y, GLint z)
 {
     glUniform3i(location->location, x, y, z);
 }
 
-void
-WebGLRenderingContext::uniform3iv(WebGLUniformLocation* location, GLsizei count, const GLint* v)
+void WebGLRenderingContext::uniform3iv(WebGLUniformLocation* location, GLsizei count, const GLint* v)
 {
     glUniform3iv(location->location, count, v);
 }
 
-void
-WebGLRenderingContext::uniform4f(WebGLUniformLocation* location, GLfloat x, GLfloat y, GLfloat z, GLfloat w)
+void WebGLRenderingContext::uniform4f(WebGLUniformLocation* location, GLfloat x, GLfloat y, GLfloat z, GLfloat w)
 {
     glUniform4f(location->location, x, y, z, w);
 }
 
-void
-WebGLRenderingContext::uniform4fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v)
+void WebGLRenderingContext::uniform4fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v)
 {
     glUniform4fv(location->location, count, v);
 }
 
-void
-WebGLRenderingContext::uniform4i(WebGLUniformLocation* location, GLint x, GLint y, GLint z, GLint w)
+void WebGLRenderingContext::uniform4i(WebGLUniformLocation* location, GLint x, GLint y, GLint z, GLint w)
 {
     glUniform4i(location->location, x, y, z, w);
 }
 
-void
-WebGLRenderingContext::uniform4iv(WebGLUniformLocation* location, GLsizei count, const GLint* v)
+void WebGLRenderingContext::uniform4iv(WebGLUniformLocation* location, GLsizei count, const GLint* v)
 {
     glUniform4iv(location->location, count, v);
 }
 
-void
-WebGLRenderingContext::uniformMatrix2fv(WebGLUniformLocation* location, GLboolean transpose, GLsizei count, const GLfloat* value)
+void WebGLRenderingContext::uniformMatrix2fv(WebGLUniformLocation* location,
+                                             GLboolean transpose,
+                                             GLsizei count,
+                                             const GLfloat* value)
 {
     glUniformMatrix2fv(location->location, 1, transpose, value);
 }
 
-void
-WebGLRenderingContext::uniformMatrix3fv(WebGLUniformLocation* location, GLboolean transpose, GLsizei count, const GLfloat* value)
+void WebGLRenderingContext::uniformMatrix3fv(WebGLUniformLocation* location,
+                                             GLboolean transpose,
+                                             GLsizei count,
+                                             const GLfloat* value)
 {
     glUniformMatrix3fv(location->location, 1, transpose, value);
 }
 
-void
-WebGLRenderingContext::uniformMatrix4fv(WebGLUniformLocation* location, GLboolean transpose, GLsizei count, const GLfloat* value)
+void WebGLRenderingContext::uniformMatrix4fv(WebGLUniformLocation* location,
+                                             GLboolean transpose,
+                                             GLsizei count,
+                                             const GLfloat* value)
 {
     glUniformMatrix4fv(location->location, 1, transpose, value);
 }
 
-void
-WebGLRenderingContext::drawArrays(GLenum mode, GLint first, GLsizei count)
-{
-    glDrawArrays(mode, first, count);
-}
+void WebGLRenderingContext::drawArrays(GLenum mode, GLint first, GLsizei count) { glDrawArrays(mode, first, count); }
 
-void
-WebGLRenderingContext::vertexAttribPointer(GLuint indx, GLint size, GLenum type, GLboolean normalized, GLsizei stride, GLint offset)
+void WebGLRenderingContext::vertexAttribPointer(
+    GLuint indx, GLint size, GLenum type, GLboolean normalized, GLsizei stride, GLint offset)
 {
     glVertexAttribPointer(indx, size, type, normalized, stride, (const void*)offset);
 }
 
-void
-WebGLRenderingContext::drawElements(GLenum mode, GLsizei count, GLenum type, GLint offset)
+void WebGLRenderingContext::drawElements(GLenum mode, GLsizei count, GLenum type, GLint offset)
 {
     glDrawElements(mode, count, type, (const void*)offset);
 }
 
-WebGLRenderbuffer*
-WebGLRenderingContext::createRenderbuffer()
+WebGLRenderbuffer* WebGLRenderingContext::createRenderbuffer() { return new WebGLRenderbuffer(); }
+
+void WebGLRenderingContext::bindRenderbuffer(GLenum target, WebGLRenderbuffer* renderbuffer)
 {
-	return new WebGLRenderbuffer();
+    if (renderbuffer == nullptr) {
+        glBindRenderbuffer(target, 0);
+    } else {
+        renderbuffer->bindRenderbuffer(target);
+    }
 }
 
-void
-WebGLRenderingContext::bindRenderbuffer(GLenum target, WebGLRenderbuffer* renderbuffer)
+void WebGLRenderingContext::renderbufferStorage(GLenum target, GLenum internalformat, GLsizei width, GLsizei height)
 {
-	if (renderbuffer == nullptr)
-	{
-		glBindRenderbuffer(target, 0);
-	}
-	else
-	{
-		renderbuffer->bindRenderbuffer(target);
-	}
+    glRenderbufferStorage(target, internalformat, width, height);
 }
 
-void
-WebGLRenderingContext::renderbufferStorage(GLenum target, GLenum internalformat, GLsizei width, GLsizei height)
+WebGLFramebuffer* WebGLRenderingContext::createFramebuffer() { return new WebGLFramebuffer(); }
+
+void WebGLRenderingContext::bindFramebuffer(GLenum target, WebGLFramebuffer* framebuffer)
 {
-	glRenderbufferStorage(target, internalformat, width, height);
+    if (framebuffer == nullptr) {
+        glBindFramebuffer(target, 0);
+    } else {
+        framebuffer->bindFramebuffer(target);
+    }
 }
 
-WebGLFramebuffer*
-WebGLRenderingContext::createFramebuffer()
+void WebGLRenderingContext::framebufferRenderbuffer(GLenum target,
+                                                    GLenum attachment,
+                                                    GLenum renderbuffertarget,
+                                                    WebGLRenderbuffer* renderbuffer)
 {
-	return new WebGLFramebuffer();
+    if (renderbuffer == nullptr) {
+        glFramebufferRenderbuffer(target, attachment, renderbuffertarget, 0);
+    } else {
+        renderbuffer->framebufferRenderbuffer(target, attachment, renderbuffertarget);
+    }
 }
 
-void
-WebGLRenderingContext::bindFramebuffer(GLenum target, WebGLFramebuffer* framebuffer)
+void WebGLRenderingContext::framebufferTexture2D(
+    GLenum target, GLenum attachment, GLenum textarget, WebGLTexture* texture, GLint level)
 {
-	if (framebuffer == nullptr)
-	{
-		glBindFramebuffer(target, 0);
-	}
-	else
-	{
-		framebuffer->bindFramebuffer(target);
-	}
-}
-
-void
-WebGLRenderingContext::framebufferRenderbuffer(GLenum target, GLenum attachment, GLenum renderbuffertarget, WebGLRenderbuffer* renderbuffer)
-{
-	if (renderbuffer == nullptr)
-	{
-		glFramebufferRenderbuffer(target, attachment, renderbuffertarget, 0);
-	}
-	else
-	{
-		renderbuffer->framebufferRenderbuffer(target, attachment, renderbuffertarget);
-	}
-}
-
-void
-WebGLRenderingContext::framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, WebGLTexture* texture, GLint level)
-{
-	if (texture == nullptr)
-	{
-		glFramebufferTexture2D(target, attachment, textarget, 0, level);
-	}
-	else
-	{
+    if (texture == nullptr) {
+        glFramebufferTexture2D(target, attachment, textarget, 0, level);
+    } else {
         texture->framebufferTexture2D(target, attachment, textarget, level);
-	}
+    }
 }
 
-JsValueRef
-WebGLRenderingContext::getParameter(GLenum pname)
+JsValueRef WebGLRenderingContext::getParameter(GLenum pname)
 {
-    static int intParameters[] = {
-        GL_MAX_VERTEX_ATTRIBS,
-        GL_MAX_VERTEX_UNIFORM_VECTORS,
-        GL_MAX_VARYING_VECTORS,
-        GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS,
-        GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS,
-        GL_MAX_TEXTURE_IMAGE_UNITS,
-        GL_MAX_FRAGMENT_UNIFORM_VECTORS,
-        GL_MAX_TEXTURE_SIZE,
-        GL_MAX_CUBE_MAP_TEXTURE_SIZE,
-		GL_MAX_RENDERBUFFER_SIZE };
+    static int intParameters[] = {GL_MAX_VERTEX_ATTRIBS,
+                                  GL_MAX_VERTEX_UNIFORM_VECTORS,
+                                  GL_MAX_VARYING_VECTORS,
+                                  GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS,
+                                  GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS,
+                                  GL_MAX_TEXTURE_IMAGE_UNITS,
+                                  GL_MAX_FRAGMENT_UNIFORM_VECTORS,
+                                  GL_MAX_TEXTURE_SIZE,
+                                  GL_MAX_CUBE_MAP_TEXTURE_SIZE,
+                                  GL_MAX_RENDERBUFFER_SIZE};
 
     bool isIntParameter = false;
-    for (auto param : intParameters)
-    {
-        if (param == pname)
-        {
+    for (auto param : intParameters) {
+        if (param == pname) {
             isIntParameter = true;
             break;
         }
     }
 
-    if (isIntParameter)
-    {
+    if (isIntParameter) {
         GLint retValue;
         glGetIntegerv(pname, &retValue);
-		JsValueRef retJsValue;
-		RETURN_NULL_IF_JS_ERROR(JsIntToNumber(retValue, &retJsValue));
-		return retJsValue;
-    }
-	else if (pname == UNPACK_FLIP_Y_WEBGL)
-	{
-		JsValueRef retJsValue;
-		RETURN_NULL_IF_JS_ERROR(JsBoolToBoolean(FlipYEnabled, &retJsValue));
-		return retJsValue;
-	}
-    else if (pname == UNPACK_PREMULTIPLY_ALPHA_WEBGL)
-    {
-		JsValueRef retJsValue;
-		RETURN_NULL_IF_JS_ERROR(JsBoolToBoolean(false, &retJsValue));
-		return retJsValue;
-    }
-    else if (pname == GL_VIEWPORT)
-    {
-		JsValueRef retArray;
-		RETURN_NULL_IF_JS_ERROR(JsCreateTypedArray(JsTypedArrayType::JsArrayTypeInt32, nullptr, 0, 4, &retArray));
-		JsTypedArrayType type;
-		int elementSize;
-		ChakraBytePtr buffer;
-		unsigned int bufferLength;
-		RETURN_NULL_IF_JS_ERROR(JsGetTypedArrayStorage(retArray, &buffer, &bufferLength, &type, &elementSize));
+        JsValueRef retJsValue;
+        RETURN_NULL_IF_JS_ERROR(JsIntToNumber(retValue, &retJsValue));
+        return retJsValue;
+    } else if (pname == UNPACK_FLIP_Y_WEBGL) {
+        JsValueRef retJsValue;
+        RETURN_NULL_IF_JS_ERROR(JsBoolToBoolean(FlipYEnabled, &retJsValue));
+        return retJsValue;
+    } else if (pname == UNPACK_PREMULTIPLY_ALPHA_WEBGL) {
+        JsValueRef retJsValue;
+        RETURN_NULL_IF_JS_ERROR(JsBoolToBoolean(false, &retJsValue));
+        return retJsValue;
+    } else if (pname == GL_VIEWPORT) {
+        JsValueRef retArray;
+        RETURN_NULL_IF_JS_ERROR(JsCreateTypedArray(JsTypedArrayType::JsArrayTypeInt32, nullptr, 0, 4, &retArray));
+        JsTypedArrayType type;
+        int elementSize;
+        ChakraBytePtr buffer;
+        unsigned int bufferLength;
+        RETURN_NULL_IF_JS_ERROR(JsGetTypedArrayStorage(retArray, &buffer, &bufferLength, &type, &elementSize));
 
         glGetIntegerv(GL_VIEWPORT, reinterpret_cast<GLint*>(buffer));
 
-		return retArray;
-    }
-	else if (pname == GL_VERSION)
-	{
-		wstring versionString = L"WebGL 1.0";
-		JsValueRef retJsValue;
-		JsPointerToString(versionString.c_str(), versionString.length(), &retJsValue);
-		return retJsValue;
-	}
-    else
-    {
-		return nullptr;
+        return retArray;
+    } else if (pname == GL_VERSION) {
+        wstring versionString = L"WebGL 1.0";
+        JsValueRef retJsValue;
+        JsPointerToString(versionString.c_str(), versionString.length(), &retJsValue);
+        return retJsValue;
+    } else {
+        return nullptr;
     }
 }
 
-WebGLShaderPrecisionFormat*
-WebGLRenderingContext::getShaderPrecisionFormat(GLenum shadertype, GLenum precisiontype)
+WebGLShaderPrecisionFormat* WebGLRenderingContext::getShaderPrecisionFormat(GLenum shadertype, GLenum precisiontype)
 {
     GLint range[2];
     GLint precision;
@@ -671,26 +463,10 @@ WebGLRenderingContext::getShaderPrecisionFormat(GLenum shadertype, GLenum precis
     return new WebGLShaderPrecisionFormat(range[0], range[1], precision);
 }
 
-void
-WebGLRenderingContext::stencilFunc(GLenum func, GLint ref, GLuint mask)
-{
-    glStencilFunc(func, ref, mask);
-}
+void WebGLRenderingContext::stencilFunc(GLenum func, GLint ref, GLuint mask) { glStencilFunc(func, ref, mask); }
 
-void
-WebGLRenderingContext::stencilMask(GLuint mask)
-{
-    glStencilMask(mask);
-}
+void WebGLRenderingContext::stencilMask(GLuint mask) { glStencilMask(mask); }
 
-void
-WebGLRenderingContext::stencilOp(GLenum fail, GLenum zfail, GLenum zpass)
-{
-    glStencilOp(fail, zfail, zpass);
-}
+void WebGLRenderingContext::stencilOp(GLenum fail, GLenum zfail, GLenum zpass) { glStencilOp(fail, zfail, zpass); }
 
-void
-WebGLRenderingContext::lineWidth(GLfloat width)
-{
-	glLineWidth(width);
-}
+void WebGLRenderingContext::lineWidth(GLfloat width) { glLineWidth(width); }

--- a/HoloJS/HoloJsHost/WebGLRenderingContext.h
+++ b/HoloJS/HoloJsHost/WebGLRenderingContext.h
@@ -1,186 +1,206 @@
 ﻿#pragma once
 
-namespace HologramJS
-{
-	namespace WebGL
-	{
-		class WebGLRenderingContext : public HologramJS::Utilities::IRelease
-		{
-		public:
-			WebGLRenderingContext() {}
+#include "IRelease.h"
+#include "ChakraForHoloJS.h"
+#include "WebGLObjects.h"
 
-			void Release() {}
+namespace HologramJS {
+namespace WebGL {
+class WebGLRenderingContext : public HologramJS::Utilities::IRelease {
+   public:
+    WebGLRenderingContext() {}
 
-			WebGLShaderPrecisionFormat* getShaderPrecisionFormat(GLenum shadertype, GLenum precisiontype);
+    void Release() {}
 
-			//Object^ getExtension(Platform::String^ name);
-			JsValueRef getParameter(GLenum pname);
+    WebGLShaderPrecisionFormat* getShaderPrecisionFormat(GLenum shadertype, GLenum precisiontype);
+
+    // Object^ getExtension(Platform::String^ name);
+    JsValueRef getParameter(GLenum pname);
 
 #pragma region Frame and render buffers
-			WebGLRenderbuffer* createRenderbuffer();
-			void bindRenderbuffer(GLenum target, WebGLRenderbuffer* renderbuffer);
-			void renderbufferStorage(GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
+    WebGLRenderbuffer* createRenderbuffer();
+    void bindRenderbuffer(GLenum target, WebGLRenderbuffer* renderbuffer);
+    void renderbufferStorage(GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
 
-			WebGLFramebuffer* createFramebuffer();
-			void bindFramebuffer(GLenum target, WebGLFramebuffer* framebuffer);
+    WebGLFramebuffer* createFramebuffer();
+    void bindFramebuffer(GLenum target, WebGLFramebuffer* framebuffer);
 
-			void framebufferRenderbuffer(GLenum target, GLenum attachment, GLenum renderbuffertarget, WebGLRenderbuffer* renderbuffer);
+    void framebufferRenderbuffer(GLenum target,
+                                 GLenum attachment,
+                                 GLenum renderbuffertarget,
+                                 WebGLRenderbuffer* renderbuffer);
 
-			void framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, WebGLTexture* texture, GLint level);
+    void framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, WebGLTexture* texture, GLint level);
 #pragma endregion
 
 #pragma region Textures
-			WebGLTexture* createTexture();
+    WebGLTexture* createTexture();
 
-			void  bindTexture(GLenum target, WebGLTexture* texture);
+    void bindTexture(GLenum target, WebGLTexture* texture);
 
-			void texParameteri(GLenum target, GLenum pname, GLint param);
+    void texParameteri(GLenum target, GLenum pname, GLint param);
 
-			void texImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, void* pixels);
-			void texImage2DNoFlip(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, void* pixels);
+    void texImage2D(GLenum target,
+                    GLint level,
+                    GLenum internalformat,
+                    GLsizei width,
+                    GLsizei height,
+                    GLint border,
+                    GLenum format,
+                    GLenum type,
+                    void* pixels);
+    void texImage2DNoFlip(GLenum target,
+                          GLint level,
+                          GLenum internalformat,
+                          GLsizei width,
+                          GLsizei height,
+                          GLint border,
+                          GLenum format,
+                          GLenum type,
+                          void* pixels);
 
-			//void texImage2D(GLenum target, GLint level, GLenum internalformat, GLenum format, GLenum type, WebGLRenderer::RenderingContext2D* context2D);
+    // void texImage2D(GLenum target, GLint level, GLenum internalformat, GLenum format, GLenum type,
+    // WebGLRenderer::RenderingContext2D* context2D);
 
-			void activeTexture(GLenum texture);
-			void generateMipmap(GLenum target);
-			void pixelStorei(GLenum pname, GLint param);
-			void pixelStorei(GLenum pname, GLboolean param);
+    void activeTexture(GLenum texture);
+    void generateMipmap(GLenum target);
+    void pixelStorei(GLenum pname, GLint param);
+    void pixelStorei(GLenum pname, GLboolean param);
 #pragma endregion
 
-			void clearDepth(GLclampf depth);
+    void clearDepth(GLclampf depth);
 
-			void clearStencil(GLint s);
+    void clearStencil(GLint s);
 
-			void enable(GLenum cap);
-			void disable(GLenum cap);
+    void enable(GLenum cap);
+    void disable(GLenum cap);
 
-			void depthFunc(GLenum func);
+    void depthFunc(GLenum func);
 
-			void depthMask(GLboolean flag);
-			void depthRange(GLclampf zNear, GLclampf zFar);
+    void depthMask(GLboolean flag);
+    void depthRange(GLclampf zNear, GLclampf zFar);
 
-			void frontFace(GLenum mode);
+    void frontFace(GLenum mode);
 
-			void cullFace(GLenum mode);
+    void cullFace(GLenum mode);
 
-			void blendColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha);
+    void blendColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha);
 
-			void blendEquation(GLenum mode);
+    void blendEquation(GLenum mode);
 
-			void blendEquationSeparate(GLenum modeRGB, GLenum modeAlpha);
+    void blendEquationSeparate(GLenum modeRGB, GLenum modeAlpha);
 
-			void blendFunc(GLenum sfactor, GLenum dfactor);
+    void blendFunc(GLenum sfactor, GLenum dfactor);
 
-			void blendFuncSeparate(GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha);
+    void blendFuncSeparate(GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha);
 
-			void scissor(GLint x, GLint y, GLsizei width, GLsizei height);
+    void scissor(GLint x, GLint y, GLsizei width, GLsizei height);
 
-			void viewport(GLint x, GLint y, GLsizei width, GLsizei height);
+    void viewport(GLint x, GLint y, GLsizei width, GLsizei height);
 
-			void clearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha);
+    void clearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha);
 
-			void clear(GLbitfield mask);
+    void clear(GLbitfield mask);
 
-			WebGLBuffer* createBuffer();
-			void deleteBuffer(WebGLBuffer* buffer);
+    WebGLBuffer* createBuffer();
+    void deleteBuffer(WebGLBuffer* buffer);
 
-			void bindBuffer(GLenum target, WebGLBuffer* buffer);
+    void bindBuffer(GLenum target, WebGLBuffer* buffer);
 
-			void bufferData(GLenum target, GLsizeiptr size, void* data, GLenum usage);
+    void bufferData(GLenum target, GLsizeiptr size, void* data, GLenum usage);
 
-			void colorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha);
+    void colorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha);
 
-			void drawArrays(GLenum mode, GLint first, GLsizei count);
-			void drawElements(GLenum mode, GLsizei count, GLenum type, GLint offset);
+    void drawArrays(GLenum mode, GLint first, GLsizei count);
+    void drawElements(GLenum mode, GLsizei count, GLenum type, GLint offset);
 
-			void enableVertexAttribArray(GLuint index);
+    void enableVertexAttribArray(GLuint index);
 
-			void disableVertexAttribArray(GLuint index);
+    void disableVertexAttribArray(GLuint index);
 
-			void vertexAttribPointer(GLuint indx, GLint size, GLenum type, GLboolean normalized, GLsizei stride, GLint offset);
+    void vertexAttribPointer(GLuint indx, GLint size, GLenum type, GLboolean normalized, GLsizei stride, GLint offset);
 
-			void stencilFunc(GLenum func, GLint ref, GLuint mask);
-			void stencilMask(GLuint mask);
-			void stencilOp(GLenum fail, GLenum zfail, GLenum zpass);
+    void stencilFunc(GLenum func, GLint ref, GLuint mask);
+    void stencilMask(GLuint mask);
+    void stencilOp(GLenum fail, GLenum zfail, GLenum zpass);
 
 #pragma region Program
-			WebGLProgram* createProgram();
-			void useProgram(WebGLProgram* program);
-			void validateProgram(WebGLProgram* program);
-			void linkProgram(WebGLProgram* program);
-			JsValueRef getProgramParameter(WebGLProgram* program, GLenum pname);
-			std::wstring getProgramInfoLog(WebGLProgram* program);
-			void deleteProgram(WebGLProgram* program);
-			void bindAttribLocation(WebGLProgram* program, GLuint index, std::wstring& name);
-			WebGLActiveInfo* getActiveUniform(WebGLProgram* program, GLuint index);
-			WebGLActiveInfo* getActiveAttrib(WebGLProgram* program, GLuint index);
-			GLint getAttribLocation(WebGLProgram* program, std::wstring& name);
+    WebGLProgram* createProgram();
+    void useProgram(WebGLProgram* program);
+    void validateProgram(WebGLProgram* program);
+    void linkProgram(WebGLProgram* program);
+    JsValueRef getProgramParameter(WebGLProgram* program, GLenum pname);
+    std::wstring getProgramInfoLog(WebGLProgram* program);
+    void deleteProgram(WebGLProgram* program);
+    void bindAttribLocation(WebGLProgram* program, GLuint index, std::wstring& name);
+    WebGLActiveInfo* getActiveUniform(WebGLProgram* program, GLuint index);
+    WebGLActiveInfo* getActiveAttrib(WebGLProgram* program, GLuint index);
+    GLint getAttribLocation(WebGLProgram* program, std::wstring& name);
 #pragma endregion
 
 #pragma region Shaders
-			WebGLShader* createShader(GLenum type);
-			void shaderSource(WebGLShader* shader, std::wstring& source);
-			void compileShader(WebGLShader* shader);
-			JsValueRef getShaderParameter(WebGLShader* shader, GLenum pname);
-			std::wstring getShaderInfoLog(WebGLShader* shader);
-			void attachShader(WebGLProgram* program, WebGLShader* shader);
-			void deleteShader(WebGLShader* shader);
-#pragma endregion 
+    WebGLShader* createShader(GLenum type);
+    void shaderSource(WebGLShader* shader, std::wstring& source);
+    void compileShader(WebGLShader* shader);
+    JsValueRef getShaderParameter(WebGLShader* shader, GLenum pname);
+    std::wstring getShaderInfoLog(WebGLShader* shader);
+    void attachShader(WebGLProgram* program, WebGLShader* shader);
+    void deleteShader(WebGLShader* shader);
+#pragma endregion
 
 #pragma region Uniforms
 
-			WebGLUniformLocation* getUniformLocation(WebGLProgram* program, std::wstring& name);
+    WebGLUniformLocation* getUniformLocation(WebGLProgram* program, std::wstring& name);
 
-			void uniform1f(WebGLUniformLocation* location, GLfloat x);
+    void uniform1f(WebGLUniformLocation* location, GLfloat x);
 
-			void uniform1fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v);
+    void uniform1fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v);
 
-			void uniform1i(WebGLUniformLocation* location, GLint x);
+    void uniform1i(WebGLUniformLocation* location, GLint x);
 
-			void uniform1iv(WebGLUniformLocation* location, GLsizei count, const GLint* v);
+    void uniform1iv(WebGLUniformLocation* location, GLsizei count, const GLint* v);
 
-			void uniform2f(WebGLUniformLocation* location, GLfloat x, GLfloat y);
+    void uniform2f(WebGLUniformLocation* location, GLfloat x, GLfloat y);
 
-			void uniform2fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v);
+    void uniform2fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v);
 
-			void uniform2i(WebGLUniformLocation* location, GLint x, GLint y);
+    void uniform2i(WebGLUniformLocation* location, GLint x, GLint y);
 
-			void uniform2iv(WebGLUniformLocation* location, GLsizei count, const GLint* v);
+    void uniform2iv(WebGLUniformLocation* location, GLsizei count, const GLint* v);
 
-			void uniform3f(WebGLUniformLocation* location, GLfloat x, GLfloat y, GLfloat z);
+    void uniform3f(WebGLUniformLocation* location, GLfloat x, GLfloat y, GLfloat z);
 
-			void uniform3fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v);
+    void uniform3fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v);
 
-			void uniform3i(WebGLUniformLocation* location, GLint x, GLint y, GLint z);
+    void uniform3i(WebGLUniformLocation* location, GLint x, GLint y, GLint z);
 
-			void uniform3iv(WebGLUniformLocation* location, GLsizei count, const GLint* v);
+    void uniform3iv(WebGLUniformLocation* location, GLsizei count, const GLint* v);
 
-			void uniform4f(WebGLUniformLocation* location, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
+    void uniform4f(WebGLUniformLocation* location, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
 
-			void uniform4fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v);
+    void uniform4fv(WebGLUniformLocation* location, GLsizei count, const GLfloat* v);
 
-			void uniform4i(WebGLUniformLocation* location, GLint x, GLint y, GLint z, GLint w);
+    void uniform4i(WebGLUniformLocation* location, GLint x, GLint y, GLint z, GLint w);
 
-			void uniform4iv(WebGLUniformLocation* location, GLsizei count, const GLint* v);
+    void uniform4iv(WebGLUniformLocation* location, GLsizei count, const GLint* v);
 
-			void uniformMatrix2fv(WebGLUniformLocation* location, GLboolean transpose, GLsizei count, const GLfloat* value);
+    void uniformMatrix2fv(WebGLUniformLocation* location, GLboolean transpose, GLsizei count, const GLfloat* value);
 
-			void uniformMatrix3fv(WebGLUniformLocation* location, GLboolean transpose, GLsizei count, const GLfloat* value);
+    void uniformMatrix3fv(WebGLUniformLocation* location, GLboolean transpose, GLsizei count, const GLfloat* value);
 
-			void uniformMatrix4fv(WebGLUniformLocation* location, GLboolean transpose, GLsizei count, const GLfloat* value);
+    void uniformMatrix4fv(WebGLUniformLocation* location, GLboolean transpose, GLsizei count, const GLfloat* value);
 #pragma endregion
 
 #pragma region Lines
-			void lineWidth(GLfloat width);
+    void lineWidth(GLfloat width);
 #pragma endregion
 
-		private:
+   private:
+    const GLenum UNSIGNED_BYTE = 0x1401;
+    const GLenum UNPACK_FLIP_Y_WEBGL = 0x9240;
+    const GLenum UNPACK_PREMULTIPLY_ALPHA_WEBGL = 0x9241;
 
-			const GLenum UNSIGNED_BYTE = 0x1401;
-			const GLenum UNPACK_FLIP_Y_WEBGL = 0x9240;
-			const GLenum UNPACK_PREMULTIPLY_ALPHA_WEBGL = 0x9241;
-
-			bool FlipYEnabled = false;
-		};
-	}
-}
+    bool FlipYEnabled = false;
+};
+}  // namespace WebGL
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/WebLoader.cpp
+++ b/HoloJS/HoloJsHost/WebLoader.cpp
@@ -1,0 +1,24 @@
+#include "pch.h"
+#include "WebLoader.h"
+
+using namespace concurrency;
+using namespace std;
+using namespace Windows::Web;
+using namespace Windows::Foundation;
+using namespace Windows::Web::Http;
+using namespace HologramJS::Loaders;
+
+WebLoader::WebLoader() {}
+
+WebLoader::~WebLoader() {}
+
+task<Platform::String ^> WebLoader::DownloadTextAsync(Uri ^ uri)
+{
+    Http::HttpClient ^ httpClient = ref new HttpClient();
+    auto responseMessage = await httpClient->GetAsync(uri);
+    if (responseMessage->IsSuccessStatusCode) {
+        return await responseMessage->Content->ReadAsStringAsync();
+    }
+
+    return L"";
+}

--- a/HoloJS/HoloJsHost/WebLoader.h
+++ b/HoloJS/HoloJsHost/WebLoader.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace HologramJS {
+namespace Loaders {
+class WebLoader {
+   public:
+    WebLoader();
+    ~WebLoader();
+
+    static concurrency::task<Platform::String ^> DownloadTextAsync(Windows::Foundation::Uri ^ uri);
+};
+
+}  // namespace Loaders
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/WindowElement.h
+++ b/HoloJS/HoloJsHost/WindowElement.h
@@ -1,146 +1,117 @@
 #pragma once
 
-#include "SpatialInput.h"
-#include "MouseInput.h"
 #include "KeyboardInput.h"
+#include "MouseInput.h"
+#include "SpatialInput.h"
 #include "SpatialMapping.h"
 
-namespace HologramJS
-{
-	namespace API
-	{
-		class WindowElement
-		{
-		public:
+namespace HologramJS {
+namespace API {
+class WindowElement {
+   public:
+    WindowElement();
+    ~WindowElement();
 
-			WindowElement();
-			~WindowElement();
+    void Close();
 
-			void Close();
+    bool Initialize();
 
-			bool Initialize();
+    void Resize(int width, int height);
+    void VSync(Windows::Foundation::Numerics::float4x4 viewMatrix);
 
-			void Resize(int width, int height);
-			void VSync(Windows::Foundation::Numerics::float4x4 viewMatrix);
+    Input::KeyboardInput& KeyboardRouter() { return m_keyboardInput; }
+    Input::MouseInput& MouseRouter() { return m_mouseInput; }
 
-			Input::KeyboardInput& KeyboardRouter() { return m_keyboardInput; }
-			Input::MouseInput& MouseRouter() { return m_mouseInput; }
+    void SetBaseUrl(const std::wstring& baseUrl) { m_baseUrl.assign(baseUrl); }
 
-			void SetBaseUrl(const std::wstring& baseUrl) { m_baseUrl.assign(baseUrl); }
+    void SetStationaryFrameOfReference(Windows::Perception::Spatial::SpatialStationaryFrameOfReference ^
+                                       frameOfReference)
+    {
+        m_spatialInput.SetStationaryFrameOfReference(frameOfReference);
+        m_spatialMapping.EnableSpatialMapping(frameOfReference);
+    }
 
-			void SetStationaryFrameOfReference(Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ frameOfReference)
-			{
-				m_spatialInput.SetStationaryFrameOfReference(frameOfReference);
-				m_spatialMapping.EnableSpatialMapping(frameOfReference);
-			}
+   private:
+    std::wstring m_baseUrl;
 
-		private:
+    Input::KeyboardInput m_keyboardInput;
+    Input::MouseInput m_mouseInput;
+    Input::SpatialInput m_spatialInput;
+    Input::SpatialMapping m_spatialMapping;
 
-			std::wstring m_baseUrl;
+    int m_width;
+    int m_height;
 
-			Input::KeyboardInput m_keyboardInput;
-			Input::MouseInput m_mouseInput;
-			Input::SpatialInput m_spatialInput;
-			Input::SpatialMapping m_spatialMapping;
+    JsValueRef m_callbackFunction = JS_INVALID_REFERENCE;
 
-			int m_width;
-			int m_height;
+    JsValueRef m_getWidthFunction = JS_INVALID_REFERENCE;
+    static JsValueRef CHAKRA_CALLBACK getWidthStatic(JsValueRef callee,
+                                                     bool isConstructCall,
+                                                     JsValueRef* arguments,
+                                                     unsigned short argumentCount,
+                                                     PVOID callbackData)
+    {
+        return reinterpret_cast<WindowElement*>(callbackData)->getWidth(arguments, argumentCount);
+    }
 
-			JsValueRef m_callbackFunction = JS_INVALID_REFERENCE;
+    JsValueRef getWidth(JsValueRef* arguments, unsigned short argumentCount);
 
-			JsValueRef m_getWidthFunction = JS_INVALID_REFERENCE;
-			static JsValueRef CHAKRA_CALLBACK getWidthStatic(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			)
-			{
-				return reinterpret_cast<WindowElement*>(callbackData)->getWidth(arguments, argumentCount);
-			}
+    JsValueRef m_getHeightFunction = JS_INVALID_REFERENCE;
+    static JsValueRef CHAKRA_CALLBACK getHeightStatic(JsValueRef callee,
+                                                      bool isConstructCall,
+                                                      JsValueRef* arguments,
+                                                      unsigned short argumentCount,
+                                                      PVOID callbackData)
+    {
+        return reinterpret_cast<WindowElement*>(callbackData)->getHeight(arguments, argumentCount);
+    }
 
-			JsValueRef getWidth(
-				JsValueRef* arguments,
-				unsigned short argumentCount
-			);
+    JsValueRef getHeight(JsValueRef* arguments, unsigned short argumentCount);
 
-			JsValueRef m_getHeightFunction = JS_INVALID_REFERENCE;
-			static JsValueRef CHAKRA_CALLBACK getHeightStatic(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			)
-			{
-				return reinterpret_cast<WindowElement*>(callbackData)->getHeight(arguments, argumentCount);
-			}
+    JsValueRef m_getBaseUrlFunction = JS_INVALID_REFERENCE;
+    static JsValueRef CHAKRA_CALLBACK getBaseUrlStatic(JsValueRef callee,
+                                                       bool isConstructCall,
+                                                       JsValueRef* arguments,
+                                                       unsigned short argumentCount,
+                                                       PVOID callbackData)
+    {
+        return reinterpret_cast<WindowElement*>(callbackData)->getBaseUrl(arguments, argumentCount);
+    }
 
-			JsValueRef getHeight(
-				JsValueRef* arguments,
-				unsigned short argumentCount
-			);
+    JsValueRef getBaseUrl(JsValueRef* arguments, unsigned short argumentCount);
 
-			JsValueRef m_getBaseUrlFunction = JS_INVALID_REFERENCE;
-			static JsValueRef CHAKRA_CALLBACK getBaseUrlStatic(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			)
-			{
-				return reinterpret_cast<WindowElement*>(callbackData)->getBaseUrl(arguments, argumentCount);
-			}
+    JsValueRef m_setCallbackFunction = JS_INVALID_REFERENCE;
+    static JsValueRef CHAKRA_CALLBACK setCallbackStatic(JsValueRef callee,
+                                                        bool isConstructCall,
+                                                        JsValueRef* arguments,
+                                                        unsigned short argumentCount,
+                                                        PVOID callbackData)
+    {
+        return reinterpret_cast<WindowElement*>(callbackData)->setCallback(arguments, argumentCount);
+    }
 
-			JsValueRef getBaseUrl(
-				JsValueRef* arguments,
-				unsigned short argumentCount
-			);
+    JsValueRef setCallback(JsValueRef* arguments, unsigned short argumentCount);
 
-			JsValueRef m_setCallbackFunction = JS_INVALID_REFERENCE;
-			static JsValueRef CHAKRA_CALLBACK setCallbackStatic(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			)
-			{
-				return reinterpret_cast<WindowElement*>(callbackData)->setCallback(arguments, argumentCount);
-			}
+    JsValueRef m_requestSpatialMapping = JS_INVALID_REFERENCE;
+    static JsValueRef CHAKRA_CALLBACK requestSpatialMappingStatic(JsValueRef callee,
+                                                                  bool isConstructCall,
+                                                                  JsValueRef* arguments,
+                                                                  unsigned short argumentCount,
+                                                                  PVOID callbackData)
+    {
+        return reinterpret_cast<WindowElement*>(callbackData)->requestSpatialMapping(arguments, argumentCount);
+    }
 
-			JsValueRef setCallback(
-				JsValueRef* arguments,
-				unsigned short argumentCount
-			);
+    JsValueRef requestSpatialMapping(JsValueRef* arguments, unsigned short argumentCount);
 
-			JsValueRef m_requestSpatialMapping = JS_INVALID_REFERENCE;
-			static JsValueRef CHAKRA_CALLBACK requestSpatialMappingStatic(
-				JsValueRef callee,
-				bool isConstructCall,
-				JsValueRef* arguments,
-				unsigned short argumentCount,
-				PVOID callbackData
-			)
-			{
-				return reinterpret_cast<WindowElement*>(callbackData)->requestSpatialMapping(arguments, argumentCount);
-			}
+    float* m_viewMatrixStoragePointer = nullptr;
+    JsValueRef m_viewMatrixScriptProjection = JS_INVALID_REFERENCE;
 
-			JsValueRef requestSpatialMapping(
-				JsValueRef* arguments,
-				unsigned short argumentCount
-			);
+    Windows::Foundation::Numerics::float4x4 m_inverseViewMatrix;
+    float* m_cameraPositionStoragePointer = nullptr;
+    JsValueRef m_cameraPositionScriptProjection = JS_INVALID_REFERENCE;
 
-			float* m_viewMatrixStoragePointer = nullptr;
-			JsValueRef m_viewMatrixScriptProjection = JS_INVALID_REFERENCE;
-
-			Windows::Foundation::Numerics::float4x4 m_inverseViewMatrix;
-			float* m_cameraPositionStoragePointer = nullptr;
-			JsValueRef m_cameraPositionScriptProjection = JS_INVALID_REFERENCE;
-
-			bool CreateViewMatrixStorageAndScriptProjection();
-		};
-	}
-}
+    bool CreateViewMatrixStorageAndScriptProjection();
+};
+}  // namespace API
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/XmlHttpRequest.cpp
+++ b/HoloJS/HoloJsHost/XmlHttpRequest.cpp
@@ -1,9 +1,9 @@
 #include "pch.h"
 #include "XmlHttpRequest.h"
-#include "ScriptHostUtilities.h"
-#include "ScriptsLoader.h"
 #include "ExternalObject.h"
+#include "ScriptHostUtilities.h"
 #include "ScriptResourceTracker.h"
+#include "ScriptsLoader.h"
 
 using namespace HologramJS::API;
 using namespace Windows::Foundation;
@@ -175,24 +175,16 @@ void XmlHttpRequest::SendRequest(const std::wstring& method, const std::wstring&
 task<void> XmlHttpRequest::ReadFromPackageAsync()
 {
     wstring completePath = BasePath + m_url;
-    auto mainPathElements = HologramJS::ScriptsLoader::SplitPath(completePath);
-
-    if (mainPathElements.size() == 0) {
-        return;
-    }
-
-    auto fileName = mainPathElements.front();
-    mainPathElements.erase(mainPathElements.begin());
 
     if (IsTextResponse()) {
-        auto responsePlatformString = await HologramJS::ScriptsLoader::ReadTextFromFile(
-            Windows::ApplicationModel::Package::Current->InstalledLocation, mainPathElements, fileName);
+        auto responsePlatformString = await HologramJS::Loaders::FileSystemLoader::ReadTextFromFileAsync(
+            Windows::ApplicationModel::Package::Current->InstalledLocation, completePath);
         m_responseText = responsePlatformString->Data();
         m_responseType.assign(L"text");
     } else  // arraybuffer or blob
     {
-        m_response = await HologramJS::ScriptsLoader::ReadBinaryFromFile(
-            Windows::ApplicationModel::Package::Current->InstalledLocation, mainPathElements, fileName);
+        m_response = await HologramJS::Loaders::FileSystemLoader::ReadBinaryFromFileAsync(
+            Windows::ApplicationModel::Package::Current->InstalledLocation, completePath);
 
         m_responseLength = m_response->Length;
     }

--- a/HoloJS/HoloJsHost/XmlHttpRequest.cpp
+++ b/HoloJS/HoloJsHost/XmlHttpRequest.cpp
@@ -1,6 +1,9 @@
 #include "pch.h"
-#include "ScriptsLoader.h"
 #include "XmlHttpRequest.h"
+#include "ScriptHostUtilities.h"
+#include "ScriptsLoader.h"
+#include "ExternalObject.h"
+#include "ScriptResourceTracker.h"
 
 using namespace HologramJS::API;
 using namespace Windows::Foundation;
@@ -19,346 +22,261 @@ JsValueRef XmlHttpRequest::m_sendXHRFunction = JS_INVALID_REFERENCE;
 JsValueRef XmlHttpRequest::m_getHeaderFunction = JS_INVALID_REFERENCE;
 JsValueRef XmlHttpRequest::m_setHeaderFunction = JS_INVALID_REFERENCE;
 
-XmlHttpRequest::XmlHttpRequest()
+XmlHttpRequest::XmlHttpRequest() {}
+
+bool XmlHttpRequest::Initialize()
 {
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"create", L"xhr", createXHR, nullptr, &m_createXHRFunction));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"send", L"xhr", sendXHR, nullptr, &m_sendXHRFunction));
+    RETURN_IF_FALSE(
+        ScriptHostUtilities::ProjectFunction(L"getResponse", L"xhr", getResponse, nullptr, &m_getResponseFunction));
+    RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(
+        L"getResponseText", L"xhr", getResponseText, nullptr, &m_getResponseTextFunction));
+    RETURN_IF_FALSE(
+        ScriptHostUtilities::ProjectFunction(L"getHeader", L"xhr", getHeader, nullptr, &m_getHeaderFunction));
+    RETURN_IF_FALSE(
+        ScriptHostUtilities::ProjectFunction(L"setHeader", L"xhr", setHeader, nullptr, &m_setHeaderFunction));
+
+    return true;
 }
 
-bool
-XmlHttpRequest::Initialize()
+_Use_decl_annotations_ JsValueRef CHAKRA_CALLBACK XmlHttpRequest::createXHR(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"create", L"xhr", createXHR, nullptr, &m_createXHRFunction));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"send", L"xhr", sendXHR, nullptr, &m_sendXHRFunction));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getResponse", L"xhr", getResponse, nullptr, &m_getResponseFunction));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getResponseText", L"xhr", getResponseText, nullptr, &m_getResponseTextFunction));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"getHeader", L"xhr", getHeader, nullptr, &m_getHeaderFunction));
-	RETURN_IF_FALSE(ScriptHostUtilities::ProjectFunction(L"setHeader", L"xhr", setHeader, nullptr, &m_setHeaderFunction));
-
-	return true;
+    ExternalObject* externalObject = new ExternalObject();
+    RETURN_INVALID_REF_IF_FALSE(externalObject->Initialize(new XmlHttpRequest()));
+    return ScriptResourceTracker::ObjectToDirectExternal(externalObject);
 }
 
-_Use_decl_annotations_
-JsValueRef
-CHAKRA_CALLBACK
-XmlHttpRequest::createXHR(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef *arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+_Use_decl_annotations_ JsValueRef CHAKRA_CALLBACK XmlHttpRequest::setHeader(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	ExternalObject* externalObject = new ExternalObject();
-	RETURN_INVALID_REF_IF_FALSE(externalObject->Initialize(new XmlHttpRequest()));
-	return ScriptResourceTracker::ObjectToDirectExternal(externalObject);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
+    auto xhr = ScriptResourceTracker::ExternalToObject<XmlHttpRequest>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(xhr);
+
+    wstring header;
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[2], header));
+
+    wstring value;
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[3], value));
+
+    xhr->m_requestHeaders.emplace_back(header, value);
+
+    return JS_INVALID_REFERENCE;
 }
 
-_Use_decl_annotations_
-JsValueRef
-CHAKRA_CALLBACK
-XmlHttpRequest::setHeader(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef *arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+_Use_decl_annotations_ JsValueRef CHAKRA_CALLBACK XmlHttpRequest::getHeader(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 4);
-	auto xhr = ScriptResourceTracker::ExternalToObject<XmlHttpRequest>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(xhr);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
+    auto xhr = ScriptResourceTracker::ExternalToObject<XmlHttpRequest>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(xhr);
 
-	wstring header;
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[2], header));
+    wstring header;
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[2], header));
 
-	wstring value;
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[3], value));
+    auto headerRef = Platform::StringReference(header.c_str());
+    if (xhr->m_responseHeaders->HasKey(headerRef)) {
+        auto valueRef = xhr->m_responseHeaders->Lookup(headerRef);
+        JsValueRef returnValue;
+        RETURN_INVALID_REF_IF_JS_ERROR(JsPointerToString(valueRef->Data(), valueRef->Length(), &returnValue));
 
-	xhr->m_requestHeaders.emplace_back(header, value);
-
-	return JS_INVALID_REFERENCE;
+        return returnValue;
+    } else {
+        return JS_INVALID_REFERENCE;
+    }
 }
 
-_Use_decl_annotations_
-JsValueRef
-CHAKRA_CALLBACK
-XmlHttpRequest::getHeader(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef *arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+_Use_decl_annotations_ JsValueRef CHAKRA_CALLBACK XmlHttpRequest::sendXHR(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 3);
-	auto xhr = ScriptResourceTracker::ExternalToObject<XmlHttpRequest>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(xhr);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
+    auto xhr = ScriptResourceTracker::ExternalToObject<XmlHttpRequest>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(xhr);
 
-	wstring header;
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[2], header));
+    wstring method;
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[2], method));
 
-	auto headerRef = Platform::StringReference(header.c_str());
-	if (xhr->m_responseHeaders->HasKey(headerRef))
-	{
-		auto valueRef = xhr->m_responseHeaders->Lookup(headerRef);
-		JsValueRef returnValue;
-		RETURN_INVALID_REF_IF_JS_ERROR(JsPointerToString(valueRef->Data(), valueRef->Length(), &returnValue));
+    wstring uri;
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[3], uri));
 
-		return returnValue;
-	}
-	else
-	{
-		return JS_INVALID_REFERENCE;
-	}
+    wstring type;
+    RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[4], type));
+
+    xhr->SendRequest(method, uri, type);
+
+    return JS_INVALID_REFERENCE;
 }
 
-_Use_decl_annotations_
-JsValueRef
-CHAKRA_CALLBACK
-XmlHttpRequest::sendXHR(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef *arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+_Use_decl_annotations_ JsValueRef CHAKRA_CALLBACK XmlHttpRequest::getResponseText(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 5);
-	auto xhr = ScriptResourceTracker::ExternalToObject<XmlHttpRequest>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(xhr);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
+    auto xhr = ScriptResourceTracker::ExternalToObject<XmlHttpRequest>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(xhr);
 
-	wstring method;
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[2], method));
+    RETURN_INVALID_REF_IF_FALSE(xhr->IsTextResponse());
 
-	wstring uri;
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[3], uri));
+    JsValueRef returnValue;
+    RETURN_INVALID_REF_IF_JS_ERROR(
+        JsPointerToString(xhr->m_responseText.c_str(), xhr->m_responseText.length(), &returnValue));
 
-	wstring type;
-	RETURN_INVALID_REF_IF_FALSE(ScriptHostUtilities::GetString(arguments[4], type));
-
-	xhr->SendRequest(method, uri, type);
-
-	return JS_INVALID_REFERENCE;
+    return returnValue;
 }
 
-_Use_decl_annotations_
-JsValueRef
-CHAKRA_CALLBACK
-XmlHttpRequest::getResponseText(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef *arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+_Use_decl_annotations_ JsValueRef CHAKRA_CALLBACK XmlHttpRequest::getResponse(
+    JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, PVOID callbackData)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
-	auto xhr = ScriptResourceTracker::ExternalToObject<XmlHttpRequest>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(xhr);
+    RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
+    auto xhr = ScriptResourceTracker::ExternalToObject<XmlHttpRequest>(arguments[1]);
+    RETURN_INVALID_REF_IF_NULL(xhr);
 
-	RETURN_INVALID_REF_IF_FALSE(xhr->IsTextResponse());
+    if (xhr->IsTextResponse()) {
+        return getResponseText(callee, isConstructCall, arguments, argumentCount, callbackData);
+    } else {
+        Microsoft::WRL::ComPtr<Windows::Storage::Streams::IBufferByteAccess> bufferByteAccess;
+        RETURN_INVALID_REF_IF_FAILED(
+            reinterpret_cast<IInspectable*>(xhr->m_response)->QueryInterface(IID_PPV_ARGS(&bufferByteAccess)));
 
-	JsValueRef returnValue;
-	RETURN_INVALID_REF_IF_JS_ERROR(JsPointerToString(xhr->m_responseText.c_str(), xhr->m_responseText.length(), &returnValue));
+        byte* responseNativeBuffer;
+        RETURN_INVALID_REF_IF_FAILED(bufferByteAccess->Buffer(&responseNativeBuffer));
 
-	return returnValue;
+        JsValueRef returnArray;
+        void* responesExternalBuffer;
+        RETURN_INVALID_REF_IF_JS_ERROR(ScriptResourceTracker::CreateAndTrackExternalBuffer(
+            xhr->m_responseLength, &responesExternalBuffer, &returnArray));
+
+        CopyMemory(responesExternalBuffer, responseNativeBuffer, xhr->m_responseLength);
+
+        return returnArray;
+    }
 }
 
-_Use_decl_annotations_
-JsValueRef
-CHAKRA_CALLBACK
-XmlHttpRequest::getResponse(
-	JsValueRef callee,
-	bool isConstructCall,
-	JsValueRef *arguments,
-	unsigned short argumentCount,
-	PVOID callbackData
-)
+void XmlHttpRequest::SendRequest(const std::wstring& method, const std::wstring& uri, const std::wstring type)
 {
-	RETURN_INVALID_REF_IF_FALSE(argumentCount == 2);
-	auto xhr = ScriptResourceTracker::ExternalToObject<XmlHttpRequest>(arguments[1]);
-	RETURN_INVALID_REF_IF_NULL(xhr);
+    m_method = method;
+    m_url = uri;
+    m_state = RequestState::OPENED;
+    m_responseType = type;
 
-	if (xhr->IsTextResponse())
-	{
-		return getResponseText(callee, isConstructCall, arguments, argumentCount, callbackData);
-	}
-	else
-	{
-		Microsoft::WRL::ComPtr<Windows::Storage::Streams::IBufferByteAccess> bufferByteAccess;
-		RETURN_INVALID_REF_IF_FAILED(reinterpret_cast<IInspectable*>(xhr->m_response)->QueryInterface(IID_PPV_ARGS(&bufferByteAccess)));
+    if (m_url.empty() || (_wcsicmp(m_method.c_str(), L"get") != 0)) {
+        return;
+    }
 
-		byte* responseNativeBuffer;
-		RETURN_INVALID_REF_IF_FAILED(bufferByteAccess->Buffer(&responseNativeBuffer));
-
-		JsValueRef returnArray;
-		void* responesExternalBuffer;
-		RETURN_INVALID_REF_IF_JS_ERROR(ScriptResourceTracker::CreateAndTrackExternalBuffer(xhr->m_responseLength, &responesExternalBuffer, &returnArray));
-
-		CopyMemory(responesExternalBuffer, responseNativeBuffer, xhr->m_responseLength);
-
-		return returnArray;
-	}
+    if ((_wcsnicmp(m_url.c_str(), L"http://", wcslen(L"http://")) == 0) ||
+        (_wcsnicmp(m_url.c_str(), L"https://", wcslen(L"https://")) == 0) || !UseFileSystem) {
+        DownloadAsync();
+    } else {
+        ReadFromPackageAsync();
+    }
 }
 
-void
-XmlHttpRequest::SendRequest(
-	const std::wstring& method,
-	const std::wstring& uri,
-	const std::wstring type
-)
+task<void> XmlHttpRequest::ReadFromPackageAsync()
 {
-	m_method = method;
-	m_url = uri;
-	m_state = RequestState::OPENED;
-	m_responseType = type;
+    wstring completePath = BasePath + m_url;
+    auto mainPathElements = HologramJS::ScriptsLoader::SplitPath(completePath);
 
-	if (m_url.empty() || (_wcsicmp(m_method.c_str(), L"get") != 0))
-	{
-		return;
-	}
+    if (mainPathElements.size() == 0) {
+        return;
+    }
 
-	if ((_wcsnicmp(m_url.c_str(), L"http://", wcslen(L"http://")) == 0)
-		|| (_wcsnicmp(m_url.c_str(), L"https://", wcslen(L"https://")) == 0)
-		|| !UseFileSystem)
-	{
-		DownloadAsync();
-	}
-	else
-	{
-		ReadFromPackageAsync();
-	}
+    auto fileName = mainPathElements.front();
+    mainPathElements.erase(mainPathElements.begin());
+
+    if (IsTextResponse()) {
+        auto responsePlatformString = await HologramJS::ScriptsLoader::ReadTextFromFile(
+            Windows::ApplicationModel::Package::Current->InstalledLocation, mainPathElements, fileName);
+        m_responseText = responsePlatformString->Data();
+        m_responseType.assign(L"text");
+    } else  // arraybuffer or blob
+    {
+        m_response = await HologramJS::ScriptsLoader::ReadBinaryFromFile(
+            Windows::ApplicationModel::Package::Current->InstalledLocation, mainPathElements, fileName);
+
+        m_responseLength = m_response->Length;
+    }
+
+    m_state = RequestState::DONE;
+    m_status = 200;
+    m_statusText = L"OK";
+
+    FireStateChanged();
 }
 
-task<void>
-XmlHttpRequest::ReadFromPackageAsync()
+task<void> XmlHttpRequest::DownloadAsync()
 {
-	wstring completePath = BasePath + m_url;
-	auto mainPathElements = HologramJS::ScriptsLoader::SplitPath(completePath);
+    Windows::Foundation::Uri ^ uri;
 
-	if (mainPathElements.size() == 0)
-	{
-		return;
-	}
+    if ((_wcsnicmp(m_url.c_str(), L"http://", wcslen(L"http://")) == 0) ||
+        (_wcsnicmp(m_url.c_str(), L"https://", wcslen(L"https://")) == 0)) {
+        uri = ref new Windows::Foundation::Uri(Platform::StringReference(m_url.c_str()));
+    } else {
+        wstring completeUrl = BaseUrl + m_url;
+        uri = ref new Windows::Foundation::Uri(Platform::StringReference(completeUrl.c_str()));
+    }
 
-	auto fileName = mainPathElements.front();
-	mainPathElements.erase(mainPathElements.begin());
+    Windows::Web::Http::HttpClient ^ httpClient = ref new Windows::Web::Http::HttpClient();
 
-	if (IsTextResponse())
-	{
-		auto responsePlatformString = await HologramJS::ScriptsLoader::ReadTextFromFile(
-			Windows::ApplicationModel::Package::Current->InstalledLocation,
-			mainPathElements,
-			fileName);
-		m_responseText = responsePlatformString->Data();
-		m_responseType.assign(L"text");
-	}
-	else // arraybuffer or blob
-	{
-		m_response = await HologramJS::ScriptsLoader::ReadBinaryFromFile(
-			Windows::ApplicationModel::Package::Current->InstalledLocation,
-			mainPathElements,
-			fileName);
+    for (const auto& headerPair : m_requestHeaders) {
+        httpClient->DefaultRequestHeaders->Append(Platform::StringReference(headerPair.first.c_str()),
+                                                  Platform::StringReference(headerPair.second.c_str()));
+    }
 
-		m_responseLength = m_response->Length;
-	}
+    if (_wcsicmp(m_method.c_str(), L"get") == 0) {
+        HttpResponseMessage ^ responseMessage;
+        try {
+            responseMessage = await httpClient->GetAsync(uri);
+        } catch (...) {
+            m_status = -1;
+        }
 
-	m_state = RequestState::DONE;
-	m_status = 200;
-	m_statusText = L"OK";
+        if (responseMessage) {
+            if (responseMessage->IsSuccessStatusCode) {
+                if (IsTextResponse()) {
+                    auto responseText = await responseMessage->Content->ReadAsStringAsync();
+                    m_responseText.assign(responseText->Data());
+                } else {
+                    m_response = await responseMessage->Content->ReadAsBufferAsync();
+                    m_responseLength = m_response->Length;
+                }
 
-	FireStateChanged();
+                m_status = 200;
+                m_statusText = L"OK";
+                m_responseHeaders = responseMessage->Headers;
+            } else {
+                m_status = static_cast<int>(responseMessage->StatusCode);
+                m_statusText.assign(responseMessage->ReasonPhrase->Data());
+            }
+        }
+    }
+
+    m_state = RequestState::DONE;
+
+    FireStateChanged();
+
+    return;
 }
 
-task<void>
-XmlHttpRequest::DownloadAsync()
+void XmlHttpRequest::FireStateChanged()
 {
-	Windows::Foundation::Uri^ uri;
+    if (HasCallback()) {
+        vector<JsValueRef> parameters(5);
+        JsValueRef* typeParam = &parameters[0];
+        EXIT_IF_JS_ERROR(JsPointerToString(L"change", wcslen(L"change"), typeParam));
 
-	if ((_wcsnicmp(m_url.c_str(), L"http://", wcslen(L"http://")) == 0)
-		|| (_wcsnicmp(m_url.c_str(), L"https://", wcslen(L"https://")) == 0))
-	{
-		uri = ref new Windows::Foundation::Uri(Platform::StringReference(m_url.c_str()));
-	}
-	else
-	{
-		wstring completeUrl = BaseUrl + m_url;
-		uri = ref new Windows::Foundation::Uri( Platform::StringReference(completeUrl.c_str()));
-	}
+        JsValueRef* stateParam = &parameters[1];
+        EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(m_state), stateParam));
 
-	Windows::Web::Http::HttpClient^ httpClient = ref new  Windows::Web::Http::HttpClient();
+        JsValueRef* statusParam = &parameters[2];
+        EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(m_status), statusParam));
 
-	for (const auto& headerPair : m_requestHeaders)
-	{
-		httpClient->DefaultRequestHeaders->Append(Platform::StringReference(headerPair.first.c_str()), Platform::StringReference(headerPair.second.c_str()));
-	}
+        JsValueRef* statusTextParam = &parameters[3];
+        EXIT_IF_JS_ERROR(JsPointerToString(m_statusText.c_str(), m_statusText.length(), statusTextParam));
 
-	if (_wcsicmp(m_method.c_str(), L"get") == 0)
-	{
-		HttpResponseMessage^ responseMessage;
-		try
-		{
-			responseMessage = await httpClient->GetAsync(uri);
-		}
-		catch (...)
-		{
-			m_status = -1;
-		}
+        JsValueRef* responesTypeParam = &parameters[4];
+        EXIT_IF_JS_ERROR(JsPointerToString(m_responseType.c_str(), m_responseType.length(), responesTypeParam));
 
-		if (responseMessage)
-		{
-			if (responseMessage->IsSuccessStatusCode)
-			{
-				if (IsTextResponse())
-				{
-					auto responseText = await responseMessage->Content->ReadAsStringAsync();
-					m_responseText.assign(responseText->Data());
-				}
-				else
-				{
-					m_response = await responseMessage->Content->ReadAsBufferAsync();
-					m_responseLength = m_response->Length;
-				}
-
-				m_status = 200;
-				m_statusText = L"OK";
-				m_responseHeaders = responseMessage->Headers;
-			}
-			else
-			{
-				m_status = static_cast<int>(responseMessage->StatusCode);
-				m_statusText.assign(responseMessage->ReasonPhrase->Data());
-			}
-		}
-	}
-
-	m_state = RequestState::DONE;
-
-	FireStateChanged();
-
-	return;
-}
-
-void
-XmlHttpRequest::FireStateChanged()
-{
-	if (HasCallback())
-	{
-		vector<JsValueRef> parameters(5);
-		JsValueRef* typeParam = &parameters[0];
-		EXIT_IF_JS_ERROR(JsPointerToString(L"change", wcslen(L"change"), typeParam));
-
-		JsValueRef* stateParam = &parameters[1];
-		EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(m_state), stateParam));
-
-		JsValueRef* statusParam = &parameters[2];
-		EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(m_status), statusParam));
-
-		JsValueRef* statusTextParam = &parameters[3];
-		EXIT_IF_JS_ERROR(JsPointerToString(m_statusText.c_str(), m_statusText.length(), statusTextParam));
-
-		JsValueRef* responesTypeParam = &parameters[4];
-		EXIT_IF_JS_ERROR(JsPointerToString(m_responseType.c_str(), m_responseType.length(), responesTypeParam));
-
-		(void)InvokeCallback(parameters);
-	}
+        (void)InvokeCallback(parameters);
+    }
 }

--- a/HoloJS/HoloJsHost/XmlHttpRequest.h
+++ b/HoloJS/HoloJsHost/XmlHttpRequest.h
@@ -1,111 +1,91 @@
 #pragma once
 
-namespace HologramJS
-{
-	namespace API
-	{
-		class XmlHttpRequest : public HologramJS::Utilities::ElementWithEvents, public HologramJS::Utilities::IRelease
-		{
-		public:
-			XmlHttpRequest();
-			virtual ~XmlHttpRequest() {}
+#include "ChakraForHoloJS.h"
+#include "IRelease.h"
+#include "ObjectEvents.h"
 
-			virtual void Release() { }
+namespace HologramJS {
+namespace API {
+class XmlHttpRequest : public HologramJS::Utilities::ElementWithEvents, public HologramJS::Utilities::IRelease {
+   public:
+    XmlHttpRequest();
+    virtual ~XmlHttpRequest() {}
 
-			static bool Initialize();
+    virtual void Release() {}
 
-			void SendRequest(const std::wstring& method, const std::wstring& uri, const std::wstring type);
+    static bool Initialize();
 
-			static bool UseFileSystem;
-			static std::wstring BaseUrl;
-			static std::wstring BasePath;
+    void SendRequest(const std::wstring &method, const std::wstring &uri, const std::wstring type);
 
-		private:
+    static bool UseFileSystem;
+    static std::wstring BaseUrl;
+    static std::wstring BasePath;
 
-			bool IsTextResponse()
-			{
-				return (m_responseType.empty() || (_wcsicmp(m_responseType.c_str(), L"text") == 0));
-			}
+   private:
+    bool IsTextResponse() { return (m_responseType.empty() || (_wcsicmp(m_responseType.c_str(), L"text") == 0)); }
 
-			std::wstring m_url;
-			std::wstring m_method;
-			std::vector<std::pair<std::wstring, std::wstring>> m_requestHeaders;
-			Windows::Web::Http::Headers::HttpResponseHeaderCollection^ m_responseHeaders;
-			std::wstring m_responseType = L"";
+    std::wstring m_url;
+    std::wstring m_method;
+    std::vector<std::pair<std::wstring, std::wstring>> m_requestHeaders;
+    Windows::Web::Http::Headers::HttpResponseHeaderCollection ^ m_responseHeaders;
+    std::wstring m_responseType = L"";
 
-			std::wstring m_responseText;
-			Windows::Storage::Streams::IBuffer^ m_response;
-			unsigned long m_responseLength;
-			int m_status;
-			std::wstring m_statusText = L"";
+    std::wstring m_responseText;
+    Windows::Storage::Streams::IBuffer ^ m_response;
+    unsigned long m_responseLength;
+    int m_status;
+    std::wstring m_statusText = L"";
 
-			enum class RequestState
-			{
-				DONE = 4,
-				OPENED = 1,
-				HEADERS_RECEIVED = 2
-			};
+    enum class RequestState { DONE = 4, OPENED = 1, HEADERS_RECEIVED = 2 };
 
-			RequestState m_state;
+    RequestState m_state;
 
-			concurrency::task<void> ReadFromPackageAsync();
-			concurrency::task<void> DownloadAsync();
+    concurrency::task<void> ReadFromPackageAsync();
+    concurrency::task<void> DownloadAsync();
 
-			void FireStateChanged();
+    void FireStateChanged();
 
-			static JsValueRef m_createXHRFunction;
-			static JsValueRef CHAKRA_CALLBACK createXHR(
-				_In_ JsValueRef callee,
-				_In_ bool isConstructCall,
-				_In_ JsValueRef *arguments,
-				_In_ unsigned short argumentCount,
-				_In_ PVOID callbackData
-			);
+    static JsValueRef m_createXHRFunction;
+    static JsValueRef CHAKRA_CALLBACK createXHR(_In_ JsValueRef callee,
+                                                _In_ bool isConstructCall,
+                                                _In_ JsValueRef *arguments,
+                                                _In_ unsigned short argumentCount,
+                                                _In_ PVOID callbackData);
 
-			static JsValueRef m_sendXHRFunction;
-			static JsValueRef CHAKRA_CALLBACK sendXHR(
-				_In_ JsValueRef callee,
-				_In_ bool isConstructCall,
-				_In_ JsValueRef *arguments,
-				_In_ unsigned short argumentCount,
-				_In_ PVOID callbackData
-			);
+    static JsValueRef m_sendXHRFunction;
+    static JsValueRef CHAKRA_CALLBACK sendXHR(_In_ JsValueRef callee,
+                                              _In_ bool isConstructCall,
+                                              _In_ JsValueRef *arguments,
+                                              _In_ unsigned short argumentCount,
+                                              _In_ PVOID callbackData);
 
-			static JsValueRef m_getResponseTextFunction;
-			static JsValueRef CHAKRA_CALLBACK getResponseText(
-				_In_ JsValueRef callee,
-				_In_ bool isConstructCall,
-				_In_ JsValueRef *arguments,
-				_In_ unsigned short argumentCount,
-				_In_ PVOID callbackData
-			);
+    static JsValueRef m_getResponseTextFunction;
+    static JsValueRef CHAKRA_CALLBACK getResponseText(_In_ JsValueRef callee,
+                                                      _In_ bool isConstructCall,
+                                                      _In_ JsValueRef *arguments,
+                                                      _In_ unsigned short argumentCount,
+                                                      _In_ PVOID callbackData);
 
-			static JsValueRef m_getResponseFunction;
-			static JsValueRef CHAKRA_CALLBACK getResponse(
-				_In_ JsValueRef callee,
-				_In_ bool isConstructCall,
-				_In_ JsValueRef *arguments,
-				_In_ unsigned short argumentCount,
-				_In_ PVOID callbackData
-			);
+    static JsValueRef m_getResponseFunction;
+    static JsValueRef CHAKRA_CALLBACK getResponse(_In_ JsValueRef callee,
+                                                  _In_ bool isConstructCall,
+                                                  _In_ JsValueRef *arguments,
+                                                  _In_ unsigned short argumentCount,
+                                                  _In_ PVOID callbackData);
 
-			static JsValueRef m_setHeaderFunction;
-			static JsValueRef CHAKRA_CALLBACK setHeader(
-				_In_ JsValueRef callee,
-				_In_ bool isConstructCall,
-				_In_ JsValueRef *arguments,
-				_In_ unsigned short argumentCount,
-				_In_ PVOID callbackData
-			);
+    static JsValueRef m_setHeaderFunction;
+    static JsValueRef CHAKRA_CALLBACK setHeader(_In_ JsValueRef callee,
+                                                _In_ bool isConstructCall,
+                                                _In_ JsValueRef *arguments,
+                                                _In_ unsigned short argumentCount,
+                                                _In_ PVOID callbackData);
 
-			static JsValueRef m_getHeaderFunction;
-			static JsValueRef CHAKRA_CALLBACK getHeader(
-				_In_ JsValueRef callee,
-				_In_ bool isConstructCall,
-				_In_ JsValueRef *arguments,
-				_In_ unsigned short argumentCount,
-				_In_ PVOID callbackData
-			);
-		};
-	}
-}
+    static JsValueRef m_getHeaderFunction;
+    static JsValueRef CHAKRA_CALLBACK getHeader(_In_ JsValueRef callee,
+                                                _In_ bool isConstructCall,
+                                                _In_ JsValueRef *arguments,
+                                                _In_ unsigned short argumentCount,
+                                                _In_ PVOID callbackData);
+};
+}  // namespace API
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/pch.cpp
+++ b/HoloJS/HoloJsHost/pch.cpp
@@ -2,10 +2,10 @@
 
 void Log(PCSTR file, int line)
 {
-	std::string completeOutput = "Failure in file ";
-	completeOutput += file;
-	completeOutput += ", line ";
-	completeOutput += std::to_string(line);
-	completeOutput += "\r\n";
-	OutputDebugStringA(completeOutput.c_str());
+    std::string completeOutput = "Failure in file ";
+    completeOutput += file;
+    completeOutput += ", line ";
+    completeOutput += std::to_string(line);
+    completeOutput += "\r\n";
+    OutputDebugStringA(completeOutput.c_str());
 }

--- a/HoloJS/HoloJsHost/pch.cpp
+++ b/HoloJS/HoloJsHost/pch.cpp
@@ -1,11 +1,1 @@
 ﻿#include "pch.h"
-
-void Log(PCSTR file, int line)
-{
-    std::string completeOutput = "Failure in file ";
-    completeOutput += file;
-    completeOutput += ", line ";
-    completeOutput += std::to_string(line);
-    completeOutput += "\r\n";
-    OutputDebugStringA(completeOutput.c_str());
-}

--- a/HoloJS/HoloJsHost/pch.h
+++ b/HoloJS/HoloJsHost/pch.h
@@ -5,15 +5,6 @@
 #include <experimental\resumable>
 #include <pplawait.h>
 
-// Chakra stuff
-#define USE_EDGEMODE_JSRT
-#define CHAKRA_CALLBACK CALLBACK
-#define CHAKRA_API STDAPI_(JsErrorCode)
-typedef DWORD_PTR ChakraCookie;
-typedef BYTE* ChakraBytePtr;
-#include <jsrt.h>
-#include <chakrart.h>
-
 #include <filesystem>
 #include <memory>
 
@@ -68,14 +59,3 @@ void Log(PCSTR file, int line);
 
 #define HANDLE_EXCEPTION_IF_JS_ERROR(x) if ((x) != JsNoError) { HologramJS::ScriptErrorHandling::PrintException();}
 #define RETURN_ON_SCRIPT_ERROR(x) if ((x) != JsNoError) { HologramJS::ScriptErrorHandling::PrintException(); return false; }
-
-#include "IRelease.h"
-#include "ScriptErrorHandling.h"
-#include "ObjectEvents.h"
-#include "ExternalObject.h"
-#include "ScriptHostUtilities.h"
-#include "ScriptResourceTracker.h"
-
-#include <windows.storage.streams.h>
-#include <wrl/implements.h>
-#include "IBufferOnMemory.h"

--- a/HoloJS/HoloJsHost/pch.h
+++ b/HoloJS/HoloJsHost/pch.h
@@ -23,9 +23,6 @@
 #include <EGL/eglext.h>
 #include <EGL/eglplatform.h>
 
-// ANGLE include for Windows Store
-#include <angle_windowsstore.h>
-
 //WIC
 #include <wincodec.h>
 
@@ -37,25 +34,4 @@
 //D3D
 #include <d3d11.h>
 
-void Log(PCSTR file, int line);
-
-#define EXIT_IF_JS_ERROR(x) do { if ((x) != JsNoError) { Log(__FILE__, __LINE__); return; } } while (0, 0)
-#define EXIT_IF_FALSE(x) do { if ((x) == false) { Log(__FILE__, __LINE__); return; } } while (0, 0)
-#define EXIT_IF_TRUE(x) do { if ((x) == true) { Log(__FILE__, __LINE__); return; } } while (0, 0)
-#define EXIT_IF_FAILED(x) do { if (FAILED(x)) { Log(__FILE__, __LINE__); return; } } while (0, 0)
-#define RETURN_IF_JS_ERROR(x) do { if ((x) != JsNoError) { Log(__FILE__, __LINE__); return false; } } while (0, 0)
-#define RETURN_IF_FAILED(x) do { if (FAILED(x)) { Log(__FILE__, __LINE__); return false; } } while (0, 0)
-#define RETURN_NULL_IF_JS_ERROR(x) do { if ((x) != JsNoError) { Log(__FILE__, __LINE__); return nullptr; } } while (0, 0)
-#define RETURN_IF_FALSE(x) do { if ((x) == false) { Log(__FILE__, __LINE__); return false; } } while (0, 0)
-#define RETURN_IF_TRUE(x) do { if ((x) == true) { Log(__FILE__, __LINE__); return false; } } while (0, 0)
-#define RETURN_IF_NULL(x) do { if ((x) == nullptr) { Log(__FILE__, __LINE__); return false; } } while (0, 0)
-#define RETURN_NULL_IF_FALSE(x) do { if ((x) == false) { Log(__FILE__, __LINE__); return nullptr; } } while (0, 0)
-#define RETURN_NULL_IF_FAILED(x) do { if (FAILED(x)) { Log(__FILE__, __LINE__); return nullptr; } } while (0, 0)
-#define RETURN_INVALID_REF_IF_FALSE(x) do { if ((x) == false) { Log(__FILE__, __LINE__); return JS_INVALID_REFERENCE; } } while (0, 0)
-#define RETURN_INVALID_REF_IF_TRUE(x) do { if ((x) == true) { Log(__FILE__, __LINE__); return JS_INVALID_REFERENCE; } } while (0, 0)
-#define RETURN_INVALID_REF_IF_FAILED(x) do { if (FAILED(x)) { Log(__FILE__, __LINE__); return JS_INVALID_REFERENCE; } } while (0, 0)
-#define RETURN_INVALID_REF_IF_NULL(x) do { if ((x) == nullptr) { Log(__FILE__, __LINE__); return JS_INVALID_REFERENCE; } } while (0, 0)
-#define RETURN_INVALID_REF_IF_JS_ERROR(x) do { if ((x) != JsNoError) { Log(__FILE__, __LINE__); return JS_INVALID_REFERENCE; } } while (0, 0)
-
-#define HANDLE_EXCEPTION_IF_JS_ERROR(x) if ((x) != JsNoError) { HologramJS::ScriptErrorHandling::PrintException();}
-#define RETURN_ON_SCRIPT_ERROR(x) if ((x) != JsNoError) { HologramJS::ScriptErrorHandling::PrintException(); return false; }
+#include "ErrorHandling.h"


### PR DESCRIPTION
Ran the code through clang-format to normalize the style. Added the .clang-format file to the solution

clang-format re-sorts included headers and this uncovered header ordering issues. Changed headers to include the required headers, avoiding header ordering requirements. Where it was not possible (pch.h must be first, Chakra headers), the order was added to the .clang-format file.

Minor refactoring on the ScriptsLoader to split it into multiple classes.