### PR TITLE
Enable holographic mode when running on Mixed Reality headsets

### DIFF
--- a/HoloJS/HoloJsHost/HoloJsApp.cpp
+++ b/HoloJS/HoloJsHost/HoloJsApp.cpp
@@ -53,11 +53,10 @@ void HoloJsAppView::Initialize(CoreApplicationView ^ applicationView)
     // http://msdn.microsoft.com/en-us/library/windows/apps/xaml/hh994930.aspx
 }
 
-void HoloJsAppView::ActivateWindowInCorrectContext(Windows::UI::Core::CoreWindow ^ window,
-                                                   bool m_isHolographicActivation)
+void HoloJsAppView::ActivateWindowInCorrectContext(Windows::UI::Core::CoreWindow ^ window, bool isHolographicActivation)
 {
     try {
-        if ((m_isHolographicActivation && (LaunchMode == HoloJsLaunchMode::AsActivated)) ||
+        if ((isHolographicActivation && (LaunchMode == HoloJsLaunchMode::AsActivated)) ||
             (LaunchMode == HoloJsLaunchMode::Holographic)) {
             // Create a holographic space for the core window for the current view.
             mHolographicSpace = HolographicSpace::CreateForCoreWindow(window);

--- a/HoloJS/HoloJsHost/HoloJsApp.cpp
+++ b/HoloJS/HoloJsHost/HoloJsApp.cpp
@@ -58,18 +58,23 @@ void HoloJsAppView::ActivateWindowInCorrectContext(Windows::UI::Core::CoreWindow
     try {
         if ((isHolographicActivation && (LaunchMode == HoloJsLaunchMode::AsActivated)) ||
             (LaunchMode == HoloJsLaunchMode::Holographic)) {
-            // Create a holographic space for the core window for the current view.
-            mHolographicSpace = HolographicSpace::CreateForCoreWindow(window);
+			// Get the default SpatialLocator.
+			SpatialLocator ^ mLocator = SpatialLocator::GetDefault();
 
-            // Get the default SpatialLocator.
-            SpatialLocator ^ mLocator = SpatialLocator::GetDefault();
+			if (mLocator == nullptr) {
+				InitializeEGL(window);
+			}
+			else {
+				// Create a holographic space for the core window for the current view.
+				mHolographicSpace = HolographicSpace::CreateForCoreWindow(window);
 
-            // Create a stationary frame of reference.
-            mStationaryReferenceFrame =
-                mLocator->CreateStationaryFrameOfReferenceAtCurrentLocation(WorldOriginRelativePosition);
+				// Create a stationary frame of reference.
+				mStationaryReferenceFrame =
+					mLocator->CreateStationaryFrameOfReferenceAtCurrentLocation(WorldOriginRelativePosition);
 
-            // The HolographicSpace has been created, so EGL can be initialized in holographic mode.
-            InitializeEGL(mHolographicSpace);
+				// The HolographicSpace has been created, so EGL can be initialized in holographic mode.
+				InitializeEGL(mHolographicSpace);
+			}
         } else {
             // Initialize a flat view for the app
             InitializeEGL(window);

--- a/HoloJS/HoloJsHost/HoloJsApp.h
+++ b/HoloJS/HoloJsHost/HoloJsApp.h
@@ -12,7 +12,7 @@ delegate void HoloJsCallback();
 public enum class HoloJsLaunchMode {
 	AsActivated,
 	Flat,
-	HolographicIfAvailable
+	Holographic
 };
 
 [Windows::Foundation::Metadata::WebHostHidden] public ref class HoloJsAppView sealed
@@ -45,6 +45,8 @@ public enum class HoloJsLaunchMode {
 	property HoloJsLaunchMode LaunchMode;
 
    private:
+
+	void ActivateWindowInCorrectContext(Windows::UI::Core::CoreWindow ^ window, bool m_isHolographicActivation);
     void RecreateRenderer();
 
     // Application lifecycle event handlers.
@@ -63,7 +65,6 @@ public enum class HoloJsLaunchMode {
 
     bool m_WindowClosed;
     bool m_WindowVisible;
-    bool m_holographicActivation = false;
 
     EGLDisplay m_EglDisplay;
     EGLContext m_EglContext;

--- a/HoloJS/HoloJsHost/HoloJsApp.h
+++ b/HoloJS/HoloJsHost/HoloJsApp.h
@@ -4,95 +4,105 @@
 
 namespace HologramJS {
 
-    using float4x4 = Windows::Foundation::Numerics::float4x4;
+using float4x4 = Windows::Foundation::Numerics::float4x4;
 
-    public delegate void HoloJsCallback();
+public
+delegate void HoloJsCallback();
 
-    [Windows::Foundation::Metadata::WebHostHidden]
-    public ref class HoloJsAppView sealed : public Windows::ApplicationModel::Core::IFrameworkView
+public enum class HoloJsLaunchMode {
+	AsActivated,
+	Flat,
+	HolographicIfAvailable
+};
+
+[Windows::Foundation::Metadata::WebHostHidden] public ref class HoloJsAppView sealed
+    : public Windows::ApplicationModel::Core::IFrameworkView {
+   public:
+    HoloJsAppView(Platform::String ^ appUri);
+
+    // IFrameworkView Methods.
+    virtual void Initialize(Windows::ApplicationModel::Core::CoreApplicationView ^ applicationView);
+    virtual void SetWindow(Windows::UI::Core::CoreWindow ^ window);
+    virtual void Load(Platform::String ^ entryPoint);
+    virtual void Run();
+    virtual void Uninitialize();
+
+    // Enable auto stereo rendering
+    property bool AutoStereoEnabled;
+
+    // Enable depth based image stabilization
+    property bool ImageStabilizationEnabled;
+
+    // Callback to allow developers to run their own extensions.
+    property HoloJsCallback ^ OnBeforeRun;
+
+    // Handle web-ar protocol activations; will execute scripts navigated to on the web-ar protocol
+    property bool EnableWebArProtocolHandler;
+
+    // The location of the world coordinate system to use; the default location is 2 meters infront of the camera
+    property Windows::Foundation::Numerics::float3 WorldOriginRelativePosition;
+
+	property HoloJsLaunchMode LaunchMode;
+
+   private:
+    void RecreateRenderer();
+
+    // Application lifecycle event handlers.
+    void OnActivated(Windows::ApplicationModel::Core::CoreApplicationView ^ applicationView,
+                     Windows::ApplicationModel::Activation::IActivatedEventArgs ^ args);
+
+    // Window event handlers.
+    void OnVisibilityChanged(Windows::UI::Core::CoreWindow ^ sender,
+                             Windows::UI::Core::VisibilityChangedEventArgs ^ args);
+    void OnWindowClosed(Windows::UI::Core::CoreWindow ^ sender, Windows::UI::Core::CoreWindowEventArgs ^ args);
+
+    void InitializeEGL(Windows::Graphics::Holographic::HolographicSpace ^ holographicSpace);
+    void InitializeEGL(Windows::UI::Core::CoreWindow ^ window);
+    void InitializeEGLInner(Platform::Object ^ windowBasis);
+    void CleanupEGL();
+
+    bool m_WindowClosed;
+    bool m_WindowVisible;
+    bool m_holographicActivation = false;
+
+    EGLDisplay m_EglDisplay;
+    EGLContext m_EglContext;
+    EGLSurface m_EglSurface;
+
+    // The holographic space the app will use for rendering.
+    Windows::Graphics::Holographic::HolographicSpace ^ mHolographicSpace = nullptr;
+
+    Windows::Perception::Spatial::SpatialStationaryFrameOfReference ^ mStationaryReferenceFrame = nullptr;
+
+    EGLint m_PanelWidth = 0;
+    EGLint m_PanelHeight = 0;
+
+    Platform::String ^ m_appUri;
+
+    HologramScriptHost ^ m_holoScriptHost;
+    void LoadAndExecuteScript();
+};
+
+[Windows::Foundation::Metadata::WebHostHidden] public ref class HoloJsAppSource sealed
+    : Windows::ApplicationModel::Core::IFrameworkViewSource {
+   public:
+    HoloJsAppSource(Platform::String ^ appUri)
+        : m_appUri(appUri),
+          m_appView(nullptr){}
+
+              // The default overload is meaningless - only useful for JavaScript but the whole class is WebHostHidden.
+              // It makes the compiler happy though
+              [Windows::Foundation::Metadata::DefaultOverloadAttribute] HoloJsAppSource(
+                  Windows::ApplicationModel::Core::IFrameworkView ^ appView)
+        : m_appView(appView), m_appUri(nullptr)
     {
-    public:
-        HoloJsAppView(Platform::String^ appUri);
+    }
 
-        // IFrameworkView Methods.
-        virtual void Initialize(Windows::ApplicationModel::Core::CoreApplicationView^ applicationView);
-        virtual void SetWindow(Windows::UI::Core::CoreWindow^ window);
-        virtual void Load(Platform::String^ entryPoint);
-        virtual void Run();
-        virtual void Uninitialize();
-
-        // Enable auto stereo rendering
-        property bool AutoStereoEnabled;
-
-        // Enable depth based image stabilization
-        property bool ImageStabilizationEnabled;
-
-        // Callback to allow developers to run their own extensions.
-        property HoloJsCallback^ OnBeforeRun;
-
-        // Handle web-ar protocol activations; will execute scripts navigated to on the web-ar protocol
-        property bool EnableWebArProtocolHandler;
-
-        // The location of the world coordinate system to use; the default location is 2 meters infront of the camera
-        property Windows::Foundation::Numerics::float3 WorldOriginRelativePosition;
-
-    private:
-        void RecreateRenderer();
-
-        // Application lifecycle event handlers.
-        void OnActivated(Windows::ApplicationModel::Core::CoreApplicationView^ applicationView, Windows::ApplicationModel::Activation::IActivatedEventArgs^ args);
-
-        // Window event handlers.
-        void OnVisibilityChanged(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::VisibilityChangedEventArgs^ args);
-        void OnWindowClosed(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::CoreWindowEventArgs^ args);
-
-        void InitializeEGL(Windows::Graphics::Holographic::HolographicSpace^ holographicSpace);
-        void InitializeEGL(Windows::UI::Core::CoreWindow^ window);
-        void InitializeEGLInner(Platform::Object^ windowBasis);
-        void CleanupEGL();
-
-        bool m_WindowClosed;
-        bool m_WindowVisible;
-
-        EGLDisplay m_EglDisplay;
-        EGLContext m_EglContext;
-        EGLSurface m_EglSurface;
-
-        // The holographic space the app will use for rendering.
-        Windows::Graphics::Holographic::HolographicSpace^ mHolographicSpace = nullptr;
-
-        
-        Windows::Perception::Spatial::SpatialStationaryFrameOfReference^ mStationaryReferenceFrame = nullptr;
-
-        EGLint m_PanelWidth = 0;
-        EGLint m_PanelHeight = 0;
-
-        Platform::String^ m_appUri;
-
-        HologramScriptHost^ m_holoScriptHost;
-        void LoadAndExecuteScript();
-    };
-
-    [Windows::Foundation::Metadata::WebHostHidden]
-    public ref class HoloJsAppSource sealed : Windows::ApplicationModel::Core::IFrameworkViewSource
-    {
-    public:
-        HoloJsAppSource(Platform::String^ appUri) :
-            m_appUri(appUri),
-            m_appView(nullptr) {}
-
-        // The default overload is meaningless - only useful for JavaScript but the whole class is WebHostHidden.
-        // It makes the compiler happy though
-        [Windows::Foundation::Metadata::DefaultOverloadAttribute]
-        HoloJsAppSource(Windows::ApplicationModel::Core::IFrameworkView^ appView) :
-            m_appView(appView),
-            m_appUri(nullptr) {}
-
-        virtual Windows::ApplicationModel::Core::IFrameworkView^ CreateView() {
-            return (m_appView ? m_appView : ref new HologramJS::HoloJsAppView(m_appUri));
-        }
-    private:
-        Platform::String^ m_appUri;
-        Windows::ApplicationModel::Core::IFrameworkView^ m_appView;
-    };
-}
+    virtual Windows::ApplicationModel::Core::IFrameworkView ^
+        CreateView() { return (m_appView ? m_appView : ref new HologramJS::HoloJsAppView(m_appUri)); } private
+        : Platform::String
+          ^
+          m_appUri;
+    Windows::ApplicationModel::Core::IFrameworkView ^ m_appView;
+};
+}  // namespace HologramJS

--- a/HoloJS/HoloJsHost/HoloJsApp.h
+++ b/HoloJS/HoloJsHost/HoloJsApp.h
@@ -9,11 +9,8 @@ using float4x4 = Windows::Foundation::Numerics::float4x4;
 public
 delegate void HoloJsCallback();
 
-public enum class HoloJsLaunchMode {
-	AsActivated,
-	Flat,
-	Holographic
-};
+public
+enum class HoloJsLaunchMode { AsActivated, Flat, Holographic };
 
 [Windows::Foundation::Metadata::WebHostHidden] public ref class HoloJsAppView sealed
     : public Windows::ApplicationModel::Core::IFrameworkView {
@@ -42,11 +39,10 @@ public enum class HoloJsLaunchMode {
     // The location of the world coordinate system to use; the default location is 2 meters infront of the camera
     property Windows::Foundation::Numerics::float3 WorldOriginRelativePosition;
 
-	property HoloJsLaunchMode LaunchMode;
+    property HoloJsLaunchMode LaunchMode;
 
    private:
-
-	void ActivateWindowInCorrectContext(Windows::UI::Core::CoreWindow ^ window, bool m_isHolographicActivation);
+    void ActivateWindowInCorrectContext(Windows::UI::Core::CoreWindow ^ window, bool m_isHolographicActivation);
     void RecreateRenderer();
 
     // Application lifecycle event handlers.

--- a/HoloJS/HoloJsHost/HoloJsHost-Vs2017.vcxproj
+++ b/HoloJS/HoloJsHost/HoloJsHost-Vs2017.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/HoloJS/HoloJsHost/SpatialInput.cpp
+++ b/HoloJS/HoloJsHost/SpatialInput.cpp
@@ -30,11 +30,10 @@ bool SpatialInput::AddEventListener(const wstring& type)
 {
     for (int i = 0; i < ARRAYSIZE(g_supportedSpatialInputEvents); i++) {
         if (type == g_supportedSpatialInputEvents[i]) {
-			if (m_frameOfReference == nullptr)
-			{
-				// The event was handled, but there is no frame of reference
-				return true;
-			}
+            if (m_frameOfReference == nullptr) {
+                // The event was handled, but there is no frame of reference
+                return true;
+            }
 
             m_inputRefCount++;
 
@@ -87,11 +86,10 @@ bool SpatialInput::RemoveEventListener(const wstring& type)
 {
     for (int i = 0; i < ARRAYSIZE(g_supportedSpatialInputEvents); i++) {
         if (type == g_supportedSpatialInputEvents[i]) {
-			if (m_frameOfReference == nullptr)
-			{
-				// The event was handled, but there is no frame of reference
-				return true;
-			}
+            if (m_frameOfReference == nullptr) {
+                // The event was handled, but there is no frame of reference
+                return true;
+            }
 
             m_inputRefCount--;
 

--- a/HoloJS/HoloJsHost/SpatialInput.cpp
+++ b/HoloJS/HoloJsHost/SpatialInput.cpp
@@ -30,6 +30,12 @@ bool SpatialInput::AddEventListener(const wstring& type)
 {
     for (int i = 0; i < ARRAYSIZE(g_supportedSpatialInputEvents); i++) {
         if (type == g_supportedSpatialInputEvents[i]) {
+			if (m_frameOfReference == nullptr)
+			{
+				// The event was handled, but there is no frame of reference
+				return true;
+			}
+
             m_inputRefCount++;
 
             if (m_inputRefCount == 1) {
@@ -81,6 +87,12 @@ bool SpatialInput::RemoveEventListener(const wstring& type)
 {
     for (int i = 0; i < ARRAYSIZE(g_supportedSpatialInputEvents); i++) {
         if (type == g_supportedSpatialInputEvents[i]) {
+			if (m_frameOfReference == nullptr)
+			{
+				// The event was handled, but there is no frame of reference
+				return true;
+			}
+
             m_inputRefCount--;
 
             if (m_inputRefCount == 0 && m_spatialInputAvailable) {

--- a/HoloJS/HoloJsHost/SpatialMapping.cpp
+++ b/HoloJS/HoloJsHost/SpatialMapping.cpp
@@ -42,10 +42,9 @@ JsValueRef SpatialMapping::GetSpatialData(float extentX, float extentY, float ex
 
 void SpatialMapping::EnableSpatialMapping(SpatialStationaryFrameOfReference ^ frameOfReference)
 {
-	if (frameOfReference == nullptr)
-	{
-		return;
-	}
+    if (frameOfReference == nullptr) {
+        return;
+    }
 
     m_frameOfReference = frameOfReference;
 
@@ -75,7 +74,8 @@ bool SpatialMapping::CreateSurfaceObserver(float extentX, float extentY, float e
     }
 
     SpatialBoundingBox axisAlignedBoundingBox = {
-        {0.f, 0.f, 0.f}, {extentX, extentY, extentZ},
+        {0.f, 0.f, 0.f},
+        {extentX, extentY, extentZ},
     };
     SpatialBoundingVolume ^ bounds =
         SpatialBoundingVolume::FromBox(m_frameOfReference->CoordinateSystem, axisAlignedBoundingBox);

--- a/HoloJS/HoloJsHost/SpatialMapping.cpp
+++ b/HoloJS/HoloJsHost/SpatialMapping.cpp
@@ -42,6 +42,11 @@ JsValueRef SpatialMapping::GetSpatialData(float extentX, float extentY, float ex
 
 void SpatialMapping::EnableSpatialMapping(SpatialStationaryFrameOfReference ^ frameOfReference)
 {
+	if (frameOfReference == nullptr)
+	{
+		return;
+	}
+
     m_frameOfReference = frameOfReference;
 
     auto initSurfaceObserverTask = create_task(SpatialSurfaceObserver::RequestAccessAsync());

--- a/HoloJS/HoloJsWebViewer/HoloJsWebViewer-Vs2017.vcxproj
+++ b/HoloJS/HoloJsWebViewer/HoloJsWebViewer-Vs2017.vcxproj
@@ -7,7 +7,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/HoloJS/SampleApp/SampleApp-Vs2017.vcxproj
+++ b/HoloJS/SampleApp/SampleApp-Vs2017.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/HoloJS/ThreeJSApp/App.cpp
+++ b/HoloJS/ThreeJSApp/App.cpp
@@ -16,6 +16,22 @@ void RunLocalSimple()
     CoreApplication::Run(holoJsAppSource);
 }
 
+void RunLocalWithOptions()
+{
+	// Run with some custom options for the app
+
+	// 1. Create the app and set the options
+	// If more customizations are required, copy the HoloJsAppView class in this project and make further changes as needed
+	auto holoJsAppView = ref new HoloJsAppView(ref new String(L"scripts/app.json"));
+	holoJsAppView->ImageStabilizationEnabled = false;
+	holoJsAppView->LaunchMode = HoloJsLaunchMode::HolographicIfAvailable;
+	holoJsAppView->WorldOriginRelativePosition = Windows::Foundation::Numerics::float3(0, 0, -2);
+
+	// 2. Create the source from the app and run it
+	auto holoJsAppSource = ref new HoloJsAppSource(holoJsAppView);
+	CoreApplication::Run(holoJsAppSource);
+}
+
 void RunWebWithOptions()
 {
     // Run with some custom options for the app
@@ -35,7 +51,8 @@ void RunWebWithOptions()
 [Platform::MTAThread]
 int main(Array<Platform::String^>^)
 {
-    RunLocalSimple();
+    //RunLocalSimple();
     //RunWebWithOptions();
+	RunLocalWithOptions();
 	return 0;
 }

--- a/HoloJS/ThreeJSApp/App.cpp
+++ b/HoloJS/ThreeJSApp/App.cpp
@@ -24,7 +24,7 @@ void RunLocalWithOptions()
 	// If more customizations are required, copy the HoloJsAppView class in this project and make further changes as needed
 	auto holoJsAppView = ref new HoloJsAppView(ref new String(L"scripts/app.json"));
 	holoJsAppView->ImageStabilizationEnabled = false;
-	holoJsAppView->LaunchMode = HoloJsLaunchMode::HolographicIfAvailable;
+	holoJsAppView->LaunchMode = HoloJsLaunchMode::AsActivated;
 	holoJsAppView->WorldOriginRelativePosition = Windows::Foundation::Numerics::float3(0, 0, -2);
 
 	// 2. Create the source from the app and run it

--- a/HoloJS/ThreeJSApp/ThreeJSApp-Vs2017.vcxproj
+++ b/HoloJS/ThreeJSApp/ThreeJSApp-Vs2017.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>


### PR DESCRIPTION
Disclaimer: for now tracking is sub-par on Mixed Reality headsets and stops working if the rendered scene goes out of view completely. These will be addressed later.

HoloJS runs as a flat app on Mixed Reality (MR) headsets. Rev the target platform to RS3 such that the holographic space can be created on desktop as well (not just HoloLens), and the app will run in holographic mode.

Added a LaunchMode option to the HoloJsApp class. The app can specify what kind of view to be created:
1. AsActivated: create a view that matches the launch context: flat on desktop, holographic on HoloLens and MR headset
2. Holographic: attempt to create a holographic view even when the app is launched from the desktop. The app view will be created in the MR headset.
3. Flat: create a flat view regardless on how the app was launched. On HoloLens and MR headset this will result in a flat view.