### PR TITLE
Fix crash on image load

### DIFF
--- a/HoloJS/HoloJsHost/ImageElement.cpp
+++ b/HoloJS/HoloJsHost/ImageElement.cpp
@@ -88,7 +88,7 @@ void ImageElement::LoadAsync()
 
 task<void> ImageElement::GetFromCameraAsync()
 {
-	auto mediaCapture = ref new MediaCapture();
+    auto mediaCapture = ref new MediaCapture();
 
     await mediaCapture->InitializeAsync();
 
@@ -184,18 +184,22 @@ void ImageElement::LoadImageFromBuffer(Windows::Storage::Streams::IBuffer ^ imag
 void ImageElement::FireOnLoadEvent()
 {
     if (HasCallback()) {
-        vector<JsValueRef> parameters(3);
+        vector<JsValueRef> parameters(4);
 
-        JsValueRef* typeParam = &parameters[0];
+        parameters[0] = m_scriptCallbackContext;
+
+        JsValueRef* typeParam = &parameters[1];
         EXIT_IF_JS_ERROR(JsPointerToString(L"load", wcslen(L"load"), typeParam));
 
-        JsValueRef* widthParam = &parameters[1];
+        JsValueRef* widthParam = &parameters[2];
         EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(m_width), widthParam));
 
-        JsValueRef* heightParam = &parameters[2];
+        JsValueRef* heightParam = &parameters[3];
         EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(m_height), heightParam));
 
-        (void)InvokeCallback(parameters);
+        JsValueRef result;
+        HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(
+            m_scriptCallback, parameters.data(), static_cast<unsigned short>(parameters.size()), &result));
     }
 }
 

--- a/HoloJS/HoloJsHost/ObjectEvents.h
+++ b/HoloJS/HoloJsHost/ObjectEvents.h
@@ -35,19 +35,9 @@ class ElementWithEvents {
         }
     }
 
-    bool InvokeCallback(std::vector<JsValueRef> &parameters)
-    {
-        JsValueRef result;
-        parameters.insert(parameters.begin(), m_scriptCallbackContext);
-        HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(
-            m_scriptCallback, parameters.data(), static_cast<unsigned short>(parameters.size()), &result));
-
-        return true;
-    }
-
     bool HasCallback() { return m_scriptCallback != JS_INVALID_REFERENCE; }
 
-   private:
+   protected:
     JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
     JsValueRef m_scriptCallbackContext = JS_INVALID_REFERENCE;
 };

--- a/HoloJS/HoloJsHost/VideoElement.cpp
+++ b/HoloJS/HoloJsHost/VideoElement.cpp
@@ -235,18 +235,22 @@ void VideoElement::SwapBuffers()
 void VideoElement::FireOnLoadEvent()
 {
     if (HasCallback()) {
-        vector<JsValueRef> parameters(3);
+        vector<JsValueRef> parameters(4);
 
-        JsValueRef* typeParam = &parameters[0];
+        parameters[0] = m_scriptCallbackContext;
+
+        JsValueRef* typeParam = &parameters[1];
         EXIT_IF_JS_ERROR(JsPointerToString(L"load", wcslen(L"load"), typeParam));
 
-        JsValueRef* widthParam = &parameters[1];
+        JsValueRef* widthParam = &parameters[2];
         EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(m_width), widthParam));
 
-        JsValueRef* heightParam = &parameters[2];
+        JsValueRef* heightParam = &parameters[3];
         EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(m_height), heightParam));
 
-        (void)InvokeCallback(parameters);
+        JsValueRef result;
+        HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(
+            m_scriptCallback, parameters.data(), static_cast<unsigned short>(parameters.size()), &result));
     }
 }
 

--- a/HoloJS/HoloJsHost/XmlHttpRequest.cpp
+++ b/HoloJS/HoloJsHost/XmlHttpRequest.cpp
@@ -252,22 +252,27 @@ task<void> XmlHttpRequest::DownloadAsync()
 void XmlHttpRequest::FireStateChanged()
 {
     if (HasCallback()) {
-        vector<JsValueRef> parameters(5);
-        JsValueRef* typeParam = &parameters[0];
+        vector<JsValueRef> parameters(6);
+
+        parameters[0] = m_scriptCallbackContext;
+
+        JsValueRef* typeParam = &parameters[1];
         EXIT_IF_JS_ERROR(JsPointerToString(L"change", wcslen(L"change"), typeParam));
 
-        JsValueRef* stateParam = &parameters[1];
+        JsValueRef* stateParam = &parameters[2];
         EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(m_state), stateParam));
 
-        JsValueRef* statusParam = &parameters[2];
+        JsValueRef* statusParam = &parameters[3];
         EXIT_IF_JS_ERROR(JsIntToNumber(static_cast<int>(m_status), statusParam));
 
-        JsValueRef* statusTextParam = &parameters[3];
+        JsValueRef* statusTextParam = &parameters[4];
         EXIT_IF_JS_ERROR(JsPointerToString(m_statusText.c_str(), m_statusText.length(), statusTextParam));
 
-        JsValueRef* responesTypeParam = &parameters[4];
+        JsValueRef* responesTypeParam = &parameters[5];
         EXIT_IF_JS_ERROR(JsPointerToString(m_responseType.c_str(), m_responseType.length(), responesTypeParam));
 
-        (void)InvokeCallback(parameters);
+        JsValueRef result;
+        HANDLE_EXCEPTION_IF_JS_ERROR(JsCallFunction(
+            m_scriptCallback, parameters.data(), static_cast<unsigned short>(parameters.size()), &result));
     }
 }


### PR DESCRIPTION
JsValueRef has auto-cleanup methods when it goes out of scope. When passing these types in std::vector arrays, they get released and upon being accessed on the script side they can cause bogus memory reads or crashes. The fix is to call the callback function from the same context where the parameters are declared.