### PR TITLE
Fix for XmlHttpRequest Crash

### DIFF
--- a/HoloJS/HoloJsHost/ImageElement.cpp
+++ b/HoloJS/HoloJsHost/ImageElement.cpp
@@ -5,6 +5,7 @@
 #include "ScriptHostUtilities.h"
 #include "ScriptResourceTracker.h"
 #include "ScriptsLoader.h"
+#include <array>
 
 using namespace HologramJS::Utilities;
 using namespace HologramJS::API;
@@ -205,7 +206,7 @@ void ImageElement::LoadImageFromBuffer(Windows::Storage::Streams::IBuffer ^ imag
 void ImageElement::FireOnLoadEvent()
 {
     if (HasCallback()) {
-        vector<JsValueRef> parameters(4);
+        std::array<JsValueRef, 4> parameters; // must be on stack to prevent garbage collection
 
         parameters[0] = m_scriptCallbackContext;
 

--- a/HoloJS/HoloJsHost/ScriptingFramework/XmlHttpRequest.js
+++ b/HoloJS/HoloJsHost/ScriptingFramework/XmlHttpRequest.js
@@ -9,7 +9,7 @@
             self.statusText = arguments[3];
             self.responseType = arguments[4];
 
-            if (this.readyState === XMLHttpRequest.DONE) {
+            if (self.readyState === XMLHttpRequest.DONE) {
                 if (self.status >= 200 && self.status <= 205) {
                     self.fireHandlersByType('load', {target: self});
                 } else {

--- a/HoloJS/HoloJsHost/VideoElement.cpp
+++ b/HoloJS/HoloJsHost/VideoElement.cpp
@@ -5,6 +5,7 @@
 #include "ScriptHostUtilities.h"
 #include "ScriptResourceTracker.h"
 #include "ScriptsLoader.h"
+#include <array>
 
 using namespace HologramJS::API;
 using namespace std;
@@ -235,7 +236,7 @@ void VideoElement::SwapBuffers()
 void VideoElement::FireOnLoadEvent()
 {
     if (HasCallback()) {
-        vector<JsValueRef> parameters(4);
+        std::array<JsValueRef, 4> parameters; // must be on stack to prevent garbage collection
 
         parameters[0] = m_scriptCallbackContext;
 

--- a/HoloJS/HoloJsHost/WebSocket.cpp
+++ b/HoloJS/HoloJsHost/WebSocket.cpp
@@ -2,6 +2,7 @@
 #include "WebSocket.h"
 #include "ScriptHostUtilities.h"
 #include "ScriptResourceTracker.h"
+#include <array>
 
 using namespace HologramJS::Utilities;
 using namespace HologramJS::API;
@@ -210,7 +211,7 @@ task<void> WebSocket::ConnectAsync()
 void WebSocket::FireOnError()
 {
     if (HasCallback()) {
-        vector<JsValueRef> parameters(2);
+        std::array<JsValueRef, 2> parameters; // must be on stack to prevent garbage collection
 
         parameters[0] = m_scriptCallbackContext;
 
@@ -265,7 +266,7 @@ void WebSocket::FireOnOpen()
     m_isConnected = true;
 
     if (HasCallback()) {
-        vector<JsValueRef> parameters(2);
+        std::array<JsValueRef, 2> parameters; // must be on stack to prevent garbage collection
 
         parameters[0] = m_scriptCallbackContext;
 

--- a/HoloJS/HoloJsHost/XmlHttpRequest.cpp
+++ b/HoloJS/HoloJsHost/XmlHttpRequest.cpp
@@ -4,6 +4,7 @@
 #include "ScriptHostUtilities.h"
 #include "ScriptResourceTracker.h"
 #include "ScriptsLoader.h"
+#include <array>
 
 using namespace HologramJS::API;
 using namespace Windows::Foundation;
@@ -323,7 +324,12 @@ task<void> XmlHttpRequest::SendAsync()
     if (requestMessage) {
         try {
             responseMessage = await httpClient->SendRequestAsync(requestMessage);
-        } catch (...) {
+		}
+		catch (Platform::Exception ^ex) {
+			m_status = 503; // Service unavailable
+			m_statusText.assign(ex->Message->Data());
+		}
+		catch (...) {
             m_status = -1;
         }
     }
@@ -357,7 +363,7 @@ task<void> XmlHttpRequest::SendAsync()
 void XmlHttpRequest::FireStateChanged()
 {
     if (HasCallback()) {
-        vector<JsValueRef> parameters(6);
+		std::array<JsValueRef, 6> parameters; // must be on stack to prevent garbage collection
 
         parameters[0] = m_scriptCallbackContext;
 


### PR DESCRIPTION
Working on a project that uses HoloJS with frequent XmlHttpRequests to update positions of the object being displayed (about 30 updates per second). Kept running into intermittent crashes, typically in XmlHttpRequest::FireStateChanged, sometimes during timer updates, sometimes the responseType string ended up corrupt rather than "text".

After a bunch of debugging I found that one or more of the objects in the vector of JsValueRef parameters was being unexpectedly garbage collected before JsCallFunction completed. To prevent garbage collection the hosted chakra.dll needs to have have an active reference or be able to see it on the stack. Since the contents of the "vector" are on the heap, it didn't see them so there is a very small window where the object could be incorrectly garbage collected. 
 
Changed vector<JsValueRef> to array<JsValueRef> so that garbage collector sees references on the stack to prevent the problem. Also added "catch" clause in SendAsync so that a reasonable error event is raised when the server is down (this may address problem #173).

Also updated other uses of vector<JsValueRef> that could cause similar problems in ImageElement, VideoElement, and WebSocket.