### PR TITLE
Fix adding content headers

### DIFF
--- a/HoloJS/HoloJsHost/XmlHttpRequest.cpp
+++ b/HoloJS/HoloJsHost/XmlHttpRequest.cpp
@@ -270,10 +270,8 @@ task<void> XmlHttpRequest::SendAsync()
 
     HttpRequestMessage ^ requestMessage = ref new HttpRequestMessage();
     for (const auto& headerPair : m_requestHeaders) {
-        if (_wcsicmp(headerPair.first.c_str(), L"content-type") == 0) {
-            if (m_contentType == HttpContentType::Buffer) {
-                m_httpContent->Headers->ContentType->MediaType = Platform::StringReference(headerPair.second.c_str());
-            }
+        if ((_wcsicmp(headerPair.first.c_str(), L"content-type") == 0) && (m_httpContent != nullptr)) {
+            m_httpContent->Headers->ContentType->MediaType = Platform::StringReference(headerPair.second.c_str());
         } else {
             requestMessage->Headers->Append(Platform::StringReference(headerPair.first.c_str()),
                                             Platform::StringReference(headerPair.second.c_str()));

--- a/HoloJS/HoloJsHost/XmlHttpRequest.cpp
+++ b/HoloJS/HoloJsHost/XmlHttpRequest.cpp
@@ -254,6 +254,30 @@ task<void> XmlHttpRequest::ReadFromPackageAsync()
     FireStateChanged();
 }
 
+bool XmlHttpRequest::IsContentHeader(std::wstring headerName)
+{
+    if (_wcsicmp(headerName.c_str(), L"content-type") == 0) {
+        return true;
+    }
+
+    return false;
+}
+
+void XmlHttpRequest::SetHeaders(HttpRequestMessage ^ requestMessage)
+{
+    for (const auto& headerPair : m_requestHeaders) {
+        if (IsContentHeader(headerPair.first)) {
+            if (m_httpContent != nullptr) {
+                m_httpContent->Headers->Insert(Platform::StringReference(headerPair.first.c_str()),
+                                               Platform::StringReference(headerPair.second.c_str()));
+            }
+        } else {
+            requestMessage->Headers->Insert(Platform::StringReference(headerPair.first.c_str()),
+                                            Platform::StringReference(headerPair.second.c_str()));
+        }
+    }
+}
+
 task<void> XmlHttpRequest::SendAsync()
 {
     Windows::Foundation::Uri ^ uri;
@@ -269,14 +293,7 @@ task<void> XmlHttpRequest::SendAsync()
     Windows::Web::Http::HttpClient ^ httpClient = ref new Windows::Web::Http::HttpClient();
 
     HttpRequestMessage ^ requestMessage = ref new HttpRequestMessage();
-    for (const auto& headerPair : m_requestHeaders) {
-        if ((_wcsicmp(headerPair.first.c_str(), L"content-type") == 0) && (m_httpContent != nullptr)) {
-            m_httpContent->Headers->ContentType->MediaType = Platform::StringReference(headerPair.second.c_str());
-        } else {
-            requestMessage->Headers->Append(Platform::StringReference(headerPair.first.c_str()),
-                                            Platform::StringReference(headerPair.second.c_str()));
-        }
-    }
+    SetHeaders(requestMessage);
 
     HttpResponseMessage ^ responseMessage;
 

--- a/HoloJS/HoloJsHost/XmlHttpRequest.h
+++ b/HoloJS/HoloJsHost/XmlHttpRequest.h
@@ -54,6 +54,9 @@ class XmlHttpRequest : public HologramJS::Utilities::ElementWithEvents, public H
     concurrency::task<void> ReadFromPackageAsync();
     concurrency::task<void> SendAsync();
 
+    bool IsContentHeader(std::wstring headerName);
+    void SetHeaders(Windows::Web::Http::HttpRequestMessage ^ requestMessage);
+
     void FireStateChanged();
 
     static JsValueRef m_createXHRFunction;


### PR DESCRIPTION
Setting content headers was not working for all content type (buffer). Added a more robust (but still incomplete) implementation.