### PR TITLE
Fix spatial input

### DIFF
--- a/HoloJS/HoloJsHost/HoloJsHost-Vs2017.vcxproj
+++ b/HoloJS/HoloJsHost/HoloJsHost-Vs2017.vcxproj
@@ -34,8 +34,8 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/HoloJS/HoloJsHost/SpatialInput.cpp
+++ b/HoloJS/HoloJsHost/SpatialInput.cpp
@@ -42,31 +42,33 @@ bool SpatialInput::AddEventListener(const wstring& type)
                     return true;
                 }
 
-                m_sourcePressedToken = SpatialInteractionManager::GetForCurrentView()->SourcePressed +=
+                m_spatialInteractionManager = SpatialInteractionManager::GetForCurrentView();
+
+                m_sourcePressedToken = m_spatialInteractionManager->SourcePressed +=
                     ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
                         [this](SpatialInteractionManager ^ sender, SpatialInteractionSourceEventArgs ^ args) {
                             QueueEventOrFireCallback(SpatialInputEventType::Pressed, args);
                         });
 
-                m_sourceReleasedToken = SpatialInteractionManager::GetForCurrentView()->SourceReleased +=
+                m_sourceReleasedToken = m_spatialInteractionManager->SourceReleased +=
                     ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
                         [this](SpatialInteractionManager ^ sender, SpatialInteractionSourceEventArgs ^ args) {
                             QueueEventOrFireCallback(SpatialInputEventType::Released, args);
                         });
 
-                m_sourceDetectedToken = SpatialInteractionManager::GetForCurrentView()->SourceDetected +=
+                m_sourceDetectedToken = m_spatialInteractionManager->SourceDetected +=
                     ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
                         [this](SpatialInteractionManager ^ sender, SpatialInteractionSourceEventArgs ^ args) {
                             QueueEventOrFireCallback(SpatialInputEventType::Detected, args);
                         });
 
-                m_sourceLostToken = SpatialInteractionManager::GetForCurrentView()->SourceLost +=
+                m_sourceLostToken = m_spatialInteractionManager->SourceLost +=
                     ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
                         [this](SpatialInteractionManager ^ sender, SpatialInteractionSourceEventArgs ^ args) {
                             QueueEventOrFireCallback(SpatialInputEventType::Lost, args);
                         });
 
-                m_sourceUpdateToken = SpatialInteractionManager::GetForCurrentView()->SourceUpdated +=
+                m_sourceUpdateToken = m_spatialInteractionManager->SourceUpdated +=
                     ref new TypedEventHandler<SpatialInteractionManager ^, SpatialInteractionSourceEventArgs ^>(
                         [this](SpatialInteractionManager ^ sender, SpatialInteractionSourceEventArgs ^ args) {
                             QueueEventOrFireCallback(SpatialInputEventType::Update, args);

--- a/HoloJS/HoloJsHost/SpatialInput.h
+++ b/HoloJS/HoloJsHost/SpatialInput.h
@@ -29,6 +29,8 @@ class SpatialInput {
    private:
     JsValueRef m_scriptCallback = JS_INVALID_REFERENCE;
 
+    Windows::UI::Input::Spatial::SpatialInteractionManager ^ m_spatialInteractionManager;
+
     Windows::Foundation::EventRegistrationToken m_sourcePressedToken;
     Windows::Foundation::EventRegistrationToken m_sourceReleasedToken;
     Windows::Foundation::EventRegistrationToken m_sourceLostToken;

--- a/HoloJS/HoloJsHost/SpatialMapping.cpp
+++ b/HoloJS/HoloJsHost/SpatialMapping.cpp
@@ -235,7 +235,7 @@ void SpatialMapping::ProcessSurface(SpatialSurfaceInfo ^ surface)
             m_indexBuffers.emplace_back(mesh->TriangleIndices->ElementCount);
             auto destIndexPointer = m_indexBuffers.back().data();
             auto sourceIndexPointer = reinterpret_cast<short int*>(GetPointerToData(mesh->TriangleIndices->Data));
-            for (unsigned int i = 0; i <= mesh->TriangleIndices->ElementCount - 3; i += 3) {
+            for (unsigned int i = 0; i < mesh->TriangleIndices->ElementCount; i += 3) {
                 destIndexPointer[i] = sourceIndexPointer[i + 2];
                 destIndexPointer[i + 1] = sourceIndexPointer[i + 1];
                 destIndexPointer[i + 2] = sourceIndexPointer[i];

--- a/HoloJS/HoloJsWebViewer/HoloJsWebViewer-Vs2017.vcxproj
+++ b/HoloJS/HoloJsWebViewer/HoloJsWebViewer-Vs2017.vcxproj
@@ -7,8 +7,8 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/HoloJS/SampleApp/SampleApp-Vs2017.vcxproj
+++ b/HoloJS/SampleApp/SampleApp-Vs2017.vcxproj
@@ -34,8 +34,8 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/HoloJS/ThreeJSApp/ThreeJSApp-Vs2017.vcxproj
+++ b/HoloJS/ThreeJSApp/ThreeJSApp-Vs2017.vcxproj
@@ -34,8 +34,8 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
There was no persisted reference to the SpatialInteractionManager, which causes event registration to be dropped on build 17720.

Also target the RS4 SDK and fix an AV in spatial mapping.