### PR TITLE
Add promise continuation callback in native code

### DIFF
--- a/HoloJS/HoloJsHost/System.h
+++ b/HoloJS/HoloJsHost/System.h
@@ -22,6 +22,13 @@ class System {
         return reinterpret_cast<System*>(callbackData)->log(callee, arguments, argumentCount);
     }
 
+    static void CALLBACK StaticPromiseContinuationCallback(JsValueRef task, void* callbackState)
+    {
+        reinterpret_cast<System*>(callbackState)->PromiseContinuationCallback(task);
+    }
+
+    void PromiseContinuationCallback(JsValueRef task);
+
     JsValueRef log(JsValueRef callee, JsValueRef* arguments, unsigned short argumentCount);
 };
 


### PR DESCRIPTION
Fixes #104 

A promise continuation callback was not registered in native code, which caused resolve/reject in script to throw exceptions.