### PR TITLE
Don't force http protocol on web-ar links

### DIFF
--- a/HoloJS/HoloJsHost/HoloJsApp.cpp
+++ b/HoloJS/HoloJsHost/HoloJsApp.cpp
@@ -202,9 +202,9 @@ void HoloJsAppView::OnActivated(CoreApplicationView^ applicationView, IActivated
         ProtocolActivatedEventArgs^ eventArgs = dynamic_cast<ProtocolActivatedEventArgs^>(args);
 
         std::wstring appUri = eventArgs->Uri->RawUri->Data();
-        if (appUri.find(L"web-ar://") == 0)
+        if (appUri.find(L"web-ar:") == 0)
         {
-            appUri.replace(0, wcslen(L"web-ar"), L"http");
+            appUri.replace(0, wcslen(L"web-ar:"), L"");
         }
 
         m_appUri = ref new String(appUri.data());

--- a/HoloJS/HoloJsWebViewer/app.cpp
+++ b/HoloJS/HoloJsWebViewer/app.cpp
@@ -16,7 +16,7 @@ int main(Array<Platform::String^>^)
     // If the app is launched without protocol invocation, run the bellow script that shows a canned message
     auto holoJsAppView = ref new HoloJsAppView(ref new String(L"http://holojs.azurewebsites.net/samples/webarviewer/webarviewer.json"));
 
-    // This app handles activations on the web-ar protocol; it is invoked by the web browser when a web-ar:// link is navigated to
+    // This app handles activations on the web-ar protocol; it is invoked by the web browser when a web-ar: link is navigated to
     // The app will execute any script navigated to on the web-ar protocol
     // NB: in order for this option to work, the app's manifest must declare the web-ar protocol
     holoJsAppView->EnableWebArProtocolHandler = true;

--- a/WebSamples/index.html
+++ b/WebSamples/index.html
@@ -8,7 +8,7 @@
         $(function () {
             $(".webar-link").attr("href", function (i, href) {
                 let root = window.location.pathname.substr(0, window.location.pathname.lastIndexOf('/'));
-                return 'web-ar://' + window.location.host + root + '/' + href;
+                return 'web-ar:' + window.location.protocol + '//' + window.location.host + root + '/' + href;
             });
         });
         


### PR DESCRIPTION
web-ar links should be able to explicitly specify the protocol for retrieving the json file (e.g. webar:https://holojs.azurewebsites.net/samples/photosphere/photosphere.json) and not be forced to plain http