### PR TITLE
Implement canvas.toDataURL

### DIFF
--- a/HoloJS/HoloJsHost/CanvasProjections.h
+++ b/HoloJS/HoloJsHost/CanvasProjections.h
@@ -78,6 +78,12 @@ class CanvasProjections {
                                                 JsValueRef* arguments,
                                                 unsigned short argumentCount,
                                                 PVOID callbackData);
+
+    static JsValueRef CHAKRA_CALLBACK toDataURL(JsValueRef callee,
+                                                bool isConstructCall,
+                                                JsValueRef* arguments,
+                                                unsigned short argumentCount,
+                                                PVOID callbackData);
 };
 }  // namespace Canvas
 }  // namespace HologramJS

--- a/HoloJS/HoloJsHost/RenderingContext2D.cpp
+++ b/HoloJS/HoloJsHost/RenderingContext2D.cpp
@@ -12,6 +12,8 @@ using namespace Windows::Foundation::Numerics;
 using namespace Windows::Storage::Streams;
 using namespace Windows::UI;
 using namespace HologramJS::Canvas;
+using namespace Microsoft::WRL;
+using namespace Windows::Security::Cryptography;
 
 RenderingContext2D::RenderingContext2D() { this->createRenderTarget(); }
 
@@ -109,4 +111,128 @@ Platform::Array<unsigned char> ^ RenderingContext2D::getImageData(Rect& rect, un
     } else {
         return nullptr;
     }
+}
+
+bool RenderingContext2D::toDataURL(const std::wstring& type, double encoderOptions, std::wstring* encodedImage)
+{
+    RETURN_IF_TRUE(m_isOptimizedBitmap);
+
+    enum class EncodingType { PNG, JPEG, Unknown } encodingType = EncodingType::Unknown;
+
+    if (_wcsicmp(type.c_str(), L"image/png") == 0) {
+        encodingType = EncodingType::PNG;
+    } else if (_wcsicmp(type.c_str(), L"image/jpeg") == 0) {
+        encodingType = EncodingType::JPEG;
+    }
+
+    // Only PNG and Jpeg are supported
+    RETURN_IF_TRUE(encodingType == EncodingType::Unknown);
+
+    ComPtr<IWICImagingFactory> imagingFactory = NULL;
+    RETURN_IF_FAILED(CoCreateInstance(CLSID_WICImagingFactory,
+                                      NULL,
+                                      CLSCTX_INPROC_SERVER,
+                                      IID_IWICImagingFactory,
+                                      (LPVOID*)imagingFactory.ReleaseAndGetAddressOf()));
+
+    // Get the raw pixels from the underlying canvas
+    auto canvasPixels = m_canvasRenderTarget->GetPixelBytes();
+    auto canvasPixelsLength = canvasPixels->Length;
+    auto canvasPixelData = canvasPixels->begin();
+
+    // Convert from 32bpp RGBA to 24bpp BGR
+    std::vector<byte> bgrPixels((canvasPixelsLength * 3) / 4);
+
+    for (int i = 0, j = 0; i < canvasPixelsLength; i += 4, j += 3) {
+        bgrPixels[j + 0] = canvasPixelData[i + 2];
+        bgrPixels[j + 1] = canvasPixelData[i + 1];
+        bgrPixels[j + 2] = canvasPixelData[i + 0];
+    }
+
+    // Create a memory stream to hold the encoded image
+    ComPtr<IStream> memoryStream;
+    HRESULT hr = ::CreateStreamOnHGlobal(nullptr, true /*delete on release*/, memoryStream.ReleaseAndGetAddressOf());
+    
+    // Create a WIC stream over our memory stream
+    ComPtr<IWICStream> imageStream = NULL;
+    RETURN_IF_FAILED(imagingFactory->CreateStream(imageStream.ReleaseAndGetAddressOf()));
+    RETURN_IF_FAILED(imageStream->InitializeFromIStream(memoryStream.Get()));
+
+    // Create the encoder corresponding to the requested type
+    ComPtr<IWICBitmapEncoder> encoder = NULL;
+    RETURN_IF_FAILED(imagingFactory->CreateEncoder(
+        encodingType == EncodingType::JPEG ? GUID_ContainerFormatJpeg : GUID_ContainerFormatPng,
+        NULL,
+        encoder.ReleaseAndGetAddressOf()));
+
+    RETURN_IF_FAILED(encoder->Initialize(imageStream.Get(), WICBitmapEncoderNoCache));
+
+    ComPtr<IWICBitmapFrameEncode> bitmapFrame = NULL;
+    ComPtr<IPropertyBag2> propertyBag = NULL;
+    RETURN_IF_FAILED(
+        encoder->CreateNewFrame(bitmapFrame.ReleaseAndGetAddressOf(), propertyBag.ReleaseAndGetAddressOf()));
+
+    // If encoding to JPEG, set the image quality to what the caller requested;
+    // PNG does not support image quality settings
+    if (encodingType == EncodingType::JPEG) {
+        PROPBAG2 option = {0};
+        option.pstrName = L"ImageQuality";
+        VARIANT varValue;
+        VariantInit(&varValue);
+        varValue.vt = VT_R4;
+        varValue.fltVal = encoderOptions;
+        RETURN_IF_FAILED(propertyBag->Write(1, &option, &varValue));
+    }
+
+    // Initialize the encoder
+    RETURN_IF_FAILED(bitmapFrame->Initialize(propertyBag.Get()));
+    RETURN_IF_FAILED(bitmapFrame->SetSize(m_canvasRenderTarget->Size.Width, m_canvasRenderTarget->Size.Height));
+
+    // Set the input format to the encoder and make sure the format is acceptable
+    WICPixelFormatGUID formatGUID = GUID_WICPixelFormat24bppBGR;
+    RETURN_IF_FAILED(bitmapFrame->SetPixelFormat(&formatGUID));
+    RETURN_IF_FALSE(IsEqualGUID(formatGUID, GUID_WICPixelFormat24bppBGR));
+
+    // Write the canvas pizes to the encoder
+    auto height = m_canvasRenderTarget->Size.Height;
+    auto stride = bgrPixels.size() / m_canvasRenderTarget->Size.Height;
+    hr = bitmapFrame->WritePixels(height, stride, bgrPixels.size(), bgrPixels.data());
+
+    // Finalize the encoding operation
+    RETURN_IF_FAILED(bitmapFrame->Commit());
+    RETURN_IF_FAILED(encoder->Commit());
+
+    // Figure out long is the encoded stream
+    LARGE_INTEGER seekSize;
+    seekSize.QuadPart = 0;
+    ULARGE_INTEGER streamLength;
+    RETURN_IF_FAILED(imageStream->Seek(seekSize, STREAM_SEEK_END, &streamLength));
+
+    // Get the underlying memory handle and pointer to the bits
+    HGLOBAL streamMemHandle;
+    RETURN_IF_FAILED(GetHGlobalFromStream(memoryStream.Get(), &streamMemHandle));
+    byte* streamMemPtr = reinterpret_cast<byte*>(GlobalLock(streamMemHandle));
+    RETURN_IF_NULL(streamMemPtr);
+
+    // Create an IBuffer over the bits
+    Microsoft::WRL::ComPtr<HologramJS::Utilities::BufferOnMemory> imageBuffer;
+    Details::MakeAndInitialize<HologramJS::Utilities::BufferOnMemory>(
+        &imageBuffer, streamMemPtr, static_cast<unsigned int>(streamLength.QuadPart));
+    auto iinspectable = (IInspectable*)reinterpret_cast<IInspectable*>(imageBuffer.Get());
+    IBuffer ^ imageIBuffer = reinterpret_cast<IBuffer ^>(iinspectable);
+
+    // base64 encode the resulting image
+    auto encodedImagePlatString = CryptographicBuffer::EncodeToBase64String(imageIBuffer);
+
+    // Release the memory lock
+    GlobalUnlock(streamMemHandle);
+
+    // Create the dataURL
+    encodedImage->reserve(encodedImagePlatString->Length() + 128);
+    encodedImage->assign(L"data:");
+    encodedImage->append(type);
+    encodedImage->append(L";base64,");
+    encodedImage->append(encodedImagePlatString->Data());
+
+    return true;
 }

--- a/HoloJS/HoloJsHost/RenderingContext2D.cpp
+++ b/HoloJS/HoloJsHost/RenderingContext2D.cpp
@@ -193,7 +193,7 @@ bool RenderingContext2D::toDataURL(const std::wstring& type, double encoderOptio
     RETURN_IF_FAILED(bitmapFrame->SetPixelFormat(&formatGUID));
     RETURN_IF_FALSE(IsEqualGUID(formatGUID, GUID_WICPixelFormat24bppBGR));
 
-    // Write the canvas pizes to the encoder
+    // Write the canvas size to the encoder
     auto height = m_canvasRenderTarget->Size.Height;
     auto stride = bgrPixels.size() / m_canvasRenderTarget->Size.Height;
     hr = bitmapFrame->WritePixels(height, stride, bgrPixels.size(), bgrPixels.data());
@@ -202,7 +202,7 @@ bool RenderingContext2D::toDataURL(const std::wstring& type, double encoderOptio
     RETURN_IF_FAILED(bitmapFrame->Commit());
     RETURN_IF_FAILED(encoder->Commit());
 
-    // Figure out long is the encoded stream
+    // Figure out how long is the encoded stream
     LARGE_INTEGER seekSize;
     seekSize.QuadPart = 0;
     ULARGE_INTEGER streamLength;

--- a/HoloJS/HoloJsHost/RenderingContext2D.h
+++ b/HoloJS/HoloJsHost/RenderingContext2D.h
@@ -24,6 +24,8 @@ class RenderingContext2D : public HologramJS::Utilities::IRelease {
                    Windows::Foundation::Rect& srcRect,
                    Windows::Foundation::Rect& destRect);
 
+    bool toDataURL(const std::wstring& type, double encoderOptions, std::wstring* encodedImage);
+
     void clearRect(Windows::Foundation::Rect& rect);
 
     void fillRect(Windows::Foundation::Rect& rect, Windows::UI::Color& color);

--- a/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
@@ -13620,15 +13620,15 @@ defineLazyProperty(impl, "HTMLImageElement", function() {
                 var isBlob = false;
                 for (var index = 0; index < URL.objects.length; index++) {
                     if (value === URL.objects[index].key) {
-                        holographic.nativeInterface.image.setImageSourceFromBlob(this.native, URL.objects[index].data);
                         holographic.nativeInterface.eventing.setCallback(this.native, this.nativeCallback.bind(this));
+                        holographic.nativeInterface.image.setImageSourceFromBlob(this.native, URL.objects[index].data);
                         isBlob = true;
                         break;
                     }
                 }
                 if (!isBlob) {
-                    holographic.nativeInterface.image.setImageSource(this.native, value);
                     holographic.nativeInterface.eventing.setCallback(this.native, this.nativeCallback.bind(this));
+                    holographic.nativeInterface.image.setImageSource(this.native, value);
                 }
             },
             get: function getSrc() {

--- a/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/DOM.js
@@ -697,6 +697,10 @@ function OptionaltoLong(x){
     return x === undefined ? undefined : toLong(x);
 }
 
+function OptionaltoDouble(x){
+    return x === undefined ? undefined : toDouble(x);
+}
+
 function OptionalBoolean(x) {
     return (x === undefined) ? undefined : Boolean(x);
 }
@@ -5151,6 +5155,15 @@ defineLazyProperty(idl, "HTMLCanvasElement", function() {
 
             getContext: function getContext(type) {
                 return unwrap(this).getContext(String(type));
+            },
+
+            toDataURL: function toDataURL(
+                                    type,
+                                    encoderOptions)
+            {
+                return unwrap(this).toDataURL(
+                    String(type),
+                    OptionaltoDouble(encoderOptions));
             },
 
         },
@@ -13233,6 +13246,10 @@ defineLazyProperty(impl, "HTMLCanvasElement", function() {
                 holographic.nativeInterface.canvas2d.setHeight(this.context2D.ctxNative, value);
             }
         ),
+
+        toDataURL: constant(function toDataURL(type, encoderOptions) {
+            return holographic.nativeInterface.canvas2d.toDataURL(this.context2D.ctxNative, type, encoderOptions);
+        })
     });
 
     return HTMLCanvasElement;
@@ -22298,7 +22315,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 */
-/* Build time: 6-December-2017 05:42:43 */
+/* Build time: 8-January-2018 05:48:08 */
 var parserlib = {};
 (function(){
 
@@ -23202,7 +23219,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 */
-/* Build time: 6-December-2017 05:42:43 */
+/* Build time: 8-January-2018 05:48:08 */
 (function(){
 var EventTarget = parserlib.util.EventTarget,
 TokenStreamBase = parserlib.util.TokenStreamBase,

--- a/HoloJS/ThreeJSApp/Scripts/app.js
+++ b/HoloJS/ThreeJSApp/Scripts/app.js
@@ -49,8 +49,8 @@ function onVoiceCommand(voiceEvent) {
 
 //var sample = new ShadowsExample(scene, renderer);
 //var sample = new BasicCubeExample(scene, renderer);
-//var sample = new CanvasRenderingExample(scene, renderer);
-var sample = new LightsExample(scene, renderer);
+var sample = new CanvasRenderingExample(scene, renderer);
+//var sample = new LightsExample(scene, renderer);
 //var surfaceReconstructionExample = new SurfaceReconstructionExample(scene, renderer);
 
 start();

--- a/HoloJS/ThreeJSApp/Scripts/canvas-rendering.js
+++ b/HoloJS/ThreeJSApp/Scripts/canvas-rendering.js
@@ -1,6 +1,6 @@
 function CanvasRenderingExample(scene, renderer) {
 
-    let canvas = document.createElement('canvas');
+    var canvas = document.createElement('canvas');
     canvas.width = 300;
     canvas.height = 300;
     let ctx = canvas.getContext('2d');
@@ -27,6 +27,7 @@ function CanvasRenderingExample(scene, renderer) {
     image.onload = () => {
         ctx.drawImage(image, 150, 150, 100, 100);
         texture.needsUpdate = true;
+        canvas.toDataURL('image/png');
     };
 
     let texture = new THREE.Texture(canvas);

--- a/HoloJS/ThreeJSApp/Scripts/canvas-rendering.js
+++ b/HoloJS/ThreeJSApp/Scripts/canvas-rendering.js
@@ -1,6 +1,6 @@
 function CanvasRenderingExample(scene, renderer) {
 
-    var canvas = document.createElement('canvas');
+    let canvas = document.createElement('canvas');
     canvas.width = 300;
     canvas.height = 300;
     let ctx = canvas.getContext('2d');
@@ -27,7 +27,6 @@ function CanvasRenderingExample(scene, renderer) {
     image.onload = () => {
         ctx.drawImage(image, 150, 150, 100, 100);
         texture.needsUpdate = true;
-        canvas.toDataURL('image/png');
     };
 
     let texture = new THREE.Texture(canvas);


### PR DESCRIPTION
Implement toDataURL for canvas when used with a 2D context. PNG and JPEG encoding is supported.

Implement setting a data URL as source for an Image.

Note: the holographic canvas does NOT implement toDataURL