### PR TITLE
Fix DOM and XHR issues to make socket.io work

### DIFF
--- a/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
@@ -2253,7 +2253,6 @@ defineLazyProperty(global, "NodeList", function() {
 defineLazyProperty(idl, "NodeList", function() {
     return new IDLInterface({
         name: "NodeList",
-        proxyFactory: NodeListProxy,
         members: {
             item: function item(index) {
                 return wrap(unwrap(this).item(toULong(index)));
@@ -2278,7 +2277,6 @@ defineLazyProperty(global, "HTMLCollection", function() {
 defineLazyProperty(idl, "HTMLCollection", function() {
     return new IDLInterface({
         name: "HTMLCollection",
-        proxyFactory: HTMLCollectionProxy,
         members: {
             get length() {
                 return unwrap(this).length;
@@ -2779,7 +2777,6 @@ defineLazyProperty(idl, "HTMLFormControlsCollection", function() {
     return new IDLInterface({
         name: "HTMLFormControlsCollection",
         superclass: idl.HTMLCollection,
-        proxyFactory: HTMLFormControlsCollectionProxy,
         members: {
             namedItem: function namedItem(name) {
                 return unwrap(this).namedItem(String(name));
@@ -2825,7 +2822,6 @@ defineLazyProperty(idl, "HTMLOptionsCollection", function() {
     return new IDLInterface({
         name: "HTMLOptionsCollection",
         superclass: idl.HTMLCollection,
-        proxyFactory: HTMLOptionsCollectionProxy,
         members: {
             get length() {
                 return unwrap(this).length;
@@ -2865,7 +2861,6 @@ defineLazyProperty(idl, "HTMLPropertiesCollection", function() {
     return new IDLInterface({
         name: "HTMLPropertiesCollection",
         superclass: idl.HTMLCollection,
-        proxyFactory: HTMLPropertiesCollectionProxy,
         members: {
             namedItem: function namedItem(name) {
                 return wrap(unwrap(this).namedItem(String(name)));
@@ -2911,7 +2906,6 @@ defineLazyProperty(global, "DOMStringMap", function() {
 defineLazyProperty(idl, "DOMStringMap", function() {
     return new IDLInterface({
         name: "DOMStringMap",
-        proxyFactory: DOMStringMapProxy,
         members: {
         },
     });
@@ -2928,7 +2922,6 @@ defineLazyProperty(global, "DOMElementMap", function() {
 defineLazyProperty(idl, "DOMElementMap", function() {
     return new IDLInterface({
         name: "DOMElementMap",
-        proxyFactory: DOMElementMapProxy,
         members: {
         },
     });
@@ -22305,7 +22298,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 */
-/* Build time: 21-November-2017 09:22:26 */
+/* Build time: 6-December-2017 05:42:43 */
 var parserlib = {};
 (function(){
 
@@ -23209,7 +23202,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 */
-/* Build time: 21-November-2017 09:22:26 */
+/* Build time: 6-December-2017 05:42:43 */
 (function(){
 var EventTarget = parserlib.util.EventTarget,
 TokenStreamBase = parserlib.util.TokenStreamBase,
@@ -28385,7 +28378,6 @@ function Window() {
     this.document = new impl.DOMImplementation().createHTMLDocument("");
     this.document._scripting_enabled = true;
     this.document.defaultView = this;
-    this.location = new Location(this, "about:blank");
 
     // These numbers must match native code
     this.input = { 
@@ -28572,7 +28564,8 @@ wmset(idlToImplMap, global, w);
      });
  });
 
-Object.defineProperty(global, "location", {
+ // Remove the location property for HoloJs's DOM
+/*Object.defineProperty(global, "location", {
     get: function() {
         return wrap(unwrap(this).location);
     },
@@ -28581,7 +28574,7 @@ Object.defineProperty(global, "location", {
     },
     enumerable: false,
     configurable: true, // XXX: check this
-});
+});*/
 
 
 Object.defineProperty(global, "onload", {

--- a/HoloJS/HoloJsHost/XmlHttpRequest.cpp
+++ b/HoloJS/HoloJsHost/XmlHttpRequest.cpp
@@ -177,6 +177,7 @@ bool XmlHttpRequest::CreateHttpContent(JsValueRef scriptContent)
         wstring payload;
         RETURN_IF_FALSE(ScriptHostUtilities::GetString(scriptContent, payload));
         m_httpContent = ref new HttpStringContent(Platform::StringReference(payload.c_str()));
+        m_contentType = HttpContentType::String;
     } else if (contentType == JsTypedArray || contentType == JsArrayBuffer) {
         byte* buffer;
         unsigned int bufferLength;
@@ -198,7 +199,7 @@ bool XmlHttpRequest::CreateHttpContent(JsValueRef scriptContent)
         m_contentIBuffer = reinterpret_cast<IBuffer ^>(iinspectable);
 
         m_httpContent = ref new HttpBufferContent(m_contentIBuffer);
-        m_contentIsBufferType = true;
+        m_contentType = HttpContentType::Buffer;
     } else {
         // Other payload type?
         return false;
@@ -273,7 +274,7 @@ task<void> XmlHttpRequest::SendAsync()
     HttpRequestMessage ^ requestMessage = ref new HttpRequestMessage();
     for (const auto& headerPair : m_requestHeaders) {
         if (_wcsicmp(headerPair.first.c_str(), L"content-type") == 0) {
-            if (m_httpContent != nullptr) {
+            if (m_contentType == HttpContentType::Buffer) {
                 m_httpContent->Headers->ContentType->MediaType = Platform::StringReference(headerPair.second.c_str());
             }
         } else {

--- a/HoloJS/HoloJsHost/XmlHttpRequest.h
+++ b/HoloJS/HoloJsHost/XmlHttpRequest.h
@@ -34,8 +34,10 @@ class XmlHttpRequest : public HologramJS::Utilities::ElementWithEvents, public H
     // The payload that came from script; keep a reference to it for the duration of the request
     JsValueRef m_refScriptPayloadValue;
     Windows::Web::Http::IHttpContent ^ m_httpContent;
+    enum class HttpContentType { NoContent, String, Buffer };
+    HttpContentType m_contentType = HttpContentType::NoContent;
+
     Microsoft::WRL::ComPtr<HologramJS::Utilities::BufferOnMemory> m_contentBuffer;
-    bool m_contentIsBufferType;
     Windows::Storage::Streams::IBuffer ^ m_contentIBuffer;
     bool CreateHttpContent(JsValueRef scriptContent);
 


### PR DESCRIPTION
Remove proxy-ing from DOM.JS. The intent of the proxy is to hide internal DOM implementation from scripts, as per W3 spec. However, that is not a goal in HoloJS and proxying can be taken out.

Remove global.location and window.location from the DOM. It confuses socket.io into thinking a cross domain request is required, and JSONP is not supported in HoloJS.

Fix a bug in XmlHttpRequest where setting content type on HttpStringContent would cause a crash.

With the above fixes, socket.io's chat sample appears to be working.