### PR TITLE
Minor fix to canvas sample

### DIFF
--- a/HoloJS/ThreeJSApp/Scripts/canvas-rendering.js
+++ b/HoloJS/ThreeJSApp/Scripts/canvas-rendering.js
@@ -4,6 +4,7 @@ function CanvasRenderingExample(scene, renderer) {
     canvas.width = 300;
     canvas.height = 300;
     let ctx = canvas.getContext('2d');
+    ctx.globalAlpha = 0.7;
 
     // Draw rectangle
     ctx.fillStyle = 'rgba(255, 0, 0, 0.5)';
@@ -12,7 +13,7 @@ function CanvasRenderingExample(scene, renderer) {
     // Draw text
     ctx.font = '40px Arial';
     ctx.fillStyle = '#00ff00';
-    ctx.fillText('Hello\nCanvas', 10, 10);
+    ctx.fillText('Hello Canvas', 10, 50);
 
     // Draw gradient
     let gradient = ctx.createLinearGradient(0, 0, 100, 0);


### PR DESCRIPTION
Multi-line text rendering is not part of the canvas 2d context standard. Remove '\n' from sample rendered text.