### PR TITLE
Point the viewer to versioned web content

### DIFF
--- a/HoloJS/HoloJsWebViewer/app.cpp
+++ b/HoloJS/HoloJsWebViewer/app.cpp
@@ -14,7 +14,7 @@ using namespace HologramJS;
 int main(Array<Platform::String^>^)
 {
     // If the app is launched without protocol invocation, run the bellow script that shows a canned message
-    auto holoJsAppView = ref new HoloJsAppView(ref new String(L"http://holojs.azurewebsites.net/samples/webarviewer/webarviewer.json"));
+    auto holoJsAppView = ref new HoloJsAppView(ref new String(L"http://holojs.azurewebsites.net/v1/samples/webarviewer/webarviewer.json"));
 
     // This app handles activations on the web-ar protocol; it is invoked by the web browser when a web-ar: link is navigated to
     // The app will execute any script navigated to on the web-ar protocol


### PR DESCRIPTION
There was a breaking change in protocol activation. The previously published content no longer loads in the latest viewer (and the other way around).

A new version of the web samples were published to http://holojs.azurewebsites.net/v1/samples/ and the viewer is updated to point to this version. Previous versions of the viewer will continue to work, loading content from the previous version of the web samples.