### PR TITLE
Use #define to avoid compilation of RS3 API in the VS2015 solution

### DIFF
--- a/HoloJS/HoloJsHost/HoloJsApp.cpp
+++ b/HoloJS/HoloJsHost/HoloJsApp.cpp
@@ -96,10 +96,14 @@ void HoloJsAppView::SetWindow(CoreWindow ^ window)
     window->Closed +=
         ref new TypedEventHandler<CoreWindow ^, CoreWindowEventArgs ^>(this, &HoloJsAppView::OnWindowClosed);
 
+#ifndef HOLOJS_VS2015
     if (!Windows::Foundation::Metadata::ApiInformation::IsApiContractPresent(
             Platform::StringReference(L"Windows.Foundation.UniversalApiContract"), 4, 0)) {
         ActivateWindowInCorrectContext(window, true /* before RS3 all activations are considered holographic*/);
     }
+#else
+	ActivateWindowInCorrectContext(window, true /* before RS3 all activations are considered holographic*/);
+#endif
 }
 
 void HoloJsAppView::LoadAndExecuteScript()
@@ -200,6 +204,7 @@ void HoloJsAppView::Uninitialize() {}
 // Application lifecycle event handler.
 void HoloJsAppView::OnActivated(CoreApplicationView ^ applicationView, IActivatedEventArgs ^ args)
 {
+#ifndef HOLOJS_VS2015
     if (Windows::Foundation::Metadata::ApiInformation::IsApiContractPresent(
             Platform::StringReference(L"Windows.Foundation.UniversalApiContract"), 4, 0)) {
         auto isHolographicActivation =
@@ -210,6 +215,7 @@ void HoloJsAppView::OnActivated(CoreApplicationView ^ applicationView, IActivate
         // set by the app itself
         ActivateWindowInCorrectContext(applicationView->CoreWindow, isHolographicActivation);
     }
+#endif
 
     // On protocol activation, use the URI from the activation as the app URI
     if (args->Kind == ActivationKind::Protocol && EnableWebArProtocolHandler) {

--- a/HoloJS/HoloJsHost/HoloJsHost.vcxproj
+++ b/HoloJS/HoloJsHost/HoloJsHost.vcxproj
@@ -118,7 +118,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HOLOJS_VS2015;_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
@@ -135,7 +135,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HOLOJS_VS2015;_WINRT_DLL;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>


### PR DESCRIPTION
VS 2015 does not work with Windows SDK 16299. Add a #define to avoid compiling code. When building with VS2015 the target SDK version for HoloJS remains 14393.